### PR TITLE
Platform compat

### DIFF
--- a/crates/engine/src/window/app.rs
+++ b/crates/engine/src/window/app.rs
@@ -115,6 +115,86 @@ impl WinitGpuiApp {
         }
     }
 
+    /// Create the initial GPUI window on Linux (no Winit window)
+    #[cfg(not(target_os = "windows"))]
+    fn create_linux_gpui_window(&mut self) {
+        // Create a dummy window state for GPUI application
+        let bounds = Bounds {
+            origin: point(px(0.0), px(0.0)),
+            size: gpui::size(px(1280.0), px(720.0)),
+        };
+
+        let mut gpui_app = Application::new().with_assets(Assets);
+
+        // Clone engine_state for use in closures
+        let engine_state_for_actions = self.engine_state.clone();
+
+        // Load custom fonts and initialize GPUI components
+        gpui_app.update(|app| {
+            if let Some(font_data) = Assets::get("fonts/JetBrainsMono-Regular.ttf") {
+                match app.text_system().add_fonts(vec![font_data.data]) {
+                    Ok(_) => println!("Successfully loaded JetBrains Mono font"),
+                    Err(e) => println!("Failed to load JetBrains Mono font: {:?}", e),
+                }
+            } else {
+                println!("Could not find JetBrains Mono font file");
+            }
+
+            // Initialize GPUI components
+            gpui_component::init(app);
+            crate::themes::init(app);
+            crate::ui::windows::terminal::init(app);
+
+            // Setup keybindings
+            app.bind_keys([
+                KeyBinding::new("ctrl-,", OpenSettings, None),
+                KeyBinding::new("ctrl-space", ToggleCommandPalette, None),
+            ]);
+
+            let engine_state = engine_state_for_actions.clone();
+            app.on_action(move |_: &OpenSettings, _app_cx| {
+                println!("⚙️  Settings window requested - creating new window!");
+                engine_state.request_window(crate::engine_state::WindowRequest::Settings);
+            });
+
+            app.activate(true);
+        });
+
+        println!("✅ GPUI components initialized");
+
+        // Store window_id in EngineState metadata
+        let window_id_u64 = 1u64; // Use dummy ID for Linux
+        self.engine_state.set_metadata("latest_window_id".to_string(), window_id_u64.to_string());
+
+        // Create GPUI window with standard API
+        let window_options = gpui::WindowOptions {
+            window_bounds: Some(gpui::WindowBounds::Windowed(bounds)),
+            titlebar: Some(gpui::TitlebarOptions {
+                title: Some("Pulsar Engine".into()),
+                appears_transparent: false,
+                traffic_light_position: None,
+            }),
+            focus: true,
+            show: true,
+            ..Default::default()
+        };
+
+        let _gpui_window = gpui_app.update(|cx| {
+            cx.open_window(window_options, |window, cx| {
+                let entry_view = cx.new(|cx| EntryWindow::new(window, cx));
+                cx.new(|cx| Root::new(entry_view.clone().into(), window, cx))
+            })
+        }).expect("Failed to open GPUI window");
+
+        self.engine_state.increment_window_count();
+        println!("✅ [Linux] GPUI window created successfully!");
+
+        // Run the GPUI application
+        gpui_app.run(move |_cx| {
+            // Application is now running
+        });
+    }
+
     /// Create a new window based on a request
     ///
     /// # Arguments
@@ -163,26 +243,36 @@ impl ApplicationHandler for WinitGpuiApp {
             return;
         }
 
-        println!("Γ£à Creating main window...");
+        println!("✅ Creating main window...");
 
-        let window_attributes = WinitWindow::default_attributes()
-            .with_title("Pulsar Engine")
-            .with_inner_size(winit::dpi::LogicalSize::new(1280.0, 720.0))
-            .with_transparent(false);
+        // On Windows, create a Winit window for external GPUI rendering
+        #[cfg(target_os = "windows")]
+        {
+            let window_attributes = WinitWindow::default_attributes()
+                .with_title("Pulsar Engine")
+                .with_inner_size(winit::dpi::LogicalSize::new(1280.0, 720.0))
+                .with_transparent(false);
 
-        let winit_window = Arc::new(
-            event_loop
-                .create_window(window_attributes)
-                .expect("Failed to create window"),
-        );
+            let winit_window = Arc::new(
+                event_loop
+                    .create_window(window_attributes)
+                    .expect("Failed to create window"),
+            );
 
-        let window_id = winit_window.id();
-        let window_state = WindowState::new(winit_window);
+            let window_id = winit_window.id();
+            let window_state = WindowState::new(winit_window);
 
-        self.windows.insert(window_id, window_state);
-        self.engine_state.increment_window_count();
+            self.windows.insert(window_id, window_state);
+            self.engine_state.increment_window_count();
 
-        println!("Γ£à Main window created (total windows: {})", self.engine_state.window_count());
+            println!("✅ Main window created (total windows: {})", self.engine_state.window_count());
+        }
+        
+        // On Linux/macOS, we'll create the GPUI window directly in about_to_wait
+        #[cfg(not(target_os = "windows"))]
+        {
+            println!("🔵 [Linux] Skipping Winit window creation - GPUI will handle windowing");
+        }
     }
 
     fn window_event(
@@ -201,11 +291,8 @@ impl ApplicationHandler for WinitGpuiApp {
                 // Clean up Vulkan resources on Linux/macOS
                 #[cfg(not(target_os = "windows"))]
                 if let Some(window_state) = self.windows.get_mut(&window_id) {
-                    if let Some(mut vk_state) = window_state.vk_state.take() {
-                        unsafe {
-                            crate::window::vulkan_init::cleanup_vulkan(&mut vk_state);
-                        }
-                    }
+                    // No Vulkan cleanup needed when using GPUI standard windows
+                    // GPUI handles its own resource cleanup
                 }
 
                 self.windows.remove(&window_id);
@@ -599,53 +686,15 @@ impl ApplicationHandler for WinitGpuiApp {
                         }
                     }
 
-                    // Vulkan rendering for Linux/macOS
+                    // No custom rendering needed for Linux/macOS when using GPUI standard windows
                     #[cfg(not(target_os = "windows"))]
-                    unsafe {
-                        // Only render if the window has been properly configured (to avoid Wayland errors)
-                        if *window_configured && *needs_render {
-                            println!("🔵 [Linux] Triggering GPUI render (window configured)...");
-                            
-                            // First, ensure the window is active and visible
-                            if let Some(gpui_window_ref) = gpui_window.as_ref() {
-                                let _ = gpui_app.update(|app| {
-                                    gpui_window_ref.update(app, |_view, window, cx| {
-                                        // Force window refresh and mark as dirty
-                                        window.refresh();
-                                        cx.notify();
-                                        println!("🔵 [Linux] Forced window refresh and notify");
-                                    });
-                                });
-                            }
-                            
-                            let _ = gpui_app.update(|app| {
-                                app.refresh_windows();
-                                println!("🔵 [Linux] Called refresh_windows");
-                            });
-                            let _ = gpui_app.update(|app| {
-                                app.draw_windows();
-                                println!("🔵 [Linux] Called draw_windows");
-                            });
-                            *needs_render = false;
-                        } else if !*window_configured {
-                            println!("🔵 [Linux] Skipping render - window not yet configured");
-                        }
-
-                        // Render Vulkan frame
-                        if let Some(vk) = vk_state.as_mut() {
-                            // Render frame with green clear color (matches Windows background)
-                            let clear_color = [0.0f32, 1.0, 0.0, 1.0]; // Green
-
-                            match crate::window::vulkan_init::render_frame(vk, clear_color) {
-                                Ok(_) => {
-                                    // Frame rendered successfully
-                                }
-                                Err(e) => {
-                                    eprintln!("❌ Vulkan render error: {:?}", e);
-                                }
-                            }
-                        }
+                    {
+                        // GPUI handles all rendering for standard windows
+                        // No need for manual Vulkan rendering or external window coordination
                     }
+
+                    // No need for continuous redraws on Linux when using GPUI standard windows
+                    // GPUI handles its own rendering loop
 
                     // Don't continuously request redraws - only render when events occur or GPUI requests it
                 }
@@ -722,13 +771,6 @@ impl ApplicationHandler for WinitGpuiApp {
                 }
                 // Handle window resize - resize GPUI renderer and request redraw
                 WindowEvent::Resized(new_size) => {
-                    // Mark window as configured on first resize (Linux/Wayland)
-                    #[cfg(not(target_os = "windows"))]
-                    if !*window_configured {
-                        *window_configured = true;
-                        println!("🔵 [Linux] Window configured after resize - enabling rendering");
-                    }
-                    
                     // Tell GPUI to resize its internal rendering buffers AND update logical size (Windows only)
                     #[cfg(target_os = "windows")]
                     if let Some(gpui_window_ref) = gpui_window.as_ref() {
@@ -817,23 +859,10 @@ impl ApplicationHandler for WinitGpuiApp {
                         }
                     }
 
-                    // Resize Vulkan swapchain on Linux/macOS
+                    // No Vulkan resize needed on Linux when using GPUI standard windows
                     #[cfg(not(target_os = "windows"))]
-                    if let Some(vk) = vk_state.as_mut() {
-                        unsafe {
-                            match crate::window::vulkan_init::recreate_swapchain(
-                                vk,
-                                new_size.width,
-                                new_size.height,
-                            ) {
-                                Ok(_) => {
-                                    println!("✅ Vulkan swapchain resized to {}x{}", new_size.width, new_size.height);
-                                }
-                                Err(e) => {
-                                    eprintln!("❌ Failed to resize Vulkan swapchain: {:?}", e);
-                                }
-                            }
-                        }
+                    {
+                        // GPUI handles window resizing automatically for standard windows
                     }
 
                     *needs_render = true;
@@ -997,7 +1026,7 @@ impl ApplicationHandler for WinitGpuiApp {
                     // Find and close the window with this ID
                     let window_id_native = unsafe { std::mem::transmute::<u64, WindowId>(window_id) };
                     if self.windows.remove(&window_id_native).is_some() {
-                        println!("Γ£à Closed window with ID: {:?}", window_id);
+                        println!("✅ Closed window with ID: {:?}", window_id);
                         self.engine_state.decrement_window_count();
                     }
                 }
@@ -1007,7 +1036,15 @@ impl ApplicationHandler for WinitGpuiApp {
             }
         }
 
-        // Initialize any uninitialized GPUI windows
+        // On Linux, create the initial GPUI window if we haven't created any windows yet
+        #[cfg(not(target_os = "windows"))]
+        if self.windows.is_empty() && self.engine_state.window_count() == 0 {
+            println!("🔵 [Linux] Creating initial GPUI window...");
+            self.create_linux_gpui_window();
+        }
+
+        // Initialize any uninitialized GPUI windows (Windows only)
+        #[cfg(target_os = "windows")]
         for (window_id, window_state) in self.windows.iter_mut() {
         if !window_state.gpui_window_initialized {
             let winit_window = window_state.winit_window.clone();
@@ -1142,8 +1179,9 @@ impl ApplicationHandler for WinitGpuiApp {
 
             #[cfg(not(target_os = "windows"))]
             {
-                // Linux/macOS: Use external window API (matching Windows behavior)
-                println!("🔵 Creating GPUI external window on Linux/macOS...");
+                // Linux/macOS: GPUI external windows have limitations on Wayland
+                // Instead, use GPUI's standard window creation and coordinate with our Vulkan renderer
+                println!("🔵 Creating GPUI standard window on Linux/macOS...");
 
                 let app = &mut window_state.gpui_app;
 
@@ -1183,21 +1221,6 @@ impl ApplicationHandler for WinitGpuiApp {
 
                 println!("✅ GPUI components initialized");
 
-                // Create external handle for Linux/macOS
-                let external_handle = {
-                    let gpui_raw_handle = winit_window
-                        .window_handle()
-                        .expect("Failed to get window handle")
-                        .as_raw();
-
-                    ExternalWindowHandle {
-                        raw_handle: gpui_raw_handle,
-                        bounds,
-                        scale_factor,
-                        surface_handle: None,
-                    }
-                };
-
                 // Store window_id in EngineState metadata
                 let window_id_u64 = unsafe { std::mem::transmute::<_, u64>(*window_id) };
                 self.engine_state.set_metadata("latest_window_id".to_string(), window_id_u64.to_string());
@@ -1208,44 +1231,58 @@ impl ApplicationHandler for WinitGpuiApp {
 
                 let captured_window_id = window_id_u64;
 
-                // Open GPUI window using external window API with appropriate view
-                let gpui_window = window_state.gpui_app.open_window_external(external_handle.clone(), |window, cx| {
-                    match &window_state.window_type {
-                        Some(WindowRequest::Settings) => {
-                            let settings_view = cx.new(|cx| crate::ui::windows::settings_window::SettingsWindow::new(window, cx));
-                            cx.new(|cx| Root::new(settings_view.clone().into(), window, cx))
+                // Create GPUI window with standard API, not external
+                let window_options = gpui::WindowOptions {
+                    window_bounds: Some(gpui::WindowBounds::Windowed(bounds)),
+                    titlebar: Some(gpui::TitlebarOptions {
+                        title: Some("Pulsar Engine".into()),
+                        appears_transparent: false,
+                        traffic_light_position: None,
+                    }),
+                    focus: true,
+                    show: true,
+                    ..Default::default()
+                };
+
+                let gpui_window = app.update(|cx| {
+                    cx.open_window(window_options, |window, cx| {
+                        match &window_state.window_type {
+                            Some(WindowRequest::Settings) => {
+                                let settings_view = cx.new(|cx| crate::ui::windows::settings_window::SettingsWindow::new(window, cx));
+                                cx.new(|cx| Root::new(settings_view.clone().into(), window, cx))
+                            }
+                            Some(WindowRequest::ProjectSplash { project_path }) => {
+                                let loading_view = cx.new(|cx| crate::ui::windows::loading_window::LoadingWindow::new_with_window_id(
+                                    std::path::PathBuf::from(project_path),
+                                    captured_window_id,
+                                    window,
+                                    cx
+                                ));
+                                cx.new(|cx| Root::new(loading_view.clone().into(), window, cx))
+                            }
+                            Some(WindowRequest::ProjectEditor { project_path }) => {
+                                let app = cx.new(|cx| crate::ui::core::app::PulsarApp::new_with_project_and_window_id(
+                                    std::path::PathBuf::from(project_path),
+                                    captured_window_id,
+                                    window,
+                                    cx
+                                ));
+                                let pulsar_root = cx.new(|cx| crate::ui::core::app::PulsarRoot::new("Pulsar Engine", app, window, cx));
+                                cx.new(|cx| Root::new(pulsar_root.into(), window, cx))
+                            }
+                            Some(WindowRequest::CloseWindow { .. }) | None => {
+                                let entry_view = cx.new(|cx| EntryWindow::new(window, cx));
+                                cx.new(|cx| Root::new(entry_view.clone().into(), window, cx))
+                            }
                         }
-                        Some(WindowRequest::ProjectSplash { project_path }) => {
-                            let loading_view = cx.new(|cx| crate::ui::windows::loading_window::LoadingWindow::new_with_window_id(
-                                std::path::PathBuf::from(project_path),
-                                captured_window_id,
-                                window,
-                                cx
-                            ));
-                            cx.new(|cx| Root::new(loading_view.clone().into(), window, cx))
-                        }
-                        Some(WindowRequest::ProjectEditor { project_path }) => {
-                            let app = cx.new(|cx| crate::ui::core::app::PulsarApp::new_with_project_and_window_id(
-                                std::path::PathBuf::from(project_path),
-                                captured_window_id,
-                                window,
-                                cx
-                            ));
-                            let pulsar_root = cx.new(|cx| crate::ui::core::app::PulsarRoot::new("Pulsar Engine", app, window, cx));
-                            cx.new(|cx| Root::new(pulsar_root.into(), window, cx))
-                        }
-                        Some(WindowRequest::CloseWindow { .. }) | None => {
-                            let entry_view = cx.new(|cx| EntryWindow::new(window, cx));
-                            cx.new(|cx| Root::new(entry_view.clone().into(), window, cx))
-                        }
-                    }
+                    })
                 }).expect("Failed to open GPUI window");
 
                 window_state.gpui_window = Some(gpui_window);
                 
-                // On Linux, delay the initial render to allow the window to be properly configured
-                // This fixes the "attached a buffer before configure event" Wayland error
-                println!("🔵 [Linux] External window created, will render after configuration");
+                // Close the Winit window since GPUI has its own
+                // We'll use GPUI's window for display instead of the external approach
+                println!("🔵 [Linux] Using GPUI standard window instead of external window");
             }
 
             // Initialize D3D11 for blitting on Windows
@@ -1610,21 +1647,9 @@ float4 main(PS_INPUT input) : SV_TARGET {
             // Initialize Vulkan for rendering on Linux/macOS
             #[cfg(not(target_os = "windows"))]
             unsafe {
-                println!("🔵 Initializing Vulkan for GPU rendering...");
-
-                match crate::window::vulkan_init::init_vulkan(
-                    &window_state.winit_window,
-                    size.width,
-                    size.height,
-                ) {
-                    Ok(vk_state_init) => {
-                        window_state.vk_state = Some(vk_state_init);
-                        println!("✅ Vulkan initialized successfully!");
-                    }
-                    Err(e) => {
-                        eprintln!("❌ Failed to initialize Vulkan: {:?}", e);
-                    }
-                }
+                // Skip Vulkan initialization when using GPUI's standard window
+                // GPUI will handle its own rendering
+                println!("🔵 Skipping Vulkan init - GPUI handles rendering for standard windows");
             }
 
             window_state.gpui_window_initialized = true;

--- a/crates/engine/src/window/state.rs
+++ b/crates/engine/src/window/state.rs
@@ -86,6 +86,10 @@ pub struct WindowState {
     /// Whether this window needs to render on next frame
     pub needs_render: bool,
     
+    /// Whether the external window has been properly configured (Linux/Wayland)
+    #[cfg(not(target_os = "windows"))]
+    pub window_configured: bool,
+    
     /// Type of window (Settings, ProjectEditor, etc.)
     pub window_type: Option<WindowRequest>,
 
@@ -276,6 +280,8 @@ impl WindowState {
             gpui_window: None,
             gpui_window_initialized: false,
             needs_render: true,
+            #[cfg(not(target_os = "windows"))]
+            window_configured: false,
             window_type: None,
 
             // Event tracking


### PR DESCRIPTION
This pull request refactors the Linux (and macOS) window creation and rendering path for the engine to use GPUI's standard windowing API instead of the previous approach that relied on Winit and external window handles. The changes simplify the codebase by delegating window management and rendering to GPUI on non-Windows platforms, reducing custom Vulkan code and improving maintainability. Windows continues to use the existing Winit + external GPUI rendering path.

**Platform-specific window management and rendering:**

* Added a new `create_linux_gpui_window` method in `WinitGpuiApp` to handle initial window creation directly via GPUI on Linux, bypassing Winit window creation and using GPUI's own event loop and rendering. [[1]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737R118-R197) [[2]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L980-R1047)
* On Linux/macOS, replaced the use of external window handles and custom Vulkan initialization/cleanup/resizing/rendering with GPUI's standard window API, letting GPUI fully manage window lifecycle and rendering. [[1]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L1115-R1184) [[2]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L1156-L1170) [[3]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L1181-R1248) [[4]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737R1278-R1285) [[5]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L597-R697) [[6]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L790-R865) [[7]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L1579-R1652)
* Updated event handling and window cleanup logic to reflect that Vulkan resources are no longer managed directly on Linux/macOS, and that GPUI is responsible for all rendering and resource management.

**Code and state cleanup:**

* Removed unnecessary Vulkan resource management and rendering code for Linux/macOS, including swapchain handling and explicit render calls, as these are now handled by GPUI. [[1]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L597-R697) [[2]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L790-R865) [[3]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L1579-R1652)
* Simplified window state by adding a `window_configured` field for Linux/Wayland and initializing it appropriately. [[1]](diffhunk://#diff-865709daa779bc6cb605e949e0e4e9bdab718796fb295223261fd7c7754c2492R89-R92) [[2]](diffhunk://#diff-865709daa779bc6cb605e949e0e4e9bdab718796fb295223261fd7c7754c2492R283-R284) [[3]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737R359-R360)

**User feedback and logging:**

* Updated log messages throughout to clearly indicate the new window creation and rendering flow on Linux, and improved success/failure messages for clarity. [[1]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L163-R250) [[2]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L182-R275) [[3]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L970-R1029) [[4]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737L1115-R1184) [[5]](diffhunk://#diff-218e8a531b0f1fb2cb9bcd1a64be3aeba106f3478701b5e6ad15d8fb6269c737R1278-R1285)

These changes make the Linux/macOS windowing code simpler, more robust, and easier to maintain by relying on GPUI's built-in capabilities.