### PR TITLE
Sketchfab updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,12 +270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "antidote"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,32 +1154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boring-sys2"
-version = "4.15.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6c876a958d17057d9d3a31075bb9609237413a1fe665432782c31ef596eb6b"
-dependencies = [
- "autocfg",
- "bindgen 0.72.1",
- "cmake",
- "fs_extra",
- "fslock",
-]
-
-[[package]]
-name = "boring2"
-version = "4.15.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
-dependencies = [
- "bitflags 2.11.0",
- "boring-sys2",
- "foreign-types 0.5.0",
- "libc",
- "openssl-macros",
-]
-
-[[package]]
 name = "borsh"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,34 +1178,13 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 4.0.3",
-]
-
-[[package]]
-name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 5.0.0",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -1590,15 +1537,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,7 +1666,7 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
- "brotli 8.0.2",
+ "brotli",
  "compression-core",
  "deflate64",
  "flate2",
@@ -3406,28 +3344,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "fslock"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -4691,24 +4613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http2"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e23815f8ec982e1452e1d0fda921ec20a9187fb610ad003c90cc5abd65b2c4"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.4.0",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4812,26 +4716,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry 0.6.1",
-]
-
-[[package]]
-name = "hyper2"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a1bb25e0cbdbe7b21f8ef6c3c4785f147d79e7ded438b5ee2b70e380183294"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http2",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
 ]
 
 [[package]]
@@ -5599,21 +5483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "linkme"
 version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5704,12 +5573,6 @@ name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-
-[[package]]
-name = "lru"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
 name = "lru-slab"
@@ -6139,7 +6002,7 @@ dependencies = [
  "flate2",
  "io-enum",
  "libc",
- "lru 0.12.5",
+ "lru",
  "mysql_common",
  "named_pipe",
  "pem",
@@ -9130,53 +8993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rquest"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5037287a38246515a36794ee0e475ea0bd4f3873c06229680287a52dc428ec9"
-dependencies = [
- "antidote",
- "async-compression",
- "base64 0.22.1",
- "boring-sys2",
- "boring2",
- "brotli 7.0.0",
- "bytes",
- "encoding_rs",
- "flate2",
- "foreign-types 0.5.0",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper2",
- "ipnet",
- "libc",
- "linked_hash_set",
- "log",
- "lru 0.13.0",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "socket2 0.5.10",
- "sync_wrapper",
- "system-configuration 0.6.1",
- "tokio",
- "tokio-boring2",
- "tokio-util",
- "tower 0.5.3",
- "tower-service",
- "typed-builder",
- "url",
- "webpki-root-certs 0.26.11",
- "windows-registry 0.5.3",
- "zstd",
-]
-
-[[package]]
 name = "rs_tracing"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9545,7 +9361,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs",
  "windows-sys 0.61.2",
 ]
 
@@ -11226,17 +11042,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-boring2"
-version = "4.15.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3866209c48e3d69e709a9d6105d7e2aa34e4374bc5dcaec32e0f8e53a28db14a"
-dependencies = [
- "boring-sys2",
- "boring2",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12047,26 +11852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-builder"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12267,7 +12052,7 @@ version = "0.1.0"
 dependencies = [
  "gpui-ce",
  "image",
- "rquest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "smallvec",
@@ -13125,15 +12910,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.6",
-]
-
-[[package]]
-name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
@@ -13901,17 +13677,6 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
-dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
@@ -13972,15 +13737,6 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
@@ -12050,6 +12059,7 @@ dependencies = [
 name = "ui_fab_search"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
  "gpui-ce",
  "image",
  "reqwest 0.12.28",

--- a/crates/ui/src/download_item.rs
+++ b/crates/ui/src/download_item.rs
@@ -1,0 +1,248 @@
+//! DownloadItem — a single row in the download manager list.
+//!
+//! Shows: filename + status badge, speed sparkline, progress bar, and stats row.
+//! Used by `DownloadManagerDrawer` but can also be embedded standalone.
+
+use std::path::PathBuf;
+
+use gpui::{
+    div, prelude::FluentBuilder as _, px, App, Hsla, IntoElement, InteractiveElement as _,
+    ParentElement, RenderOnce, SharedString, Styled, Window,
+};
+
+use crate::{
+    button::{Button, ButtonVariants as _},
+    h_flex, v_flex, ActiveTheme, Sizable, StyledExt as _,
+    progress::Progress,
+    speed_graph::{fmt_bytes, fmt_speed, SpeedGraph},
+};
+
+// ── Status ────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, PartialEq)]
+pub enum DownloadItemStatus {
+    InProgress,
+    Done,
+    Error(String),
+}
+
+// ── DownloadItem ──────────────────────────────────────────────────────────────
+
+/// A single download entry card — filename, speed graph, progress bar, stats.
+#[derive(IntoElement)]
+pub struct DownloadItem {
+    pub id: SharedString,
+    pub filename: SharedString,
+    /// 0.0 – 100.0
+    pub progress_pct: f32,
+    /// Current transfer rate in bytes/s.
+    pub speed_bps: f64,
+    /// Historical speed samples in bytes/s, ordered oldest → newest (max ~60).
+    pub speed_history: Vec<f64>,
+    pub status: DownloadItemStatus,
+    pub bytes_received: u64,
+    pub total_bytes: Option<u64>,
+    /// Local path to the completed file (present when status is Done).
+    pub path: Option<PathBuf>,
+}
+
+impl RenderOnce for DownloadItem {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let fg = cx.theme().foreground;
+        let muted_fg = cx.theme().muted_foreground;
+        let border = cx.theme().border;
+        let card_bg = cx.theme().secondary;
+
+        let green: Hsla = gpui::rgb(0x22C55E).into();
+        let green_dim = green.opacity(0.12);
+
+        let is_active = self.status == DownloadItemStatus::InProgress;
+        let is_done = self.status == DownloadItemStatus::Done;
+        let is_error = matches!(self.status, DownloadItemStatus::Error(_));
+
+        let progress = if is_done {
+            100.0
+        } else {
+            match self.total_bytes {
+                Some(t) if t > 0 => (self.bytes_received as f32 / t as f32 * 100.0).min(100.0),
+                _ => self.progress_pct,
+            }
+        };
+
+        div()
+            .id(self.id.clone())
+            .p_3()
+            .mb_2()
+            .rounded_lg()
+            .bg(card_bg)
+            .border_1()
+            .border_color(border)
+            .child(
+                v_flex()
+                    .gap_2()
+                    // ── Header: filename + badge ─────────────────────────
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .items_center()
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .text_sm()
+                                    .font_medium()
+                                    .text_color(fg)
+                                    .overflow_hidden()
+                                    .child(self.filename.clone()),
+                            )
+                            .child(
+                                // Status badge
+                                if is_active {
+                                    div()
+                                        .px_2()
+                                        .py(px(2.))
+                                        .rounded_full()
+                                        .text_xs()
+                                        .bg(cx.theme().accent.opacity(0.15))
+                                        .text_color(cx.theme().accent)
+                                        .child("Downloading")
+                                } else if is_done {
+                                    div()
+                                        .px_2()
+                                        .py(px(2.))
+                                        .rounded_full()
+                                        .text_xs()
+                                        .bg(green_dim)
+                                        .text_color(green)
+                                        .child("Done ✓")
+                                } else {
+                                    div()
+                                        .px_2()
+                                        .py(px(2.))
+                                        .rounded_full()
+                                        .text_xs()
+                                        .bg(gpui::red().opacity(0.12))
+                                        .text_color(gpui::red())
+                                        .child("Error")
+                                },
+                            ),
+                    )
+                    // ── Speed sparkline (active or done with history) ─────
+                    .when(!self.speed_history.is_empty(), |el| {
+                        el.child(
+                            // SpeedGraph defaults to w_full() — fills card width
+                            SpeedGraph::new(&self.speed_history)
+                                .height(px(44.)),
+                        )
+                    })
+                    // ── Progress bar ─────────────────────────────────────
+                    .when(is_active || is_done, |el| {
+                        el.child(Progress::new().value(progress))
+                    })
+                    // ── Stats row ────────────────────────────────────────
+                    .child(
+                        h_flex()
+                            .gap_3()
+                            .text_xs()
+                            .text_color(muted_fg)
+                            // Speed (active only)
+                            .when(is_active && self.speed_bps > 0.0, |el| {
+                                el.child(div().child(fmt_speed(self.speed_bps)))
+                            })
+                            // Bytes received / total
+                            .child(div().child(match self.total_bytes {
+                                Some(total) => format!(
+                                    "{} / {}",
+                                    fmt_bytes(self.bytes_received),
+                                    fmt_bytes(total)
+                                ),
+                                None => fmt_bytes(self.bytes_received),
+                            }))
+                            // ETA (active, known size, positive speed)
+                            .when_some(
+                                eta_str(is_active, self.bytes_received, self.total_bytes, self.speed_bps),
+                                |el, eta| el.child(div().child(format!("ETA {}", eta))),
+                            )
+                            // Done / error messages
+                            .when(is_done, |el| {
+                                el.child(div().text_color(green).child("Complete"))
+                            })
+                            .when(is_error, |el| {
+                                let msg = match &self.status {
+                                    DownloadItemStatus::Error(m) => m.as_str(),
+                                    _ => "",
+                                };
+                                el.child(div().text_color(gpui::red()).child(msg.to_string()))
+                            }),
+                    )
+                    // ── Open Folder button (Done items with known path) ──
+                    .when_some(
+                        if is_done { self.path.clone() } else { None },
+                        |el, path| {
+                            el.child(
+                                h_flex().justify_end()
+                                    .child(
+                                        Button::new(SharedString::from(format!("open-folder-{}", self.id)))
+                                            .label("📂 Open Folder")
+                                            .with_size(crate::Size::Small)
+                                            .on_click(move |_, _, _cx| {
+                                                reveal_in_file_manager(&path);
+                                            }),
+                                    ),
+                            )
+                        },
+                    ),
+            )
+    }
+}
+
+/// Open the parent folder of `path` in the system file manager.
+pub fn reveal_in_file_manager(path: &std::path::Path) {
+    let folder = path.parent().unwrap_or(path);
+    #[cfg(target_os = "windows")]
+    {
+        // Use /select to highlight the file; fall back to opening the folder.
+        let _ = std::process::Command::new("explorer")
+            .args(["/select,", &path.to_string_lossy()])
+            .spawn()
+            .or_else(|_| std::process::Command::new("explorer").arg(folder).spawn());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // `open -R` reveals (selects) the file in Finder.
+        let _ = std::process::Command::new("open")
+            .arg("-R")
+            .arg(path)
+            .spawn()
+            .or_else(|_| std::process::Command::new("open").arg(folder).spawn());
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let _ = std::process::Command::new("xdg-open").arg(folder).spawn();
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn eta_str(
+    is_active: bool,
+    bytes_received: u64,
+    total_bytes: Option<u64>,
+    speed_bps: f64,
+) -> Option<String> {
+    if !is_active || speed_bps <= 0.0 {
+        return None;
+    }
+    let total = total_bytes?;
+    if total <= bytes_received {
+        return None;
+    }
+    let remaining = (total - bytes_received) as f64;
+    let secs = remaining / speed_bps;
+    Some(if secs < 60.0 {
+        format!("{:.0}s", secs)
+    } else if secs < 3600.0 {
+        format!("{:.0}m {:.0}s", secs / 60.0, secs % 60.0)
+    } else {
+        format!("{:.1}h", secs / 3600.0)
+    })
+}

--- a/crates/ui/src/download_manager.rs
+++ b/crates/ui/src/download_manager.rs
@@ -1,0 +1,191 @@
+//! DownloadManagerDrawer — a side-panel drawer listing all in-progress and
+//! completed downloads with per-item speed sparklines and progress bars.
+//!
+//! Usage inside a GPUI `Render` impl — conditionally include as a sibling of
+//! the main layout so the `anchored()` overlay covers the full window:
+//!
+//! ```rust
+//! .when(self.show_download_manager, |el| {
+//!     el.child(
+//!         DownloadManagerDrawer::new(entries)
+//!             .on_close(|_, window, cx| { window.close_drawer(cx); })
+//!     )
+//! })
+//! ```
+
+use std::rc::Rc;
+
+use gpui::{
+    div, prelude::FluentBuilder as _, px, App, ClickEvent, IntoElement, ParentElement, RenderOnce,
+    SharedString, Styled, Window,
+};
+
+use crate::{
+    download_item::{DownloadItem, DownloadItemStatus},
+    drawer::Drawer,
+    h_flex, v_flex, ActiveTheme, StyledExt as _,
+    root::ContextModal as _,
+    speed_graph::{fmt_bytes, fmt_speed},
+};
+
+// ── DownloadEntry (data record) ───────────────────────────────────────────────
+
+/// All the data needed to render one row in the download manager.
+#[derive(Clone)]
+pub struct DownloadEntry {
+    pub uid: SharedString,
+    pub filename: SharedString,
+    /// 0.0 – 100.0
+    pub progress_pct: f32,
+    /// Current transfer rate, bytes/s.
+    pub speed_bps: f64,
+    /// Rolling history of speed samples (bytes/s), oldest → newest.
+    pub speed_history: Vec<f64>,
+    pub status: DownloadItemStatus,
+    pub bytes_received: u64,
+    pub total_bytes: Option<u64>,
+    /// Local path to the completed file (used to show Open Folder button).
+    pub path: Option<std::path::PathBuf>,
+}
+
+// ── DownloadManagerDrawer ─────────────────────────────────────────────────────
+
+/// A `Drawer` panel that lists all downloads with speed graphs and progress bars.
+///
+/// The drawer is right-anchored over the window.  Typically rendered
+/// conditionally; the on_close callback should set the parent's visibility flag.
+#[derive(IntoElement)]
+pub struct DownloadManagerDrawer {
+    downloads: Vec<DownloadEntry>,
+    on_close: Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>,
+}
+
+impl DownloadManagerDrawer {
+    pub fn new(downloads: Vec<DownloadEntry>) -> Self {
+        Self {
+            downloads,
+            on_close: Rc::new(|_, _, _| {}),
+        }
+    }
+
+    /// Callback invoked when the user closes the drawer (overlay click or Esc).
+    pub fn on_close(
+        mut self,
+        f: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_close = Rc::new(f);
+        self
+    }
+}
+
+impl RenderOnce for DownloadManagerDrawer {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let on_close = self.on_close.clone();
+        let muted_fg = cx.theme().muted_foreground;
+
+        // ── Summary header ────────────────────────────────────────────────
+        let active_count = self
+            .downloads
+            .iter()
+            .filter(|e| e.status == DownloadItemStatus::InProgress)
+            .count();
+
+        let title_text = if active_count > 0 {
+            format!("Downloads — {} active", active_count)
+        } else {
+            "Downloads".to_string()
+        };
+
+        // ── Build total-speeds footer ─────────────────────────────────────
+        let total_speed: f64 = self
+            .downloads
+            .iter()
+            .filter(|e| e.status == DownloadItemStatus::InProgress)
+            .map(|e| e.speed_bps)
+            .sum();
+
+        let total_bytes: u64 = self.downloads.iter().map(|e| e.bytes_received).sum();
+
+        let footer_text = if active_count > 0 {
+            format!(
+                "Total {} · {}",
+                fmt_bytes(total_bytes),
+                fmt_speed(total_speed)
+            )
+        } else {
+            fmt_bytes(total_bytes)
+        };
+
+        // ── Drawer items ──────────────────────────────────────────────────
+        let items: Vec<DownloadItem> = self
+            .downloads
+            .into_iter()
+            .map(|e| DownloadItem {
+                id: SharedString::from(format!("dl-{}", e.uid)),
+                filename: e.filename,
+                progress_pct: e.progress_pct,
+                speed_bps: e.speed_bps,
+                speed_history: e.speed_history,
+                status: e.status,
+                bytes_received: e.bytes_received,
+                total_bytes: e.total_bytes,
+                path: e.path,
+            })
+            .collect();
+
+        // ── Assemble drawer ───────────────────────────────────────────────
+        let mut drawer = Drawer::new(window, cx)
+            .title(
+                div()
+                    .text_sm()
+                    .font_semibold()
+                    .text_color(cx.theme().foreground)
+                    .child(title_text),
+            )
+            .footer(
+                h_flex()
+                    .px_4()
+                    .py_2()
+                    .w_full()
+                    .border_t_1()
+                    .border_color(cx.theme().border)
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(muted_fg)
+                            .child(footer_text),
+                    ),
+            )
+            .size(px(420.))
+            .resizable(true)
+            .overlay(true)
+            .overlay_closable(true)
+            .on_close(move |ev, window, cx| {
+                window.close_drawer(cx);
+                on_close(ev, window, cx);
+            });
+
+        // Empty state or list of items
+        if items.is_empty() {
+            drawer = drawer.child(
+                v_flex()
+                    .w_full()
+                    .py_8()
+                    .items_center()
+                    .justify_center()
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(muted_fg)
+                            .child("No downloads yet"),
+                    ),
+            );
+        } else {
+            for item in items {
+                drawer = drawer.child(item);
+            }
+        }
+
+        drawer
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -48,6 +48,9 @@ pub mod breadcrumb;
 pub mod button;
 pub mod chart;
 pub mod checkbox;
+pub mod download_item;
+pub mod download_manager;
+pub mod speed_graph;
 pub mod clipboard;
 pub mod code_editor; // Studio-quality virtualized code editor
 pub mod color_picker;
@@ -133,6 +136,11 @@ pub use graph::*;
 pub use compiler::*;
 pub use settings::*;
 pub use themes::*;
+
+// Download manager components
+pub use download_item::{DownloadItem, DownloadItemStatus, reveal_in_file_manager};
+pub use download_manager::{DownloadEntry, DownloadManagerDrawer};
+pub use speed_graph::{SpeedGraph, fmt_speed, fmt_bytes};
 
 // Engine constants (will be set by engine binary)
 pub const ENGINE_NAME: &str = "Pulsar Engine";

--- a/crates/ui/src/speed_graph.rs
+++ b/crates/ui/src/speed_graph.rs
@@ -1,0 +1,114 @@
+//! SpeedGraph — a compact bar sparkline that visualises download speed over time.
+//!
+//! Usage:
+//! ```rust
+//! SpeedGraph::new(&speed_samples)   // &[f64] bytes/s values, oldest→newest
+//!     .width(px(200.))
+//!     .height(px(40.))
+//! ```
+//!
+//! Renders as a row of proportional bars (histogram-style sparkline) — no
+//! GPUI canvas paths required; pure-div layout so it works everywhere.
+
+use gpui::{
+    div, prelude::FluentBuilder as _, px, App, IntoElement, ParentElement, Pixels, RenderOnce,
+    Styled, Window,
+};
+
+use crate::ActiveTheme;
+
+// ── SpeedGraph ────────────────────────────────────────────────────────────────
+
+/// A compact bar-sparkline for download speed history.
+///
+/// `samples` is a slice of bandwidth readings in **bytes/s**, oldest→newest.
+/// By default the chart fills its container's full width (`w_full()`).  Pass
+/// `.width(px(N))` to give it a fixed size instead.
+#[derive(IntoElement)]
+pub struct SpeedGraph {
+    samples: Vec<f64>,
+    /// `None` = fill available width (default).
+    width: Option<Pixels>,
+    height: Pixels,
+}
+
+impl SpeedGraph {
+    pub fn new(samples: &[f64]) -> Self {
+        Self {
+            samples: samples.to_vec(),
+            width: None,  // full width by default
+            height: px(36.),
+        }
+    }
+
+    /// Give the chart a fixed pixel width instead of filling the container.
+    pub fn width(mut self, w: Pixels) -> Self {
+        self.width = Some(w);
+        self
+    }
+
+    pub fn height(mut self, h: Pixels) -> Self {
+        self.height = h;
+        self
+    }
+}
+
+impl RenderOnce for SpeedGraph {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let accent = cx.theme().accent;
+        let accent_dim = cx.theme().accent.opacity(0.25);
+        let h = self.height;
+
+        let y_max = self.samples
+            .iter()
+            .cloned()
+            .fold(0.0_f64, f64::max)
+            .max(1.0);
+
+        div()
+            .map(|d| match self.width {
+                Some(w) => d.w(w),
+                None    => d.w_full(),
+            })
+            .h(h)
+            .rounded_sm()
+            .overflow_hidden()
+            .bg(accent_dim)
+            .flex()
+            .items_end() // bars grow upward from bottom
+            .children(self.samples.iter().map(|&v| {
+                let ratio = (v / y_max).clamp(0.0, 1.0) as f32;
+                let bar_h = h * ratio;
+                div()
+                    .flex_1() // equal width, fills container
+                    .h(bar_h)
+                    .bg(accent)
+            }))
+    }
+}
+
+// ── Formatting helpers re-exported for convenience ────────────────────────────
+
+/// Format bytes/sec as a human-readable string: "1.2 MB/s", "512 KB/s", etc.
+pub fn fmt_speed(bytes_per_sec: f64) -> String {
+    if bytes_per_sec >= 1_000_000.0 {
+        format!("{:.1} MB/s", bytes_per_sec / 1_000_000.0)
+    } else if bytes_per_sec >= 1_000.0 {
+        format!("{:.0} KB/s", bytes_per_sec / 1_000.0)
+    } else {
+        format!("{:.0} B/s", bytes_per_sec)
+    }
+}
+
+/// Format byte count as human-readable: "12.3 MB", "4.5 GB", etc.
+pub fn fmt_bytes(bytes: u64) -> String {
+    if bytes >= 1_000_000_000 {
+        format!("{:.2} GB", bytes as f64 / 1_000_000_000.0)
+    } else if bytes >= 1_000_000 {
+        format!("{:.1} MB", bytes as f64 / 1_000_000.0)
+    } else if bytes >= 1_000 {
+        format!("{:.0} KB", bytes as f64 / 1_000.0)
+    } else {
+        format!("{} B", bytes)
+    }
+}

--- a/ui-crates/ui_fab_search/Cargo.toml
+++ b/ui-crates/ui_fab_search/Cargo.toml
@@ -10,11 +10,12 @@ ui_common = { workspace = true }
 urlencoding = "2.1.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", features = ["json", "gzip", "brotli"] }
+reqwest = { version = "0.12", features = ["json", "gzip", "brotli", "blocking"] }
 tokio = { version = "1", features = ["rt"] }
 smol = "2"
 image = "0.25"
 smallvec = "1"
+dirs = "5"
 
 [lints]
 workspace = true

--- a/ui-crates/ui_fab_search/Cargo.toml
+++ b/ui-crates/ui_fab_search/Cargo.toml
@@ -10,7 +10,7 @@ ui_common = { workspace = true }
 urlencoding = "2.1.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rquest = { version = "=2.2.1", features = ["gzip", "brotli", "json"] }
+reqwest = { version = "0.12", features = ["json", "gzip", "brotli"] }
 tokio = { version = "1", features = ["rt"] }
 smol = "2"
 image = "0.25"

--- a/ui-crates/ui_fab_search/src/auth.rs
+++ b/ui-crates/ui_fab_search/src/auth.rs
@@ -1,0 +1,37 @@
+//! Token persistence for Sketchfab API authentication.
+//!
+//! Tokens are stored at: <config_dir>/pulsar/sketchfab_token
+//! (e.g. ~/.config/pulsar/sketchfab_token on Linux,
+//!        %APPDATA%\pulsar\sketchfab_token on Windows)
+
+use std::path::PathBuf;
+
+fn token_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("pulsar")
+        .join("sketchfab_token")
+}
+
+/// Load the previously saved API token, trimming whitespace.
+pub fn load_saved_token() -> Option<String> {
+    let path = token_path();
+    std::fs::read_to_string(&path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Persist the API token to disk (creates parent directory as needed).
+pub fn save_token(token: &str) {
+    let path = token_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, token.trim());
+}
+
+/// Delete the persisted token file, if any.
+pub fn delete_token() {
+    let _ = std::fs::remove_file(token_path());
+}

--- a/ui-crates/ui_fab_search/src/image_loader.rs
+++ b/ui-crates/ui_fab_search/src/image_loader.rs
@@ -1,12 +1,7 @@
-//! Background image downloader for Fab asset thumbnails and gallery images.
+//! Background image downloader for asset thumbnails and gallery images.
 //!
-//! Downloads image bytes via rquest + Chrome TLS impersonation, decodes them
-//! into a BGRA8 `image::Frame`, and wraps the result in a `gpui::RenderImage`.
-//!
-//! Using `ImageSource::Render(Arc<RenderImage>)` is fully synchronous on the
-//! GPUI render path — it bypasses the async asset loader entirely and returns
-//! the decoded pixel data on every render call, guaranteeing the image is
-//! always visible once stored in the cache.
+//! Downloads image bytes via reqwest, decodes them into a BGRA8 `image::Frame`,
+//! and wraps the result in a `gpui::RenderImage`.
 
 use std::sync::Arc;
 use gpui::RenderImage;
@@ -14,21 +9,21 @@ use gpui::RenderImage;
 /// Download `url` and decode it into a `RenderImage` ready for
 /// `ImageSource::Render`.  Always called from an OS thread.
 pub fn fetch_and_decode(url: &str) -> Result<Arc<RenderImage>, String> {
-    use rquest::Impersonate;
-
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|e| e.to_string())?;
 
-    let bytes = rt.block_on(async {
-        let client = rquest::Client::builder()
-            .impersonate(Impersonate::Chrome131)
+    let url = url.to_string();
+    let bytes: Vec<u8> = rt.block_on(async move {
+        let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
+            .user_agent("Pulsar-Native/1.0")
             .build()
-            .map_err(|e| e.to_string())?;
+            .map_err(|e: reqwest::Error| e.to_string())?;
 
-        let response = client.get(url).send().await.map_err(|e| e.to_string())?;
+        let response = client.get(&url).send().await
+            .map_err(|e: reqwest::Error| e.to_string())?;
 
         if !response.status().is_success() {
             return Err(format!("HTTP {}", response.status()));
@@ -38,7 +33,7 @@ pub fn fetch_and_decode(url: &str) -> Result<Arc<RenderImage>, String> {
             .bytes()
             .await
             .map(|b| b.to_vec())
-            .map_err(|e| e.to_string())
+            .map_err(|e: reqwest::Error| e.to_string())
     })?;
 
     // Decode to RGBA8

--- a/ui-crates/ui_fab_search/src/item_detail/changelog.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/changelog.rs
@@ -1,86 +1,99 @@
 use gpui::{prelude::*, *};
-use ui::{divider::Divider, v_flex, ActiveTheme, StyledExt};
+use ui::{h_flex, v_flex, ActiveTheme, StyledExt};
 
-/// A single changelog entry with a version/date header and body text.
-pub struct ChangelogEntry {
-    pub date: SharedString,
-    pub content: SharedString,
+use crate::parser::fmt_count;
+
+struct StatRow {
+    label: &'static str,
+    value: String,
 }
 
-/// Renders the release history of an asset in a readable list.
+/// Displays model statistics: views, likes, downloads, geometry, textures, PBR, etc.
 #[derive(IntoElement)]
-pub struct ChangelogSection {
-    pub entries: Vec<ChangelogEntry>,
+pub struct ModelStatsSection {
+    pub view_count: i64,
+    pub like_count: i64,
+    pub download_count: i64,
+    pub face_count: Option<i64>,
+    pub vertex_count: Option<i64>,
+    pub material_count: Option<i32>,
+    pub texture_count: Option<i32>,
+    pub animation_count: i32,
+    pub sound_count: i32,
+    pub pbr_type: Option<String>,
 }
 
-impl ChangelogSection {
-    pub fn new(entries: Vec<ChangelogEntry>) -> Self {
-        Self { entries }
+impl ModelStatsSection {
+    pub fn new(
+        view_count: i64,
+        like_count: i64,
+        download_count: i64,
+        face_count: Option<i64>,
+        vertex_count: Option<i64>,
+        material_count: Option<i32>,
+        texture_count: Option<i32>,
+        animation_count: i32,
+        sound_count: i32,
+        pbr_type: Option<String>,
+    ) -> Self {
+        Self {
+            view_count, like_count, download_count, face_count, vertex_count,
+            material_count, texture_count, animation_count, sound_count, pbr_type,
+        }
     }
 }
 
-impl RenderOnce for ChangelogSection {
+impl RenderOnce for ModelStatsSection {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let border = cx.theme().border;
         let fg = cx.theme().foreground;
         let muted = cx.theme().muted_foreground;
 
-        let entries = self.entries;
+        let mut rows: Vec<StatRow> = Vec::new();
+        rows.push(StatRow { label: "Views",      value: fmt_count(self.view_count) });
+        rows.push(StatRow { label: "Likes",      value: fmt_count(self.like_count) });
+        if self.download_count > 0 {
+            rows.push(StatRow { label: "Downloads",  value: fmt_count(self.download_count) });
+        }
+        if let Some(f) = self.face_count {
+            rows.push(StatRow { label: "Faces",      value: fmt_count(f) });
+        }
+        if let Some(v) = self.vertex_count {
+            rows.push(StatRow { label: "Vertices",   value: fmt_count(v) });
+        }
+        if let Some(m) = self.material_count {
+            rows.push(StatRow { label: "Materials",  value: m.to_string() });
+        }
+        if let Some(t) = self.texture_count {
+            rows.push(StatRow { label: "Textures",   value: t.to_string() });
+        }
+        if self.animation_count > 0 {
+            rows.push(StatRow { label: "Animations", value: self.animation_count.to_string() });
+        }
+        if self.sound_count > 0 {
+            rows.push(StatRow { label: "Sounds",     value: self.sound_count.to_string() });
+        }
+        if let Some(pbr) = self.pbr_type {
+            rows.push(StatRow { label: "PBR Type",   value: pbr });
+        }
 
         v_flex()
             .w_full()
             .px_5()
             .py_4()
-            .gap_3()
-            // section label
+            .gap_2()
+            .border_t_1()
+            .border_color(border)
             .child(
-                div()
-                    .text_xs()
-                    .font_bold()
-                    .text_color(muted)
-                    .child("Changelog"),
+                div().text_xs().font_bold().text_color(muted).child("Model Stats"),
             )
-            .children(
-                entries
-                    .into_iter()
-                    .enumerate()
-                    .flat_map(|(i, entry)| {
-                        let divider = if i > 0 {
-                            Some(
-                                div()
-                                    .w_full()
-                                    .child(Divider::horizontal().color(border))
-                                    .into_any_element(),
-                            )
-                        } else {
-                            None
-                        };
-
-                        let row = v_flex()
-                            .w_full()
-                            .gap_1()
-                            .child(
-                                div()
-                                    .text_xs()
-                                    .font_medium()
-                                    .text_color(muted)
-                                    .child(entry.date),
-                            )
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(fg)
-                                    .line_height(relative(1.6))
-                                    .child(entry.content),
-                            )
-                            .into_any_element();
-
-                        [divider, Some(row)]
-                            .into_iter()
-                            .flatten()
-                            .collect::<Vec<_>>()
-                    })
-                    .collect::<Vec<_>>(),
-            )
+            .children(rows.into_iter().map(|row| {
+                h_flex()
+                    .w_full()
+                    .justify_between()
+                    .py(px(3.0))
+                    .child(div().text_xs().text_color(muted).child(row.label))
+                    .child(div().text_xs().font_medium().text_color(fg).child(row.value))
+            }))
     }
 }

--- a/ui-crates/ui_fab_search/src/item_detail/gallery.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/gallery.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use gpui::{prelude::*, *};
-use ui::{v_flex, ActiveTheme, StyledExt};
+use ui::{v_flex, ActiveTheme, ContextModal, StyledExt, scroll::{Scrollbar, ScrollbarState}};
 
 /// A single gallery image entry.
 pub struct GalleryImage {
@@ -7,20 +9,21 @@ pub struct GalleryImage {
     pub width: u32,
     pub height: u32,
     /// Pre-decoded image ready for synchronous rendering; `None` while downloading.
-    pub image: Option<std::sync::Arc<gpui::RenderImage>>,
+    pub image: Option<Arc<gpui::RenderImage>>,
 }
 
-/// Horizontally-wrapping grid of preview images for an asset.
-/// Renders each image using a native `gpui::img()` element.
-/// Falls back to a numbered placeholder when no URL is available.
+/// Horizontally-scrolling strip of preview images for an asset.
+/// Click any thumbnail to open a fullscreen modal lightbox.
 #[derive(IntoElement)]
 pub struct GalleryStrip {
     pub images: Vec<GalleryImage>,
+    pub scroll_handle: ScrollHandle,
+    pub scroll_state: ScrollbarState,
 }
 
 impl GalleryStrip {
-    pub fn new(images: Vec<GalleryImage>) -> Self {
-        Self { images }
+    pub fn new(images: Vec<GalleryImage>, scroll_handle: ScrollHandle, scroll_state: ScrollbarState) -> Self {
+        Self { images, scroll_handle, scroll_state }
     }
 }
 
@@ -29,6 +32,9 @@ impl RenderOnce for GalleryStrip {
         let border = cx.theme().border;
         let muted = cx.theme().muted_foreground;
         let card_bg = cx.theme().sidebar;
+        let total = self.images.len();
+        let scroll_handle = self.scroll_handle;
+        let scroll_state = self.scroll_state;
 
         v_flex()
             .w_full()
@@ -43,49 +49,108 @@ impl RenderOnce for GalleryStrip {
                     .text_xs()
                     .font_bold()
                     .text_color(muted)
-                    .child(format!("Gallery ({} images)", self.images.len())),
+                    .child(format!("Gallery ({} images)", total)),
             )
-            // ── image grid ───────────────────────────────────────────────
+            // ── horizontal scroll strip with overlay scrollbar ────────────
+            // Outer has a fixed height so size_full() on the inner gives it
+            // a concrete pixel size — the same trick that makes vertical scroll work.
             .child(
                 div()
-                    .flex()
-                    .flex_row()
-                    .flex_wrap()
-                    .gap_2()
-                    .children(self.images.into_iter().enumerate().map(|(i, img_data)| {
-                        let has_image = img_data.image.is_some();
+                    .id("gallery-strip-outer")
+                    .relative()
+                    .w_full()
+                    .h(px(160.0)) // 135px thumbs + 25px scrollbar room
+                    .child(
                         div()
-                            .id(SharedString::from(format!("gallery-img-{}", i)))
-                            .w(px(180.0))
-                            .h(px(101.0))   // 16:9
-                            .flex_shrink_0()
-                            .rounded_md()
-                            .overflow_hidden()
-                            .bg(card_bg)
-                            .border_1()
-                            .border_color(border)
-                            .cursor_pointer()
-                            // Use a real img element when the image is ready
-                            .when(has_image, |el| {
-                                el.child(
-                                    img(gpui::ImageSource::Render(img_data.image.unwrap()))
-                                        .w_full()
-                                        .h_full()
-                                        .object_fit(gpui::ObjectFit::Cover),
-                                )
-                            })
-                            .when(!has_image, |el| {
-                                el.flex()
-                                    .items_center()
-                                    .justify_center()
-                                    .child(
-                                        div()
-                                            .text_xs()
-                                            .text_color(muted)
-                                            .child(format!("#{}", i + 1)),
-                                    )
-                            })
-                    })),
+                            .id("gallery-strip")
+                            .size_full()
+                            .overflow_x_scroll()
+                            .track_scroll(&scroll_handle)
+                            .flex()
+                            .flex_row()
+                            .items_start()
+                            .gap_2()
+                            .children(self.images.into_iter().enumerate().map(|(i, img_data)| {
+                                let img_arc = img_data.image;
+
+                                if let Some(arc) = img_arc {
+                                    let arc_render = arc.clone();
+                                    div()
+                                        .id(SharedString::from(format!("gallery-thumb-{}", i)))
+                                        .relative()
+                                        .w(px(240.0))
+                                        .h(px(135.0)) // 16:9
+                                        .flex_shrink_0()
+                                        .rounded_md()
+                                        .overflow_hidden()
+                                        .bg(card_bg)
+                                        .border_1()
+                                        .border_color(border)
+                                        .child(
+                                            img(gpui::ImageSource::Render(arc_render))
+                                                .w_full()
+                                                .h_full()
+                                                .object_fit(gpui::ObjectFit::Cover),
+                                        )
+                                        // transparent overlay on top captures the click
+                                        .child(
+                                            div()
+                                                .id(SharedString::from(format!("gallery-click-{}", i)))
+                                                .absolute()
+                                                .inset_0()
+                                                .cursor_pointer()
+                                                .on_click(move |_, window, cx| {
+                                                    let arc = arc.clone();
+                                                    window.open_modal(cx, move |modal, _w, _cx| {
+                                                        let arc = arc.clone();
+                                                        modal
+                                                            .width(px(960.0))
+                                                            .show_close(true)
+                                                            .child(
+                                                                div()
+                                                                    .w(px(920.0))
+                                                                    .h(px(517.0))
+                                                                    .child(
+                                                                        img(gpui::ImageSource::Render(arc))
+                                                                            .w_full()
+                                                                            .h_full()
+                                                                            .object_fit(gpui::ObjectFit::Contain),
+                                                                    ),
+                                                            )
+                                                    });
+                                                })
+                                        )
+                                        .into_any_element()
+                                } else {
+                                    div()
+                                        .id(SharedString::from(format!("gallery-thumb-{}", i)))
+                                        .w(px(240.0))
+                                        .h(px(135.0))
+                                        .flex_shrink_0()
+                                        .rounded_md()
+                                        .overflow_hidden()
+                                        .bg(card_bg)
+                                        .border_1()
+                                        .border_color(border)
+                                        .flex()
+                                        .items_center()
+                                        .justify_center()
+                                        .child(
+                                            div()
+                                                .text_xs()
+                                                .text_color(muted)
+                                                .child(format!("#{}", i + 1)),
+                                        )
+                                        .into_any_element()
+                                }
+                            })),
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .inset_0()
+                            .child(Scrollbar::horizontal(&scroll_state, &scroll_handle)),
+                    ),
             )
     }
 }

--- a/ui-crates/ui_fab_search/src/item_detail/header.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/header.rs
@@ -61,13 +61,13 @@ impl RenderOnce for DetailHeader {
                     .truncate()
                     .child(self.title),
             )
-            // ── open on fab ──────────────────────────────────────────────
+            // ── view on sketchfab ─────────────────────────────────────
             .child(
-                Button::new("detail-open-fab")
+                Button::new("detail-open-sketchfab")
                     .small()
                     .primary()
                     .icon(Icon::new(IconName::ExternalLink).small())
-                    .label("Open on Fab")
+                    .label("View on Sketchfab")
                     .on_click(move |_ev, _window, cx| {
                         cx.open_url(fab_url.as_ref());
                     }),

--- a/ui-crates/ui_fab_search/src/item_detail/license_section.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/license_section.rs
@@ -1,30 +1,32 @@
 use gpui::{prelude::*, *};
 use ui::{
     button::{Button, ButtonVariants as _},
-    divider::Divider,
     h_flex, v_flex,
-    ActiveTheme, Sizable as _, StyledExt,
+    ActiveTheme, Icon, IconName, Sizable as _, StyledExt,
 };
 
-/// One purchasable license tier.
-pub struct LicenseEntry {
-    pub name: SharedString,
-    /// Formatted price string e.g. "USD49.99" or "Free".
-    pub price: SharedString,
-    /// The Fab offer/purchase URL if available.
-    pub purchase_url: Option<SharedString>,
-}
-
-/// Displays all available licenses for an asset with their price and a buy button.
+/// Displays the Sketchfab model license with an optional link to the viewer.
 #[derive(IntoElement)]
 pub struct LicenseSection {
-    pub licenses: Vec<LicenseEntry>,
-    pub is_free: bool,
+    /// Human-readable license label (e.g. "CC BY", "CC0 (Public Domain)").
+    pub license_label: Option<SharedString>,
+    /// Whether the model is available for download.
+    pub is_downloadable: bool,
+    /// Sketchfab viewer URL for the model.
+    pub viewer_url: SharedString,
 }
 
 impl LicenseSection {
-    pub fn new(licenses: Vec<LicenseEntry>, is_free: bool) -> Self {
-        Self { licenses, is_free }
+    pub fn new(
+        license_label: Option<impl Into<SharedString>>,
+        is_downloadable: bool,
+        viewer_url: impl Into<SharedString>,
+    ) -> Self {
+        Self {
+            license_label: license_label.map(|l| l.into()),
+            is_downloadable,
+            viewer_url: viewer_url.into(),
+        }
     }
 }
 
@@ -34,6 +36,8 @@ impl RenderOnce for LicenseSection {
         let fg = cx.theme().foreground;
         let muted = cx.theme().muted_foreground;
         let success = cx.theme().success;
+        let viewer_url = self.viewer_url.clone();
+        let viewer_url2 = self.viewer_url.clone();
 
         v_flex()
             .w_full()
@@ -48,60 +52,61 @@ impl RenderOnce for LicenseSection {
                     .text_xs()
                     .font_bold()
                     .text_color(muted)
-
                     .child("Licensing"),
             )
-            // ── license rows ─────────────────────────────────────────────
-            .children(self.licenses.into_iter().enumerate().map(|(i, entry)| {
-                let url = entry.purchase_url.clone();
-                div()
+            // ── license row ──────────────────────────────────────────────
+            .child(
+                h_flex()
                     .w_full()
+                    .gap_3()
+                    .items_center()
+                    .justify_between()
                     .child(
-                        h_flex()
-                            .w_full()
-                            .gap_3()
-                            .items_center()
-                            .justify_between()
-                            .py_2()
-                            // tier name
+                        div()
+                            .text_sm()
+                            .font_semibold()
+                            .text_color(fg)
                             .child(
-                                div()
-                                    .text_sm()
-                                    .font_semibold()
-                                    .text_color(fg)
-                                    .child(entry.name),
-                            )
-                            // price badge + buy action
-                            .child(
-                                h_flex()
-                                    .gap_3()
-                                    .items_center()
-                                    // price
-                                    .child(
-                                        div()
-                                            .text_base()
-                                            .font_bold()
-                                            .text_color(if self.is_free { success } else { fg })
-                                            .child(entry.price),
-                                    )
-                                    // buy / view button
-                                    .when_some(url, |el, purchase_url| {
-                                        el.child(
-                                            Button::new(
-                                                SharedString::from(format!("buy-license-{}", i)),
-                                            )
-                                            .small()
-                                            .success()
-                                            .label(if self.is_free { "Get Free" } else { "Buy" })
-                                            .on_click(move |_ev, _win, cx| {
-                                                cx.open_url(purchase_url.as_ref());
-                                            }),
-                                        )
-                                    }),
+                                self.license_label
+                                    .unwrap_or_else(|| SharedString::from("Unknown License")),
                             ),
                     )
-                    // subtle separator between rows (except last)
-                    .child(Divider::horizontal().color(border))
-            }))
+                    .child(
+                        h_flex()
+                            .gap_3()
+                            .items_center()
+                            .when(self.is_downloadable, |el| {
+                                el.child(
+                                    div()
+                                        .text_sm()
+                                        .font_bold()
+                                        .text_color(success)
+                                        .child("Free Download"),
+                                )
+                                .child(
+                                    Button::new("view-on-sketchfab-dl")
+                                        .small()
+                                        .success()
+                                        .icon(Icon::new(IconName::ExternalLink).small())
+                                        .label("Download")
+                                        .on_click(move |_ev, _win, cx| {
+                                            cx.open_url(viewer_url.as_ref());
+                                        }),
+                                )
+                            })
+                            .when(!self.is_downloadable, |el| {
+                                el.child(
+                                    Button::new("view-on-sketchfab")
+                                        .small()
+                                        .ghost()
+                                        .icon(Icon::new(IconName::ExternalLink).small())
+                                        .label("View on Sketchfab")
+                                        .on_click(move |_ev, _win, cx| {
+                                            cx.open_url(viewer_url2.as_ref());
+                                        }),
+                                )
+                            }),
+                    ),
+            )
     }
 }

--- a/ui-crates/ui_fab_search/src/item_detail/meta_bar.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/meta_bar.rs
@@ -2,28 +2,21 @@ use std::sync::Arc;
 use gpui::{prelude::*, *};
 use ui::{
     avatar::Avatar,
-    divider::Divider,
     h_flex, v_flex,
-    ActiveTheme, Icon, IconName, Sizable as _, Size, StyledExt,
+    ActiveTheme, Sizable, Size, StyledExt,
 };
 
-/// Rating data shown in the meta bar.
-pub struct RatingInfo {
-    pub average: f64,
-    pub total: i32,
-    pub review_count: Option<i32>,
-    /// Individual bucket counts (5-star down to 1-star).
-    pub buckets: [i32; 5],
-}
+use crate::parser::fmt_count;
 
-/// Metadata bar: seller avatar, name, category, star rating, and review count.
+/// Metadata bar: seller avatar, name, category, views, likes, and publish date.
 #[derive(IntoElement)]
 pub struct MetaBar {
     pub seller_name: SharedString,
     /// Pre-decoded avatar image; `None` while downloading or if unavailable.
     pub seller_avatar: Option<Arc<gpui::RenderImage>>,
     pub category: Option<SharedString>,
-    pub rating: Option<RatingInfo>,
+    pub view_count: i64,
+    pub like_count: i64,
     pub published_at: Option<SharedString>,
 }
 
@@ -32,30 +25,19 @@ impl MetaBar {
         seller_name: impl Into<SharedString>,
         seller_avatar: Option<Arc<gpui::RenderImage>>,
         category: Option<impl Into<SharedString>>,
-        rating: Option<RatingInfo>,
+        view_count: i64,
+        like_count: i64,
         published_at: Option<impl Into<SharedString>>,
     ) -> Self {
         Self {
             seller_name: seller_name.into(),
             seller_avatar,
             category: category.map(|c| c.into()),
-            rating,
+            view_count,
+            like_count,
             published_at: published_at.map(|d| d.into()),
         }
     }
-}
-
-/// Render one filled star, half-star, or empty star.
-fn star_icon(filled: bool) -> impl IntoElement {
-    Icon::new(if filled { IconName::Star } else { IconName::Star })
-        .small()
-        .map(move |i| {
-            if filled {
-                i.text_color(gpui::rgb(0xFACC15))   // amber-400
-            } else {
-                i.text_color(gpui::rgb(0x6B7280))   // gray-500
-            }
-        })
 }
 
 impl RenderOnce for MetaBar {
@@ -71,7 +53,7 @@ impl RenderOnce for MetaBar {
             .gap_3()
             .border_b_1()
             .border_color(border)
-            // ── seller row ───────────────────────────────────────────────
+            // ── author row ───────────────────────────────────────────────
             .child(
                 h_flex()
                     .gap_3()
@@ -80,7 +62,7 @@ impl RenderOnce for MetaBar {
                         Avatar::new()
                             .with_size(Size::Medium)
                             .name(self.seller_name.clone())
-                            .map(|av| {
+                            .map(|av: Avatar| {
                                 if let Some(arc) = self.seller_avatar {
                                     av.src(gpui::ImageSource::Render(arc))
                                 } else {
@@ -108,49 +90,26 @@ impl RenderOnce for MetaBar {
                             }),
                     ),
             )
-            // ── ratings row ─────────────────────────────────────────────
-            .when_some(self.rating, |el, r| {
-                let avg = r.average.round() as usize;
-                el.child(
-                    h_flex()
-                        .gap_2()
-                        .items_center()
-                        // five stars
-                        .children((1usize..=5).map(|s| star_icon(s <= avg)))
-                        // numeric average
-                        .child(
-                            div()
-                                .text_sm()
-                                .font_bold()
-                                .text_color(fg)
-                                .child(format!("{:.1}", r.average)),
+            // ── stats row ────────────────────────────────────────────────
+            .child(
+                h_flex()
+                    .gap_4()
+                    .items_center()
+                    .child(
+                        div().text_sm().text_color(muted)
+                            .child(format!("👁 {} views", fmt_count(self.view_count))),
+                    )
+                    .child(
+                        div().text_sm().text_color(muted)
+                            .child(format!("♥ {} likes", fmt_count(self.like_count))),
+                    )
+                    .when_some(self.published_at, |el, date| {
+                        el.child(
+                            div().text_sm().text_color(muted)
+                                .child(format!("Published {}", &date[..date.len().min(10)])),
                         )
-                        // total rating count
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(muted)
-                                .child(format!("({} ratings)", r.total)),
-                        )
-                        .when_some(r.review_count, |e, n| {
-                            e.child(Divider::vertical().h(px(12.0)).color(muted))
-                             .child(
-                                div()
-                                    .text_xs()
-                                    .text_color(muted)
-                                    .child(format!("{} reviews", n)),
-                             )
-                        }),
-                )
-            })
-            // ── published date ──────────────────────────────────────────
-            .when_some(self.published_at, |el, date| {
-                el.child(
-                    div()
-                        .text_xs()
-                        .text_color(muted)
-                        .child(format!("Published {}", &date[..date.len().min(10)])),
-                )
-            })
+                    }),
+            )
     }
 }
+

--- a/ui-crates/ui_fab_search/src/item_detail/mod.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/mod.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use gpui::{prelude::*, *};
-use ui::{v_flex, ActiveTheme};
+use ui::{v_flex, ActiveTheme, scroll::{Scrollbar, ScrollbarState}};
 
 use crate::parser::{strip_html, FabItemDetail};
 
@@ -31,6 +31,8 @@ pub struct ItemDetailView {
     detail: Box<FabItemDetail>,
     /// Pre-decoded images ready for synchronous rendering, keyed by their original download URL.
     images: HashMap<String, Arc<gpui::RenderImage>>,
+    scroll_handle: ScrollHandle,
+    scroll_state: ScrollbarState,
     on_back: Box<dyn Fn(&mut Window, &mut App) + 'static>,
 }
 
@@ -38,11 +40,15 @@ impl ItemDetailView {
     pub fn new(
         detail: Box<FabItemDetail>,
         images: HashMap<String, Arc<gpui::RenderImage>>,
+        scroll_handle: ScrollHandle,
+        scroll_state: ScrollbarState,
         on_back: impl Fn(&mut Window, &mut App) + 'static,
     ) -> Self {
         Self {
             detail,
             images,
+            scroll_handle,
+            scroll_state,
             on_back: Box::new(on_back),
         }
     }
@@ -197,6 +203,7 @@ impl RenderOnce for ItemDetailView {
         div()
             .id("item-detail-root")
             .flex_1()
+            .min_h_0()
             .flex()
             .flex_col()
             .overflow_hidden()
@@ -207,8 +214,11 @@ impl RenderOnce for ItemDetailView {
             .child(
                 div()
                     .id("item-detail-scroll")
+                    .relative()
                     .flex_1()
+                    .min_h_0()
                     .overflow_y_scroll()
+                    .track_scroll(&self.scroll_handle)
                     .child(
                         v_flex()
                             .w_full()
@@ -218,6 +228,12 @@ impl RenderOnce for ItemDetailView {
                             .when(show_format_tags, |el| el.child(format_tags))
                             .when(show_desc, |el| el.child(description))
                             .when(show_changelog, |el| el.child(changelog)),
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .inset_0()
+                            .child(Scrollbar::vertical(&self.scroll_state, &self.scroll_handle)),
                     ),
             )
     }

--- a/ui-crates/ui_fab_search/src/item_detail/mod.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/mod.rs
@@ -10,9 +10,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use gpui::{prelude::*, *};
-use ui::{v_flex, ActiveTheme, scroll::{Scrollbar, ScrollbarState}};
+use ui::{v_flex, h_flex, ActiveTheme, scroll::{Scrollbar, ScrollbarState}, button::Button};
 
 use crate::parser::{strip_html, SketchfabModelDetail};
+use crate::DownloadState;
 
 use changelog::ModelStatsSection;
 use description::DescriptionSection;
@@ -33,6 +34,10 @@ pub struct ItemDetailView {
     gallery_scroll_handle: ScrollHandle,
     gallery_scroll_state: ScrollbarState,
     on_back: Box<dyn Fn(&mut Window, &mut App) + 'static>,
+    /// Present when user is authenticated and the model is downloadable.
+    on_download: Option<Box<dyn Fn(&mut Window, &mut App) + 'static>>,
+    /// Current download state, if any.
+    download_status: Option<DownloadState>,
 }
 
 impl ItemDetailView {
@@ -53,7 +58,19 @@ impl ItemDetailView {
             gallery_scroll_handle,
             gallery_scroll_state,
             on_back: Box::new(on_back),
+            on_download: None,
+            download_status: None,
         }
+    }
+
+    pub(crate) fn with_download(
+        mut self,
+        on_download: impl Fn(&mut Window, &mut App) + 'static,
+        status: Option<DownloadState>,
+    ) -> Self {
+        self.on_download = Some(Box::new(on_download));
+        self.download_status = status;
+        self
     }
 }
 
@@ -61,6 +78,8 @@ impl RenderOnce for ItemDetailView {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let d = self.detail;
         let images = self.images;
+        let on_download = self.on_download;
+        let download_status = self.download_status;
 
         // ── URL ─────────────────────────────────────────────────────────────
         let viewer_url = SharedString::from(d.viewer_url.clone());
@@ -190,6 +209,60 @@ impl RenderOnce for ItemDetailView {
                                 v_flex()
                                     .w_full()
                                     .child(meta)
+                                    .map(|el| {
+                                        let muted_fg = cx.theme().muted_foreground;
+                                        let green: gpui::Hsla = gpui::rgb(0x22C55E).into();
+                                        if let Some(dl_fn) = on_download {
+                                            el.child(
+                                                h_flex().px_4().py_3().gap_3().items_center()
+                                                    .border_b_1().border_color(cx.theme().border)
+                                                    .map(|row| match &download_status {
+                                                        Some(crate::DownloadState::InProgress {
+                                                            bytes_received,
+                                                            total_bytes,
+                                                            speed_bps,
+                                                            ..
+                                                        }) => {
+                                                            let prog = total_bytes
+                                                                .filter(|&t| t > 0)
+                                                                .map(|t| format!("{:.0}%", *bytes_received as f64 / t as f64 * 100.0))
+                                                                .unwrap_or_else(|| format!("{} KB", bytes_received / 1024));
+                                                            let speed_label = if *speed_bps > 0.0 {
+                                                                format!(" · {}", ui::fmt_speed(*speed_bps))
+                                                            } else { String::new() };
+                                                            row.child(div().text_sm().text_color(muted_fg)
+                                                                .child(format!("Downloading… {}{}", prog, speed_label)))
+                                                        }
+                                                        Some(crate::DownloadState::Done { path, .. }) => {
+                                                            let file_path = path.clone();
+                                                            row
+                                                                .child(div().text_sm().text_color(green)
+                                                                    .child("Downloaded ✓"))
+                                                                .child(Button::new("open-folder")
+                                                                    .label("📂 Open Folder")
+                                                                    .on_click(move |_, _, _cx| {
+                                                                        ui::reveal_in_file_manager(&file_path);
+                                                                    }))
+                                                        }
+                                                        Some(crate::DownloadState::Error { message, .. }) => {
+                                                            let msg = message.clone();
+                                                            row.child(div().text_sm().text_color(gpui::red())
+                                                                .child(format!("Error: {}", msg)))
+                                                                .child(Button::new("retry-dl")
+                                                                    .label("Retry")
+                                                                    .on_click(move |_, window, cx| { (dl_fn)(window, cx); }))
+                                                        }
+                                                        None => {
+                                                            row.child(Button::new("download-gltf")
+                                                                .label("↓ Download glTF")
+                                                                .on_click(move |_, window, cx| { (dl_fn)(window, cx); }))
+                                                        }
+                                                    })
+                                            )
+                                        } else {
+                                            el
+                                        }
+                                    })
                                     .when(show_gallery, |el| el.child(gallery))
                                     .when(show_license, |el| el.child(license_sec))
                                     .when(show_format_tags, |el| el.child(format_tags))

--- a/ui-crates/ui_fab_search/src/item_detail/mod.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/mod.rs
@@ -33,6 +33,8 @@ pub struct ItemDetailView {
     images: HashMap<String, Arc<gpui::RenderImage>>,
     scroll_handle: ScrollHandle,
     scroll_state: ScrollbarState,
+    gallery_scroll_handle: ScrollHandle,
+    gallery_scroll_state: ScrollbarState,
     on_back: Box<dyn Fn(&mut Window, &mut App) + 'static>,
 }
 
@@ -42,6 +44,8 @@ impl ItemDetailView {
         images: HashMap<String, Arc<gpui::RenderImage>>,
         scroll_handle: ScrollHandle,
         scroll_state: ScrollbarState,
+        gallery_scroll_handle: ScrollHandle,
+        gallery_scroll_state: ScrollbarState,
         on_back: impl Fn(&mut Window, &mut App) + 'static,
     ) -> Self {
         Self {
@@ -49,6 +53,8 @@ impl ItemDetailView {
             images,
             scroll_handle,
             scroll_state,
+            gallery_scroll_handle,
+            gallery_scroll_state,
             on_back: Box::new(on_back),
         }
     }
@@ -122,7 +128,7 @@ impl RenderOnce for ItemDetailView {
             .collect();
 
         let show_gallery = !gallery_images.is_empty();
-        let gallery = GalleryStrip::new(gallery_images);
+        let gallery = GalleryStrip::new(gallery_images, self.gallery_scroll_handle.clone(), self.gallery_scroll_state.clone());
 
         // ── licenses ────────────────────────────────────────────────────────
         let is_free = d.is_free;
@@ -213,21 +219,26 @@ impl RenderOnce for ItemDetailView {
             // scrollable body
             .child(
                 div()
-                    .id("item-detail-scroll")
                     .relative()
                     .flex_1()
                     .min_h_0()
-                    .overflow_y_scroll()
-                    .track_scroll(&self.scroll_handle)
+                    .overflow_hidden()
                     .child(
-                        v_flex()
-                            .w_full()
-                            .child(meta)
-                            .when(show_gallery, |el| el.child(gallery))
-                            .when(show_licenses, |el| el.child(license_sec))
-                            .when(show_format_tags, |el| el.child(format_tags))
-                            .when(show_desc, |el| el.child(description))
-                            .when(show_changelog, |el| el.child(changelog)),
+                        div()
+                            .id("item-detail-scroll")
+                            .size_full()
+                            .overflow_y_scroll()
+                            .track_scroll(&self.scroll_handle)
+                            .child(
+                                v_flex()
+                                    .w_full()
+                                    .child(meta)
+                                    .when(show_gallery, |el| el.child(gallery))
+                                    .when(show_licenses, |el| el.child(license_sec))
+                                    .when(show_format_tags, |el| el.child(format_tags))
+                                    .when(show_desc, |el| el.child(description))
+                                    .when(show_changelog, |el| el.child(changelog)),
+                            )
                     )
                     .child(
                         div()

--- a/ui-crates/ui_fab_search/src/item_detail/mod.rs
+++ b/ui-crates/ui_fab_search/src/item_detail/mod.rs
@@ -12,23 +12,20 @@ use std::sync::Arc;
 use gpui::{prelude::*, *};
 use ui::{v_flex, ActiveTheme, scroll::{Scrollbar, ScrollbarState}};
 
-use crate::parser::{strip_html, FabItemDetail};
+use crate::parser::{strip_html, SketchfabModelDetail};
 
-use changelog::{ChangelogEntry, ChangelogSection};
+use changelog::ModelStatsSection;
 use description::DescriptionSection;
 use format_tags::FormatTagsSection;
 use gallery::{GalleryImage, GalleryStrip};
 use header::DetailHeader;
-use license_section::{LicenseEntry, LicenseSection};
-use meta_bar::{MetaBar, RatingInfo};
+use license_section::LicenseSection;
+use meta_bar::MetaBar;
 
 /// Full item detail page — scrollable column of rich sections.
-///
-/// Constructs all sub-components from the raw [`FabItemDetail`] payload and
-/// renders them in a polished, vertically-scrollable view.
 #[derive(IntoElement)]
 pub struct ItemDetailView {
-    detail: Box<FabItemDetail>,
+    detail: Box<SketchfabModelDetail>,
     /// Pre-decoded images ready for synchronous rendering, keyed by their original download URL.
     images: HashMap<String, Arc<gpui::RenderImage>>,
     scroll_handle: ScrollHandle,
@@ -40,7 +37,7 @@ pub struct ItemDetailView {
 
 impl ItemDetailView {
     pub fn new(
-        detail: Box<FabItemDetail>,
+        detail: Box<SketchfabModelDetail>,
         images: HashMap<String, Arc<gpui::RenderImage>>,
         scroll_handle: ScrollHandle,
         scroll_state: ScrollbarState,
@@ -66,116 +63,78 @@ impl RenderOnce for ItemDetailView {
         let images = self.images;
 
         // ── URL ─────────────────────────────────────────────────────────────
-        let fab_url = SharedString::from(format!("https://www.fab.com/listings/{}", d.uid));
+        let viewer_url = SharedString::from(d.viewer_url.clone());
 
         // ── header ──────────────────────────────────────────────────────────
-        let header = DetailHeader::new(d.title.clone(), fab_url, self.on_back);
+        let header = DetailHeader::new(d.name.clone(), viewer_url.clone(), self.on_back);
 
         // ── meta bar ────────────────────────────────────────────────────────
-        let rating = d.ratings.as_ref().map(|r| RatingInfo {
-            average: r.average_rating,
-            total: r.total,
-            review_count: d.review_count,
-            buckets: [
-                r.rating5.unwrap_or(0),
-                r.rating4.unwrap_or(0),
-                r.rating3.unwrap_or(0),
-                r.rating2.unwrap_or(0),
-                r.rating1.unwrap_or(0),
-            ],
-        });
+        let seller_name: SharedString = d.user.as_ref()
+            .map(|u| SharedString::from(u.display().to_string()))
+            .unwrap_or_default();
 
-        let seller_avatar = d.user.profile_image_url.as_deref()
+        let seller_avatar: Option<Arc<gpui::RenderImage>> = d.user.as_ref()
+            .and_then(|u| u.avatar_url(128))
             .and_then(|url| images.get(url))
             .cloned();
 
+        let category = d.categories.first()
+            .map(|c| SharedString::from(c.name.clone()));
+
         let meta = MetaBar::new(
-            d.user.seller_name.clone(),
+            seller_name,
             seller_avatar,
-            d.category.as_ref().map(|c| c.name.clone()),
-            rating,
+            category,
+            d.view_count,
+            d.like_count,
             d.published_at.clone(),
         );
 
         // ── gallery ─────────────────────────────────────────────────────────
         let gallery_images: Vec<GalleryImage> = d
-            .medias
-            .iter()
-            .filter(|m| m.media_type == "image" || m.media_type.is_empty())
-            .take(12)
-            .map(|m| {
-                // Prefer the largest thumbnail image URL, fall back to media_url
-                let url = m
-                    .images
-                    .iter()
-                    .max_by_key(|i| i.width)
-                    .map(|i| i.url.as_str())
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or(m.media_url.as_str())
-                    .to_string();
-                let (w, h) = m
-                    .images
-                    .first()
-                    .map(|i| (i.width, i.height))
-                    .unwrap_or((1280, 720));
-                GalleryImage {
-                    url: SharedString::from(url.clone()),
-                    width: w,
-                    height: h,
-                    image: images.get(&url).cloned(),
-                }
+            .all_thumbnail_urls()
+            .into_iter()
+            .take(8)
+            .map(|url| GalleryImage {
+                url: SharedString::from(url.to_string()),
+                width: 1920,
+                height: 1080,
+                image: images.get(url).cloned(),
             })
             .collect();
 
         let show_gallery = !gallery_images.is_empty();
-        let gallery = GalleryStrip::new(gallery_images, self.gallery_scroll_handle.clone(), self.gallery_scroll_state.clone());
+        let gallery = GalleryStrip::new(
+            gallery_images,
+            self.gallery_scroll_handle.clone(),
+            self.gallery_scroll_state.clone(),
+        );
 
-        // ── licenses ────────────────────────────────────────────────────────
-        let is_free = d.is_free;
-        let license_entries: Vec<LicenseEntry> = d
-            .licenses
-            .iter()
-            .map(|l| {
-                let price = if is_free {
-                    SharedString::from("Free")
-                } else if let Some(ref pt) = l.price_tier {
-                    let effective = pt.discounted_price.unwrap_or(pt.price);
-                    SharedString::from(format!("{} {:.2}", pt.currency_code, effective))
-                } else {
-                    SharedString::from("—")
-                };
-
-                let purchase_url = l.slug.as_ref().map(|slug| {
-                    SharedString::from(format!("https://www.fab.com/listings/{}", slug))
-                });
-
-                LicenseEntry {
-                    name: SharedString::from(l.name.clone()),
-                    price,
-                    purchase_url,
-                }
-            })
-            .collect();
-
-        let show_licenses = !license_entries.is_empty();
-        let license_sec = LicenseSection::new(license_entries, is_free);
+        // ── license ─────────────────────────────────────────────────────────
+        let license_label: Option<SharedString> = d.license_label().map(SharedString::from);
+        let show_license = license_label.is_some();
+        let license_sec = LicenseSection::new(license_label, d.is_downloadable, viewer_url);
 
         // ── format tags ─────────────────────────────────────────────────────
-        let formats: Vec<(String, String)> = d
-            .asset_formats
-            .iter()
-            .map(|f| {
-                (
-                    f.asset_format_type.code.clone(),
-                    f.asset_format_type.name.clone(),
-                )
+        let formats: Vec<(String, String)> = d.archives.as_ref()
+            .map(|a| {
+                a.available()
+                    .into_iter()
+                    .map(|(lbl, arc)| {
+                        let size_str = arc.size_label().unwrap_or_default();
+                        let display = if size_str.is_empty() {
+                            lbl.to_string()
+                        } else {
+                            format!("{} ({})", lbl, size_str)
+                        };
+                        (lbl.to_string(), display)
+                    })
+                    .collect()
             })
-            .collect();
+            .unwrap_or_default();
 
-        let tags: Vec<SharedString> = d
-            .tags
-            .iter()
-            .map(|t| SharedString::from(t.name.clone()))
+        let tags: Vec<SharedString> = d.tags.iter()
+            .map(|t| SharedString::from(t.slug.clone()))
             .collect();
 
         let show_format_tags = !formats.is_empty() || !tags.is_empty();
@@ -187,21 +146,19 @@ impl RenderOnce for ItemDetailView {
         let show_desc = !desc_text.is_empty();
         let description = DescriptionSection::new(SharedString::from(desc_text));
 
-        // ── changelog ───────────────────────────────────────────────────────
-        let changelog_entries: Vec<ChangelogEntry> = d
-            .changelogs
-            .iter()
-            .rev()
-            .map(|c| ChangelogEntry {
-                date: SharedString::from(
-                    c.published_at.get(..10).unwrap_or("").to_string(),
-                ),
-                content: SharedString::from(strip_html(&c.content)),
-            })
-            .collect();
-
-        let show_changelog = !changelog_entries.is_empty();
-        let changelog = ChangelogSection::new(changelog_entries);
+        // ── model stats ──────────────────────────────────────────────────────
+        let stats = ModelStatsSection::new(
+            d.view_count,
+            d.like_count,
+            d.download_count,
+            d.face_count,
+            d.vertex_count,
+            d.material_count,
+            d.texture_count,
+            d.animation_count,
+            d.sound_count,
+            d.pbr_type.clone(),
+        );
 
         // ── assemble ────────────────────────────────────────────────────────
         let bg = cx.theme().background;
@@ -234,11 +191,11 @@ impl RenderOnce for ItemDetailView {
                                     .w_full()
                                     .child(meta)
                                     .when(show_gallery, |el| el.child(gallery))
-                                    .when(show_licenses, |el| el.child(license_sec))
+                                    .when(show_license, |el| el.child(license_sec))
                                     .when(show_format_tags, |el| el.child(format_tags))
                                     .when(show_desc, |el| el.child(description))
-                                    .when(show_changelog, |el| el.child(changelog)),
-                            )
+                                    .child(stats),
+                            ),
                     )
                     .child(
                         div()
@@ -249,3 +206,4 @@ impl RenderOnce for ItemDetailView {
             )
     }
 }
+

--- a/ui-crates/ui_fab_search/src/lib.rs
+++ b/ui-crates/ui_fab_search/src/lib.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use gpui::{ prelude::*, * };
 use ui::{
     ActiveTheme,
+    Root,
     Sizable,
     TitleBar,
     v_flex,
@@ -49,6 +50,8 @@ pub struct FabSearchWindow {
     results_scroll_state: ScrollbarState,
     detail_scroll_handle: ScrollHandle,
     detail_scroll_state: ScrollbarState,
+    gallery_scroll_handle: ScrollHandle,
+    gallery_scroll_state: ScrollbarState,
 }
 
 impl FabSearchWindow {
@@ -85,6 +88,8 @@ impl FabSearchWindow {
             results_scroll_state: ScrollbarState::default(),
             detail_scroll_handle: ScrollHandle::new(),
             detail_scroll_state: ScrollbarState::default(),
+            gallery_scroll_handle: ScrollHandle::new(),
+            gallery_scroll_state: ScrollbarState::default(),
         }
     }
 
@@ -470,7 +475,7 @@ impl Focusable for FabSearchWindow {
 }
 
 impl Render for FabSearchWindow {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let current_input = self.search_input.read(cx).value().to_string();
         if current_input != self.search_query {
             self.search_query = current_input;
@@ -506,23 +511,28 @@ impl Render for FabSearchWindow {
             )
             .child(
                 div()
-                    .id("log-scroll")
                     .relative()
                     .flex_1()
                     .min_h_0()
-                    .overflow_y_scroll()
-                    .track_scroll(&self.log_scroll_handle)
-                    .p_2()
+                    .overflow_hidden()
                     .child(
-                        v_flex()
-                            .gap_1()
-                            .children(self.request_log.iter().rev().map(|entry| {
-                                div()
-                                    .text_xs()
-                                    .text_color(muted_fg)
-                                    .font_family("monospace")
-                                    .child(entry.clone())
-                            }))
+                        div()
+                            .id("log-scroll")
+                            .size_full()
+                            .overflow_y_scroll()
+                            .track_scroll(&self.log_scroll_handle)
+                            .p_2()
+                            .child(
+                                v_flex()
+                                    .gap_1()
+                                    .children(self.request_log.iter().rev().map(|entry| {
+                                        div()
+                                            .text_xs()
+                                            .text_color(muted_fg)
+                                            .font_family("monospace")
+                                            .child(entry.clone())
+                                    }))
+                            )
                     )
                     .child(
                         div()
@@ -627,6 +637,8 @@ impl Render for FabSearchWindow {
                     loaded_images,
                     self.detail_scroll_handle.clone(),
                     self.detail_scroll_state.clone(),
+                    self.gallery_scroll_handle.clone(),
+                    self.gallery_scroll_state.clone(),
                     move |_window, cx| {
                         entity.update(cx, |this, cx| this.go_back(cx));
                     },
@@ -800,19 +812,24 @@ impl Render for FabSearchWindow {
             }).collect();
 
             div()
-                .id("results-scroll")
                 .relative()
                 .flex_1()
                 .min_h_0()
-                .overflow_y_scroll()
-                .track_scroll(&self.results_scroll_handle)
-                .p_4()
+                .overflow_hidden()
                 .child(
                     div()
-                        .flex()
-                        .flex_wrap()
-                        .gap_4()
-                        .children(cards)
+                        .id("results-scroll")
+                        .size_full()
+                        .overflow_y_scroll()
+                        .track_scroll(&self.results_scroll_handle)
+                        .p_4()
+                        .child(
+                            div()
+                                .flex()
+                                .flex_wrap()
+                                .gap_4()
+                                .children(cards)
+                        )
                 )
                 .child(
                     div()
@@ -824,7 +841,7 @@ impl Render for FabSearchWindow {
         };
 
         // ── root layout ────────────────────────────────────────────────────
-        v_flex()
+        let layout = v_flex()
             .size_full()
             .bg(bg)
             .child(TitleBar::new().child("Fab Search"))
@@ -872,6 +889,13 @@ impl Render for FabSearchWindow {
                     .flex_row()
                     .child(log_panel)
                     .child(body)
-            )
+            );
+
+        let modal_layer = Root::render_modal_layer(window, cx);
+
+        div()
+            .size_full()
+            .child(layout)
+            .children(modal_layer)
     }
 }

--- a/ui-crates/ui_fab_search/src/lib.rs
+++ b/ui-crates/ui_fab_search/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod image_loader;
 pub mod item_detail;
 pub mod parser;
+pub mod auth;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -14,15 +16,60 @@ use ui::{
     TitleBar,
     v_flex,
     h_flex,
-    button::{Button, ButtonVariants as _},
+    button::Button,
     input::{InputState, TextInput},
     scroll::{Scrollbar, ScrollbarState},
     skeleton::Skeleton,
+    spinner::Spinner,
+    Sizable,
     v_virtual_list, VirtualListScrollHandle,
     IconName,
     StyledExt,
+    download_item::DownloadItemStatus,
+    download_manager::{DownloadEntry, DownloadManagerDrawer},
 };
-use parser::{fmt_count, SketchfabModel, SketchfabModelDetail};
+use parser::{fmt_count, SketchfabModel, SketchfabModelDetail, SketchfabDownloadInfo, SketchfabMe};
+
+// ── Download state ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub(crate) enum DownloadState {
+    InProgress {
+        filename: String,
+        bytes_received: u64,
+        total_bytes: Option<u64>,
+        /// Transfer rate samples in bytes/s (oldest → newest, capped at 60).
+        speed_history: Vec<f64>,
+        /// Most recent sample (bytes/s) — kept separately for quick access.
+        speed_bps: f64,
+    },
+    Done {
+        filename: String,
+        path: PathBuf,
+        total_bytes: u64,
+    },
+    Error {
+        filename: String,
+        message: String,
+    },
+}
+
+impl DownloadState {
+    pub(crate) fn filename(&self) -> &str {
+        match self {
+            DownloadState::InProgress { filename, .. } => filename,
+            DownloadState::Done { filename, .. } => filename,
+            DownloadState::Error { filename, .. } => filename,
+        }
+    }
+}
+
+/// Progress messages streamed from the download thread back to the UI.
+enum DownloadMsg {
+    Progress { bytes_received: u64, total: Option<u64>, speed_bps: f64 },
+    Done { path: PathBuf, total: u64 },
+    Error(String),
+}
 
 // ── Sort options ─────────────────────────────────────────────────────────────
 
@@ -142,9 +189,27 @@ pub struct FabSearchWindow {
 
     // image cache: None = in-flight, Some(arc) = ready
     image_cache: HashMap<String, Option<std::sync::Arc<gpui::RenderImage>>>,
+    // concurrency cap for image downloads
+    image_inflight: usize,
+    image_queue: std::collections::VecDeque<String>,
 
     // entity ref (needed for v_virtual_list)
     entity: Option<Entity<Self>>,
+
+    // ── Auth ─────────────────────────────────────────────────────────────
+    api_token: Option<String>,
+    me: Option<Box<SketchfabMe>>,
+    me_loading: bool,
+    show_token_input: bool,
+    token_input: Entity<InputState>,
+
+    // ── Downloads ────────────────────────────────────────────────────────
+    download_state: HashMap<String, DownloadState>,
+    show_download_manager: bool,
+
+    // ── Likes ────────────────────────────────────────────────────────────
+    liked_uids: HashSet<String>,
+    like_inflight: HashSet<String>,
 
     // scrollbars
 
@@ -162,12 +227,17 @@ impl FabSearchWindow {
         let search_input = cx.new(|cx| {
             InputState::new(_window, cx).placeholder("Search Sketchfab models…")
         });
+        let token_input = cx.new(|cx| {
+            InputState::new(_window, cx).placeholder("Paste your Sketchfab API token…")
+        });
 
         cx.subscribe(&search_input, |this, _input, event: &ui::input::InputEvent, cx| {
             if let ui::input::InputEvent::PressEnter { .. } = event {
                 this.begin_search(cx);
             }
         }).detach();
+
+        let saved_token = auth::load_saved_token();
 
         let mut this = Self {
             focus_handle,
@@ -191,7 +261,20 @@ impl FabSearchWindow {
             detail_loading: false,
             detail_error: None,
             image_cache: HashMap::new(),
+            image_inflight: 0,
+            image_queue: std::collections::VecDeque::new(),
             entity: None,
+
+            api_token: saved_token.clone(),
+            me: None,
+            me_loading: false,
+            show_token_input: false,
+            token_input,
+
+            download_state: HashMap::new(),
+            show_download_manager: false,
+            liked_uids: HashSet::new(),
+            like_inflight: HashSet::new(),
 
             results_scroll_handle: VirtualListScrollHandle::new(),
             results_scroll_state: ScrollbarState::default(),
@@ -203,6 +286,10 @@ impl FabSearchWindow {
         // Store self-entity reference so v_virtual_list can capture it
         let entity = cx.entity();
         this.entity = Some(entity);
+        // If we have a saved token, verify it immediately
+        if saved_token.is_some() {
+            this.fetch_me(cx);
+        }
         this
     }
 
@@ -214,12 +301,294 @@ impl FabSearchWindow {
         cx.notify();
     }
 
+    // ── Auth methods ─────────────────────────────────────────────────────────
+
+    fn set_token(&mut self, token: String, cx: &mut Context<Self>) {
+        let token = token.trim().to_string();
+        if token.is_empty() { return; }
+        auth::save_token(&token);
+        self.api_token = Some(token);
+        self.me = None;
+        self.show_token_input = false;
+        self.fetch_me(cx);
+    }
+
+    fn clear_token(&mut self, cx: &mut Context<Self>) {
+        auth::delete_token();
+        self.api_token = None;
+        self.me = None;
+        self.me_loading = false;
+        self.liked_uids.clear();
+        self.like_inflight.clear();
+        cx.notify();
+    }
+
+    fn fetch_me(&mut self, cx: &mut Context<Self>) {
+        let token = match &self.api_token {
+            Some(t) => t.clone(),
+            None => return,
+        };
+        self.me_loading = true;
+        cx.notify();
+
+        let (tx, rx) = smol::channel::bounded::<Result<Box<SketchfabMe>, String>>(1);
+        std::thread::spawn(move || {
+            smol::block_on(tx.send(fetch_sketchfab_me(&token))).ok();
+        });
+
+        cx.spawn(async move |this, cx| {
+            if let Ok(result) = rx.recv().await {
+                cx.update(|cx| {
+                    this.update(cx, |view, cx| {
+                        view.me_loading = false;
+                        match result {
+                            Ok(me) => {
+                                // Pre-load avatar image
+                                if let Some(url) = me.avatar_url(64).map(|s| s.to_string()) {
+                                    view.ensure_image_loaded(url, cx);
+                                }
+                                view.me = Some(me);
+                            }
+                            Err(_) => {
+                                // Token is invalid; clear it
+                                view.api_token = None;
+                                auth::delete_token();
+                            }
+                        }
+                        cx.notify();
+                    }).ok();
+                }).ok();
+            }
+        }).detach();
+    }
+
+    // ── Download methods ─────────────────────────────────────────────────────
+
+    fn start_download(&mut self, uid: String, cx: &mut Context<Self>) {
+        // Don't restart an in-progress download.
+        if matches!(self.download_state.get(&uid), Some(DownloadState::InProgress { .. })) {
+            return;
+        }
+        let token = match &self.api_token {
+            Some(t) => t.clone(),
+            None => return,
+        };
+
+        let filename = format!("{}.zip", uid);
+        self.download_state.insert(
+            uid.clone(),
+            DownloadState::InProgress {
+                filename: filename.clone(),
+                bytes_received: 0,
+                total_bytes: None,
+                speed_history: Vec::new(),
+                speed_bps: 0.0,
+            },
+        );
+        cx.notify();
+
+        let (tx, rx) = smol::channel::unbounded::<DownloadMsg>();
+        let uid_thread = uid.clone();
+        let filename_thread = filename.clone();
+
+        std::thread::spawn(move || {
+            let run = || -> Result<(), String> {
+                // 1. Resolve download URL
+                let info = fetch_sketchfab_download_info(&uid_thread, &token)?;
+                let fmt = info
+                    .gltf
+                    .or(info.glb)
+                    .or(info.source)
+                    .ok_or_else(|| "No downloadable format available".to_string())?;
+
+                // 2. Prepare destination
+                let dest_dir = dirs::download_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join("Sketchfab");
+                std::fs::create_dir_all(&dest_dir).map_err(|e| format!("mkdir: {e}"))?;
+                let dest = dest_dir.join(&filename_thread);
+
+                // 3. Stream download, reporting progress every 500ms
+                let client = reqwest::blocking::Client::builder()
+                    .timeout(std::time::Duration::from_secs(600))
+                    .user_agent("Pulsar-Native/1.0")
+                    .build()
+                    .map_err(|e| e.to_string())?;
+
+                let resp = client.get(&fmt.url).send().map_err(|e| e.to_string())?;
+                let status = resp.status();
+                if !status.is_success() {
+                    return Err(format!("HTTP {} downloading file", status));
+                }
+                let total = resp.content_length();
+
+                let mut file = std::fs::File::create(&dest).map_err(|e| format!("create: {e}"))?;
+                let mut bytes_total: u64 = 0;
+                let mut last_sample = std::time::Instant::now();
+                let mut bytes_since_sample: u64 = 0;
+                let mut buf = vec![0u8; 64 * 1024]; // 64 KiB chunks
+                let mut reader = std::io::BufReader::new(resp);
+                use std::io::{Read, Write};
+
+                loop {
+                    let n = reader.read(&mut buf).map_err(|e| format!("read: {e}"))?;
+                    if n == 0 { break; }
+                    file.write_all(&buf[..n]).map_err(|e| format!("write: {e}"))?;
+                    bytes_total += n as u64;
+                    bytes_since_sample += n as u64;
+
+                    let elapsed = last_sample.elapsed();
+                    if elapsed >= std::time::Duration::from_millis(500) {
+                        let speed = bytes_since_sample as f64 / elapsed.as_secs_f64();
+                        smol::block_on(tx.send(DownloadMsg::Progress {
+                            bytes_received: bytes_total,
+                            total,
+                            speed_bps: speed,
+                        }))
+                        .ok();
+                        last_sample = std::time::Instant::now();
+                        bytes_since_sample = 0;
+                    }
+                }
+
+                file.flush().map_err(|e| format!("flush: {e}"))?;
+                smol::block_on(tx.send(DownloadMsg::Done { path: dest, total: bytes_total })).ok();
+                Ok(())
+            };
+
+            if let Err(e) = run() {
+                smol::block_on(tx.send(DownloadMsg::Error(e))).ok();
+            }
+        });
+
+        cx.spawn(async move |this, cx| {
+            while let Ok(msg) = rx.recv().await {
+                match msg {
+                    DownloadMsg::Progress { bytes_received, total, speed_bps } => {
+                        cx.update(|cx| {
+                            this.update(cx, |view, cx| {
+                                if let Some(DownloadState::InProgress {
+                                    bytes_received: br,
+                                    total_bytes: tb,
+                                    speed_bps: sb,
+                                    speed_history: sh,
+                                    ..
+                                }) = view.download_state.get_mut(&uid)
+                                {
+                                    *br = bytes_received;
+                                    *tb = total;
+                                    *sb = speed_bps;
+                                    sh.push(speed_bps);
+                                    if sh.len() > 60 { sh.remove(0); }
+                                }
+                                cx.notify();
+                            })
+                            .ok();
+                        })
+                        .ok();
+                    }
+                    DownloadMsg::Done { path, total } => {
+                        cx.update(|cx| {
+                            this.update(cx, |view, cx| {
+                                let filename = view
+                                    .download_state
+                                    .get(&uid)
+                                    .map(|s| s.filename().to_string())
+                                    .unwrap_or_default();
+                                view.download_state.insert(
+                                    uid.clone(),
+                                    DownloadState::Done { filename, path, total_bytes: total },
+                                );
+                                cx.notify();
+                            })
+                            .ok();
+                        })
+                        .ok();
+                        break;
+                    }
+                    DownloadMsg::Error(msg) => {
+                        cx.update(|cx| {
+                            this.update(cx, |view, cx| {
+                                let filename = view
+                                    .download_state
+                                    .get(&uid)
+                                    .map(|s| s.filename().to_string())
+                                    .unwrap_or_default();
+                                view.download_state.insert(
+                                    uid.clone(),
+                                    DownloadState::Error { filename, message: msg },
+                                );
+                                cx.notify();
+                            })
+                            .ok();
+                        })
+                        .ok();
+                        break;
+                    }
+                }
+            }
+        })
+        .detach();
+    }
+
+    // ── Like methods ─────────────────────────────────────────────────────────
+
+    #[allow(dead_code)]
+    fn is_liked(&self, uid: &str) -> bool { self.liked_uids.contains(uid) }
+
+    fn toggle_like(&mut self, uid: String, cx: &mut Context<Self>) {
+        let token = match &self.api_token {
+            Some(t) => t.clone(),
+            None => return,
+        };
+        if self.like_inflight.contains(&uid) { return; }
+        let currently_liked = self.liked_uids.contains(&uid);
+        // Optimistic update
+        if currently_liked { self.liked_uids.remove(&uid); } else { self.liked_uids.insert(uid.clone()); }
+        self.like_inflight.insert(uid.clone());
+        cx.notify();
+
+        let (tx, rx) = smol::channel::bounded::<Result<(), String>>(1);
+        let uid_thread = uid.clone();
+        std::thread::spawn(move || {
+            let result = if currently_liked {
+                sketchfab_unlike_model(&uid_thread, &token)
+            } else {
+                sketchfab_like_model(&uid_thread, &token)
+            };
+            smol::block_on(tx.send(result)).ok();
+        });
+
+        cx.spawn(async move |this, cx| {
+            if let Ok(result) = rx.recv().await {
+                cx.update(|cx| {
+                    this.update(cx, |view, cx| {
+                        view.like_inflight.remove(&uid);
+                        if let Err(_) = result {
+                            // Revert optimistic update on error
+                            if currently_liked { view.liked_uids.insert(uid); } else { view.liked_uids.remove(&uid); }
+                        }
+                        cx.notify();
+                    }).ok();
+                }).ok();
+            }
+        }).detach();
+    }
+
     fn ensure_image_loaded(&mut self, url: String, cx: &mut Context<Self>) {
         if url.is_empty() || self.image_cache.contains_key(&url) {
             return;
         }
         self.image_cache.insert(url.clone(), None);
+        if self.image_inflight < 20 {
+            self.start_image_fetch(url, cx);
+        } else {
+            self.image_queue.push_back(url);
+        }
+    }
 
+    fn start_image_fetch(&mut self, url: String, cx: &mut Context<Self>) {
+        self.image_inflight += 1;
         let (tx, rx) = smol::channel::bounded::<Option<std::sync::Arc<gpui::RenderImage>>>(1);
         let url_thread = url.clone();
         std::thread::spawn(move || {
@@ -232,6 +601,10 @@ impl FabSearchWindow {
                 cx.update(|cx| {
                     this.update(cx, |view, cx| {
                         view.image_cache.insert(url, maybe);
+                        view.image_inflight -= 1;
+                        if let Some(next_url) = view.image_queue.pop_front() {
+                            view.start_image_fetch(next_url, cx);
+                        }
                         cx.notify();
                     }).ok();
                 }).ok();
@@ -395,6 +768,7 @@ struct SearchPage {
     next: Option<String>,
 }
 
+#[allow(dead_code)]
 enum CacheValue {
     Page { models: Vec<SketchfabModel>, next: Option<String> },
     Detail(Box<SketchfabModelDetail>),
@@ -530,6 +904,74 @@ fn fetch_sketchfab_model_detail(uid: &str) -> (Vec<String>, Result<Box<Sketchfab
     (log, result)
 }
 
+// ── Auth / download / like fetch functions ───────────────────────────────────
+
+fn make_auth_client(token: &str) -> Result<reqwest::blocking::Client, String> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    let auth_value = reqwest::header::HeaderValue::from_str(&format!("Token {}", token))
+        .map_err(|e| format!("invalid token: {e}"))?;
+    headers.insert(reqwest::header::AUTHORIZATION, auth_value);
+    reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .user_agent("Pulsar-Native/1.0")
+        .default_headers(headers)
+        .build()
+        .map_err(|e| e.to_string())
+}
+
+fn fetch_sketchfab_me(token: &str) -> Result<Box<SketchfabMe>, String> {
+    let client = make_auth_client(token)?;
+    let resp = client.get("https://api.sketchfab.com/v3/me")
+        .send().map_err(|e| e.to_string())?;
+    let status = resp.status();
+    let text = resp.text().map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(format!("HTTP {} — {}", status, &text[..text.len().min(120)]));
+    }
+    serde_json::from_str::<SketchfabMe>(&text)
+        .map(Box::new)
+        .map_err(|e| format!("parse /me: {e}"))
+}
+
+fn fetch_sketchfab_download_info(uid: &str, token: &str) -> Result<SketchfabDownloadInfo, String> {
+    let client = make_auth_client(token)?;
+    let url = format!("https://api.sketchfab.com/v3/models/{}/download", uid);
+    let resp = client.get(&url).send().map_err(|e| e.to_string())?;
+    let status = resp.status();
+    let text = resp.text().map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(format!("HTTP {} — {}", status, &text[..text.len().min(200)]));
+    }
+    serde_json::from_str::<SketchfabDownloadInfo>(&text)
+        .map_err(|e| format!("parse download info: {e}"))
+}
+
+fn sketchfab_like_model(uid: &str, token: &str) -> Result<(), String> {
+    let client = make_auth_client(token)?;
+    let params = [("model", uid)];
+    let resp = client.post("https://api.sketchfab.com/v3/me/likes")
+        .form(&params)
+        .send().map_err(|e| e.to_string())?;
+    let status = resp.status();
+    if !status.is_success() && status.as_u16() != 204 {
+        let text = resp.text().unwrap_or_default();
+        return Err(format!("HTTP {} — {}", status, &text[..text.len().min(120)]));
+    }
+    Ok(())
+}
+
+fn sketchfab_unlike_model(uid: &str, token: &str) -> Result<(), String> {
+    let client = make_auth_client(token)?;
+    let url = format!("https://api.sketchfab.com/v3/me/likes/{}", uid);
+    let resp = client.delete(&url).send().map_err(|e| e.to_string())?;
+    let status = resp.status();
+    if !status.is_success() && status.as_u16() != 204 {
+        let text = resp.text().unwrap_or_default();
+        return Err(format!("HTTP {} — {}", status, &text[..text.len().min(120)]));
+    }
+    Ok(())
+}
+
 // ── Focusable + Render ───────────────────────────────────────────────────────
 
 impl Focusable for FabSearchWindow {
@@ -542,7 +984,7 @@ impl Render for FabSearchWindow {
         if current_input != self.search_query { self.search_query = current_input; }
 
         let bg         = cx.theme().background;
-        let card_bg    = cx.theme().sidebar;
+        let _card_bg   = cx.theme().sidebar;
         let border_col = cx.theme().border;
         let fg         = cx.theme().foreground;
         let muted_fg   = cx.theme().muted_foreground;
@@ -610,7 +1052,24 @@ impl Render for FabSearchWindow {
                     self.gallery_scroll_handle.clone(),
                     self.gallery_scroll_state.clone(),
                     move |_window, cx| { entity.update(cx, |this, cx| this.go_back(cx)); },
-                ).into_any_element()
+                )
+                .map(|view| {
+                    // Attach download callback if user is logged in and model is downloadable
+                    if detail.is_downloadable && self.api_token.is_some() {
+                        let uid = detail.uid.clone();
+                        let dl_status = self.download_state.get(&uid).cloned();
+                        let entity2 = cx.entity().clone();
+                        view.with_download(
+                            move |_window, cx| {
+                                entity2.update(cx, |this, cx| this.start_download(uid.clone(), cx));
+                            },
+                            dl_status,
+                        )
+                    } else {
+                        view
+                    }
+                })
+                .into_any_element()
 
             } else {
                 div().flex_1().min_h_0().flex().items_center().justify_center()
@@ -626,13 +1085,23 @@ impl Render for FabSearchWindow {
 
         } else {
             // ── Virtual results grid ──────────────────────────────────────
-            const COLS: usize = 3;
+            // Card dimensions and spacing (must match the rendered card)
+            const CARD_W: f32 = 260.0;
             const CARD_H: f32 = 260.0; // thumb(146) + body(114)
-            const ROW_H: f32 = CARD_H + 16.0; // + row gap
+            const GAP:    f32 = 16.0;  // gap_4
+            const PAD:    f32 = 16.0;  // px_4 padding on each side
+            const ROW_H:  f32 = CARD_H + GAP;
+
+            // Derive column count from available viewport width.
+            // Formula: cols = floor((avail_w - PAD + GAP) / (CARD_W + GAP))
+            // where avail_w = total_w - 2*PAD (removes left+right padding).
+            let avail_w: f32 = window.viewport_size().width.into();
+            let avail_w = avail_w - 2.0 * PAD;
+            let cols: usize = (((avail_w + GAP) / (CARD_W + GAP)).floor() as usize).max(1);
 
             let entity = self.entity.clone().unwrap();
             let total_results = self.results.len();
-            let result_rows = total_results.div_ceil(COLS);
+            let result_rows = total_results.div_ceil(cols);
             let skel_rows: usize = if self.is_loading_more { 2 } else { 0 };
             let end_row: usize = if !self.is_loading_more && self.next_url.is_none() { 1 } else { 0 };
             let total_items = result_rows + skel_rows + end_row;
@@ -655,7 +1124,7 @@ impl Render for FabSearchWindow {
                             let border_col = theme.border;
 
                             let total_res = view.results.len();
-                            let res_rows = total_res.div_ceil(COLS);
+                            let res_rows = total_res.div_ceil(cols);
                             let s_rows: usize = if view.is_loading_more { 2 } else { 0 };
 
                             // Near-bottom detection: kick off load_more when
@@ -670,8 +1139,8 @@ impl Render for FabSearchWindow {
                             range.map(|row_idx| -> AnyElement {
                                 if row_idx < res_rows {
                                     // ── Real card row ─────────────────────
-                                    let start = row_idx * COLS;
-                                    let end = (start + COLS).min(view.results.len());
+                                    let start = row_idx * cols;
+                                    let end = (start + cols).min(view.results.len());
                                     let row_cards: Vec<AnyElement> = (start..end).map(|idx| {
                                         let model = &view.results[idx];
                                         let name     = model.name.clone();
@@ -684,9 +1153,17 @@ impl Render for FabSearchWindow {
                                         let is_anim  = model.animation_count > 0;
                                         let is_sp    = model.staffpicked_at.as_ref().map(|v| !v.is_null()).unwrap_or(false);
                                         let card_uid = model.uid.clone();
-                                        let thumb_arc = model.thumb_url(260)
-                                            .and_then(|u| view.image_cache.get(u))
-                                            .and_then(|o| o.clone());
+                                        let like_uid = card_uid.clone();
+                                        let is_liked  = view.liked_uids.contains(&card_uid);
+                                        let like_busy = view.like_inflight.contains(&card_uid);
+                                        let show_like = view.api_token.is_some();
+                                        let thumb_state = model.thumb_url(260)
+                                            .map(|u| view.image_cache.get(u).and_then(|o| o.clone()));
+                                        // None          = no URL
+                                        // Some(None)    = in-flight
+                                        // Some(Some(…)) = loaded
+                                        let thumb_loading = matches!(thumb_state, None | Some(None));
+                                        let thumb_arc = thumb_state.flatten();
 
                                         div()
                                             .id(SharedString::from(format!("skfb-card-{}", idx)))
@@ -703,9 +1180,12 @@ impl Render for FabSearchWindow {
                                                         if let Some(arc) = thumb_arc {
                                                             el.child(img(gpui::ImageSource::Render(arc))
                                                                 .w_full().h_full().object_fit(gpui::ObjectFit::Cover))
-                                                        } else {
+                                                        } else if thumb_loading {
                                                             el.bg(border_col).flex().items_center().justify_center()
-                                                                .child(div().text_xs().text_color(muted_fg).child(""))
+                                                                .child(Spinner::new().with_size(ui::Size::Medium)
+                                                                    .color(muted_fg))
+                                                        } else {
+                                                            el.bg(border_col)
                                                         }
                                                     })
                                                     .when(is_sp, |el| el.child(
@@ -736,6 +1216,20 @@ impl Render for FabSearchWindow {
                                                 .child(h_flex().gap_3().items_center().mt_1()
                                                     .child(div().text_xs().text_color(muted_fg).child(format!("👁 {}", views)))
                                                     .child(div().text_xs().text_color(muted_fg).child(format!("♥ {}", likes)))
+                                                    .when(show_like, |el| el.child(
+                                                        div()
+                                                            .id(SharedString::from(format!("like-{}", idx)))
+                                                            .ml_auto()
+                                                            .cursor_pointer()
+                                                            .text_sm()
+                                                            .text_color(if is_liked { gpui::Hsla::from(gpui::rgb(0xEF4444)) } else { muted_fg })
+                                                            .opacity(if like_busy { 0.4 } else { 1.0 })
+                                                            .child(if is_liked { "♥" } else { "♡" })
+                                                            .on_click(cx.listener(move |this, _event, _, cx| {
+                                                                cx.stop_propagation();
+                                                                this.toggle_like(like_uid.clone(), cx);
+                                                            }))
+                                                    ))
                                                 )
                                             ))
                                             .into_any_element()
@@ -748,7 +1242,7 @@ impl Render for FabSearchWindow {
                                 } else if row_idx < res_rows + s_rows {
                                     // ── Skeleton row ──────────────────────
                                     h_flex().px_4().py(px(8.0)).gap_4().items_start()
-                                        .children((0..COLS).map(|i| {
+                                        .children((0..cols).map(|i| {
                                             div()
                                                 .id(SharedString::from(format!("skel-{}-{}", row_idx, i)))
                                                 .w(px(260.0)).rounded_lg()
@@ -870,7 +1364,124 @@ impl Render for FabSearchWindow {
                     }))
             })));
 
+        // ── Auth bar ──────────────────────────────────────────────────────
+        let logged_in   = self.api_token.is_some();
+        let me_name     = self.me.as_ref().map(|m| m.display().to_string());
+        let me_avatar   = self.me.as_ref()
+            .and_then(|m| m.avatar_url(64).map(|s| s.to_string()))
+            .and_then(|url| self.image_cache.get(&url).and_then(|o| o.clone()));
+        let me_loading  = self.me_loading;
+        let show_tok    = self.show_token_input;
+        let account_tier = self.me.as_ref().and_then(|m| m.account.clone());
+
+        let auth_section: AnyElement = if me_loading {
+            div().text_xs().text_color(muted_fg).child("Verifying…").into_any_element()
+        } else if logged_in {
+            h_flex().gap_2().items_center()
+                .map(|el| {
+                    if let Some(arc) = me_avatar {
+                        el.child(img(gpui::ImageSource::Render(arc))
+                            .w_6().h_6().rounded_full().overflow_hidden())
+                    } else {
+                        el.child(div().w_6().h_6().rounded_full().bg(border_col))
+                    }
+                })
+                .when_some(me_name, |el, name| {
+                    el.child(div().text_xs().font_medium().text_color(fg).child(name))
+                })
+                .when_some(account_tier, |el, tier| {
+                    el.child(div().text_xs().px_2().py(px(2.0)).rounded_full()
+                        .bg(gpui::rgb(0x6366F1)).text_color(gpui::rgb(0xFFFFFF))
+                        .child(tier))
+                })
+                .child(Button::new("logout-btn").label("Logout")
+                    .on_click(cx.listener(|this, _, _, cx| this.clear_token(cx))))
+                .into_any_element()
+        } else if show_tok {
+            h_flex().gap_2().items_center()
+                .child(div().w(px(300.0))
+                    .child(TextInput::new(&self.token_input).w_full()))
+                .child(Button::new("verify-tok").label("Verify & Save")
+                    .on_click(cx.listener(|this, _, _window, cx| {
+                        let tok = this.token_input.read(cx).value().to_string();
+                        this.set_token(tok, cx);
+                    })))
+                .child(Button::new("cancel-tok").label("Cancel")
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.show_token_input = false;
+                        cx.notify();
+                    })))
+                .child(div().text_xs().text_color(muted_fg)
+                    .child("Get your token at sketchfab.com/settings/password"))
+                .into_any_element()
+        } else {
+            Button::new("login-btn").label("Login with API Token")
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.show_token_input = true;
+                    cx.notify();
+                }))
+                .into_any_element()
+        };
+
         // ── Root ──────────────────────────────────────────────────────────
+        let dl_count = self.download_state.len();
+        let active_dl = self.download_state.values()
+            .filter(|s| matches!(s, DownloadState::InProgress { .. }))
+            .count();
+        let show_dl_btn = dl_count > 0;
+        let show_dl_mgr = self.show_download_manager;
+
+        // Build download manager entries for the drawer
+        let dl_entries: Vec<DownloadEntry> = self.download_state.iter().map(|(uid, state)| {
+            match state {
+                DownloadState::InProgress { filename, bytes_received, total_bytes, speed_bps, speed_history } => {
+                    let progress_pct = total_bytes
+                        .filter(|&t| t > 0)
+                        .map(|t| (*bytes_received as f32 / t as f32 * 100.0).min(100.0))
+                        .unwrap_or(0.0);
+                    DownloadEntry {
+                        uid: SharedString::from(uid.clone()),
+                        filename: SharedString::from(filename.clone()),
+                        progress_pct,
+                        speed_bps: *speed_bps,
+                        speed_history: speed_history.clone(),
+                        status: DownloadItemStatus::InProgress,
+                        bytes_received: *bytes_received,
+                        total_bytes: *total_bytes,
+                        path: None,
+                    }
+                }
+                DownloadState::Done { filename, path, total_bytes } => {
+                    DownloadEntry {
+                        uid: SharedString::from(uid.clone()),
+                        filename: SharedString::from(filename.clone()),
+                        progress_pct: 100.0,
+                        speed_bps: 0.0,
+                        speed_history: Vec::new(),
+                        status: DownloadItemStatus::Done,
+                        bytes_received: *total_bytes,
+                        total_bytes: Some(*total_bytes),
+                        path: Some(path.clone()),
+                    }
+                }
+                DownloadState::Error { filename, message } => {
+                    DownloadEntry {
+                        uid: SharedString::from(uid.clone()),
+                        filename: SharedString::from(filename.clone()),
+                        progress_pct: 0.0,
+                        speed_bps: 0.0,
+                        speed_history: Vec::new(),
+                        status: DownloadItemStatus::Error(message.clone()),
+                        bytes_received: 0,
+                        total_bytes: None,
+                        path: None,
+                    }
+                }
+            }
+        }).collect();
+
+        let entity_for_drawer = cx.entity().clone();
+
         let layout = v_flex()
             .size_full().bg(bg)
             .child(TitleBar::new().child("Sketchfab"))
@@ -885,6 +1496,22 @@ impl Render for FabSearchWindow {
                         .child(Button::new("search-btn")
                             .label("Search")
                             .on_click(cx.listener(|this, _, _, cx| this.begin_search(cx))))
+                        .child(div().w(px(1.0)).h(px(20.0)).bg(border_col))
+                        .child(auth_section)
+                        .when(show_dl_btn, |el| {
+                            let dl_label = if active_dl > 0 {
+                                format!("↓ {} active", active_dl)
+                            } else {
+                                format!("↓ {} done", dl_count)
+                            };
+                            el.child(div().w(px(1.0)).h(px(20.0)).bg(border_col))
+                              .child(Button::new("dl-mgr-btn")
+                                .label(dl_label)
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.show_download_manager = !this.show_download_manager;
+                                    cx.notify();
+                                })))
+                        })
                     )
             )
             .child(filter_bar)
@@ -892,6 +1519,17 @@ impl Render for FabSearchWindow {
 
         div().size_full()
             .child(layout)
+            .when(show_dl_mgr, |el| {
+                el.child(
+                    DownloadManagerDrawer::new(dl_entries)
+                        .on_close(move |_, _, cx| {
+                            entity_for_drawer.update(cx, |view, cx| {
+                                view.show_download_manager = false;
+                                cx.notify();
+                            });
+                        }),
+                )
+            })
             .children(Root::render_modal_layer(window, cx))
     }
 }

--- a/ui-crates/ui_fab_search/src/lib.rs
+++ b/ui-crates/ui_fab_search/src/lib.rs
@@ -15,6 +15,7 @@ use ui::{
     h_flex,
     button::Button,
     input::{ InputState, TextInput },
+    scroll::{Scrollbar, ScrollbarState},
     IconName,
     StyledExt,
 };
@@ -32,6 +33,7 @@ pub struct FabSearchWindow {
     error: Option<String>,
     /// Last URL fetched — used for the "Open in Browser" fallback button.
     last_url: Option<String>,
+
     // ── item detail state ──────────────────────────────────────────────────
     selected_item_uid: Option<String>,
     item_detail: Option<Box<FabItemDetail>>,
@@ -40,6 +42,13 @@ pub struct FabSearchWindow {
     // ── image cache ────────────────────────────────────────────────────────
     /// None = download in progress; Some(path) = file sitting in disk cache.
     image_cache: HashMap<String, Option<std::sync::Arc<gpui::RenderImage>>>,
+    // ── scrollbars ─────────────────────────────────────────────────────────
+    log_scroll_handle: ScrollHandle,
+    log_scroll_state: ScrollbarState,
+    results_scroll_handle: ScrollHandle,
+    results_scroll_state: ScrollbarState,
+    detail_scroll_handle: ScrollHandle,
+    detail_scroll_state: ScrollbarState,
 }
 
 impl FabSearchWindow {
@@ -70,6 +79,12 @@ impl FabSearchWindow {
             detail_loading: false,
             detail_error: None,
             image_cache: HashMap::new(),
+            log_scroll_handle: ScrollHandle::new(),
+            log_scroll_state: ScrollbarState::default(),
+            results_scroll_handle: ScrollHandle::new(),
+            results_scroll_state: ScrollbarState::default(),
+            detail_scroll_handle: ScrollHandle::new(),
+            detail_scroll_state: ScrollbarState::default(),
         }
     }
 
@@ -473,7 +488,7 @@ impl Render for FabSearchWindow {
         let log_panel = div()
             .w(px(260.0))
             .flex_shrink_0()
-            .h_full()
+            .min_h_0()
             .border_r_1()
             .border_color(border_col)
             .flex()
@@ -492,8 +507,11 @@ impl Render for FabSearchWindow {
             .child(
                 div()
                     .id("log-scroll")
+                    .relative()
                     .flex_1()
+                    .min_h_0()
                     .overflow_y_scroll()
+                    .track_scroll(&self.log_scroll_handle)
                     .p_2()
                     .child(
                         v_flex()
@@ -505,6 +523,12 @@ impl Render for FabSearchWindow {
                                     .font_family("monospace")
                                     .child(entry.clone())
                             }))
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .inset_0()
+                            .child(Scrollbar::vertical(&self.log_scroll_state, &self.log_scroll_handle))
                     )
             );
 
@@ -523,6 +547,7 @@ impl Render for FabSearchWindow {
 
             div()
                 .flex_1()
+                .min_h_0()
                 .flex()
                 .flex_col()
                 .items_center()
@@ -545,7 +570,7 @@ impl Render for FabSearchWindow {
             // ── item detail view ──────────────────────────────────────────────
             if self.detail_loading {
                 div()
-                    .flex_1()
+                    .flex_1()                    .min_h_0()                    .min_h_0()
                     .flex()
                     .items_center()
                     .justify_center()
@@ -555,6 +580,7 @@ impl Render for FabSearchWindow {
                 let err_text = err.clone();
                 div()
                     .flex_1()
+                    .min_h_0()
                     .flex()
                     .flex_col()
                     .items_center()
@@ -599,6 +625,8 @@ impl Render for FabSearchWindow {
                 item_detail::ItemDetailView::new(
                     detail.clone(),
                     loaded_images,
+                    self.detail_scroll_handle.clone(),
+                    self.detail_scroll_state.clone(),
                     move |_window, cx| {
                         entity.update(cx, |this, cx| this.go_back(cx));
                     },
@@ -608,6 +636,7 @@ impl Render for FabSearchWindow {
                 // selected but no detail yet (shouldn't happen, but guard)
                 div()
                     .flex_1()
+                    .min_h_0()
                     .flex()
                     .items_center()
                     .justify_center()
@@ -617,6 +646,7 @@ impl Render for FabSearchWindow {
         } else if self.results.is_empty() {
             div()
                 .flex_1()
+                .min_h_0()
                 .flex()
                 .items_center()
                 .justify_center()
@@ -771,8 +801,11 @@ impl Render for FabSearchWindow {
 
             div()
                 .id("results-scroll")
+                .relative()
                 .flex_1()
+                .min_h_0()
                 .overflow_y_scroll()
+                .track_scroll(&self.results_scroll_handle)
                 .p_4()
                 .child(
                     div()
@@ -780,6 +813,12 @@ impl Render for FabSearchWindow {
                         .flex_wrap()
                         .gap_4()
                         .children(cards)
+                )
+                .child(
+                    div()
+                        .absolute()
+                        .inset_0()
+                        .child(Scrollbar::vertical(&self.results_scroll_state, &self.results_scroll_handle))
                 )
                 .into_any_element()
         };
@@ -828,6 +867,7 @@ impl Render for FabSearchWindow {
             .child(
                 div()
                     .flex_1()
+                    .min_h_0()
                     .flex()
                     .flex_row()
                     .child(log_panel)

--- a/ui-crates/ui_fab_search/src/lib.rs
+++ b/ui-crates/ui_fab_search/src/lib.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use gpui::{ prelude::*, * };
+use gpui::{prelude::*, *};
 use ui::{
     ActiveTheme,
     Root,
@@ -14,36 +14,134 @@ use ui::{
     TitleBar,
     v_flex,
     h_flex,
-    button::Button,
-    input::{ InputState, TextInput },
+    button::{Button, ButtonVariants as _},
+    input::{InputState, TextInput},
     scroll::{Scrollbar, ScrollbarState},
     IconName,
     StyledExt,
 };
-use parser::{FabItemDetail, FabListing};
+use parser::{fmt_count, SketchfabModel, SketchfabModelDetail};
 
-/// Simple window that lets the user search the Fab asset store
+// ── Sort options ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum SortBy {
+    Relevance,
+    MostViewed,
+    MostLiked,
+    Newest,
+    Oldest,
+}
+
+impl SortBy {
+    fn api_value(&self) -> Option<&'static str> {
+        match self {
+            SortBy::Relevance  => None,
+            SortBy::MostViewed => Some("-viewCount"),
+            SortBy::MostLiked  => Some("-likeCount"),
+            SortBy::Newest     => Some("-publishedAt"),
+            SortBy::Oldest     => Some("publishedAt"),
+        }
+    }
+    fn label(&self) -> &'static str {
+        match self {
+            SortBy::Relevance  => "Relevance",
+            SortBy::MostViewed => "Most Viewed",
+            SortBy::MostLiked  => "Most Liked",
+            SortBy::Newest     => "Newest",
+            SortBy::Oldest     => "Oldest",
+        }
+    }
+    fn all() -> [SortBy; 5] {
+        [SortBy::Relevance, SortBy::MostViewed, SortBy::MostLiked, SortBy::Newest, SortBy::Oldest]
+    }
+}
+
+// ── License filter ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum LicenseFilter {
+    All,
+    CC0,
+    CcBy,
+    CcBySa,
+    CcByNd,
+    CcByNc,
+    CcByNcSa,
+    CcByNcNd,
+    Standard,
+    Editorial,
+}
+
+impl LicenseFilter {
+    fn api_value(&self) -> Option<&'static str> {
+        match self {
+            LicenseFilter::All      => None,
+            LicenseFilter::CC0      => Some("cc0"),
+            LicenseFilter::CcBy     => Some("by"),
+            LicenseFilter::CcBySa   => Some("by-sa"),
+            LicenseFilter::CcByNd   => Some("by-nd"),
+            LicenseFilter::CcByNc   => Some("by-nc"),
+            LicenseFilter::CcByNcSa => Some("by-nc-sa"),
+            LicenseFilter::CcByNcNd => Some("by-nc-nd"),
+            LicenseFilter::Standard => Some("st"),
+            LicenseFilter::Editorial=> Some("ed"),
+        }
+    }
+    fn label(&self) -> &'static str {
+        match self {
+            LicenseFilter::All      => "All Licenses",
+            LicenseFilter::CC0      => "CC0",
+            LicenseFilter::CcBy     => "CC BY",
+            LicenseFilter::CcBySa   => "CC BY-SA",
+            LicenseFilter::CcByNd   => "CC BY-ND",
+            LicenseFilter::CcByNc   => "CC BY-NC",
+            LicenseFilter::CcByNcSa => "CC BY-NC-SA",
+            LicenseFilter::CcByNcNd => "CC BY-NC-ND",
+            LicenseFilter::Standard => "Standard",
+            LicenseFilter::Editorial=> "Editorial",
+        }
+    }
+    fn all() -> Vec<LicenseFilter> {
+        use LicenseFilter::*;
+        vec![All, CC0, CcBy, CcBySa, CcByNd, CcByNc, CcByNcSa, CcByNcNd, Standard, Editorial]
+    }
+}
+
+// ── Main window struct ───────────────────────────────────────────────────────
+
 pub struct FabSearchWindow {
     focus_handle: FocusHandle,
     search_query: String,
     search_input: Entity<InputState>,
-    filter_kind: Option<String>,
-    results: Vec<FabListing>,
+
+    // filters
+    sort_by: SortBy,
+    filter_downloadable: bool,
+    filter_animated: bool,
+    filter_staffpicked: bool,
+    filter_license: LicenseFilter,
+    show_license_menu: bool,
+
+    // results
+    results: Vec<SketchfabModel>,
+    next_url: Option<String>,
+    prev_url: Option<String>,
     request_log: Vec<String>,
     is_loading: bool,
     error: Option<String>,
-    /// Last URL fetched — used for the "Open in Browser" fallback button.
     last_url: Option<String>,
 
-    // ── item detail state ──────────────────────────────────────────────────
+    // item detail
     selected_item_uid: Option<String>,
-    item_detail: Option<Box<FabItemDetail>>,
+    item_detail: Option<Box<SketchfabModelDetail>>,
     detail_loading: bool,
     detail_error: Option<String>,
-    // ── image cache ────────────────────────────────────────────────────────
-    /// None = download in progress; Some(path) = file sitting in disk cache.
+
+    // image cache: None = in-flight, Some(arc) = ready
     image_cache: HashMap<String, Option<std::sync::Arc<gpui::RenderImage>>>,
-    // ── scrollbars ─────────────────────────────────────────────────────────
+
+    // scrollbars
     log_scroll_handle: ScrollHandle,
     log_scroll_state: ScrollbarState,
     results_scroll_handle: ScrollHandle,
@@ -58,12 +156,12 @@ impl FabSearchWindow {
     pub fn new(_window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
         let search_input = cx.new(|cx| {
-            InputState::new(_window, cx).placeholder("Search fab...")
+            InputState::new(_window, cx).placeholder("Search Sketchfab models…")
         });
 
         cx.subscribe(&search_input, |this, _input, event: &ui::input::InputEvent, cx| {
             if let ui::input::InputEvent::PressEnter { .. } = event {
-                this.perform_search(cx);
+                this.begin_search(None, cx);
             }
         }).detach();
 
@@ -71,8 +169,15 @@ impl FabSearchWindow {
             focus_handle,
             search_query: String::new(),
             search_input,
-            filter_kind: None,
+            sort_by: SortBy::Relevance,
+            filter_downloadable: false,
+            filter_animated: false,
+            filter_staffpicked: false,
+            filter_license: LicenseFilter::All,
+            show_license_menu: false,
             results: Vec::new(),
+            next_url: None,
+            prev_url: None,
             request_log: Vec::new(),
             is_loading: false,
             error: None,
@@ -101,20 +206,16 @@ impl FabSearchWindow {
         cx.notify();
     }
 
-    /// Kick off a background download for `url` if not already cached/loading.
-    /// Stores `None` immediately (= loading) then updates to `Some(arc)` once done.
     fn ensure_image_loaded(&mut self, url: String, cx: &mut Context<Self>) {
         if url.is_empty() || self.image_cache.contains_key(&url) {
             return;
         }
-        self.image_cache.insert(url.clone(), None); // mark as in-flight
+        self.image_cache.insert(url.clone(), None);
 
-        let (tx, rx) =
-            smol::channel::bounded::<Option<std::sync::Arc<gpui::RenderImage>>>(1);
-        let url_for_thread = url.clone();
-
+        let (tx, rx) = smol::channel::bounded::<Option<std::sync::Arc<gpui::RenderImage>>>(1);
+        let url_thread = url.clone();
         std::thread::spawn(move || {
-            let maybe = image_loader::fetch_and_decode(&url_for_thread).ok();
+            let maybe = image_loader::fetch_and_decode(&url_thread).ok();
             smol::block_on(tx.send(maybe)).ok();
         });
 
@@ -124,30 +225,26 @@ impl FabSearchWindow {
                     this.update(cx, |view, cx| {
                         view.image_cache.insert(url, maybe);
                         cx.notify();
-                    })
-                    .ok();
-                })
-                .ok();
+                    }).ok();
+                }).ok();
             }
-        })
-        .detach();
+        }).detach();
     }
 
     fn open_item_detail(&mut self, uid: String, cx: &mut Context<Self>) {
-        if self.selected_item_uid.as_deref() == Some(uid.as_str()) {
+        if self.selected_item_uid.as_deref() == Some(&uid) {
             return;
         }
         self.selected_item_uid = Some(uid.clone());
         self.item_detail = None;
         self.detail_loading = true;
         self.detail_error = None;
-        self.request_log.push(format!("GET /i/listings/{}", uid));
+        self.request_log.push(format!("GET /v3/models/{}", uid));
         cx.notify();
 
-        let (tx, rx) = smol::channel::bounded::<(Vec<String>, Result<Box<FabItemDetail>, String>)>(1);
+        let (tx, rx) = smol::channel::bounded::<(Vec<String>, Result<Box<SketchfabModelDetail>, String>)>(1);
         std::thread::spawn(move || {
-            let result = fetch_fab_item_detail(&uid);
-            smol::block_on(tx.send(result)).ok();
+            smol::block_on(tx.send(fetch_sketchfab_model_detail(&uid))).ok();
         });
 
         cx.spawn(async move |this, cx| {
@@ -158,27 +255,17 @@ impl FabSearchWindow {
                         view.request_log.extend(log_lines);
                         match result {
                             Ok(detail) => {
-                                view.request_log.push(format!("  ✓ detail: {}", detail.title));
-                                // kick off gallery image downloads
-                                let gallery_urls: Vec<String> = detail.medias.iter()
-                                    .filter(|m| m.media_type == "image" || m.media_type.is_empty())
-                                    .take(12)
-                                    .map(|m| {
-                                        m.images.iter()
-                                            .max_by_key(|i| i.width)
-                                            .map(|i| i.url.as_str())
-                                            .filter(|s: &&str| !s.is_empty())
-                                            .unwrap_or(m.media_url.as_str())
-                                            .to_string()
-                                    })
-                                    .collect();
-                                for url in gallery_urls {
+                                view.request_log.push(format!("  ✓ model: {}", detail.name));
+                                // preload all thumbnail sizes as gallery images
+                                let urls: Vec<String> = detail.all_thumbnail_urls()
+                                    .into_iter().take(8).map(|s| s.to_string()).collect();
+                                for url in urls {
                                     view.ensure_image_loaded(url, cx);
                                 }
-                                // seller avatar
-                                if let Some(ref avatar_url) = detail.user.profile_image_url {
-                                    if !avatar_url.is_empty() {
-                                        view.ensure_image_loaded(avatar_url.clone(), cx);
+                                // avatar
+                                if let Some(ref user) = detail.user {
+                                    if let Some(url) = user.avatar_url(128) {
+                                        view.ensure_image_loaded(url.to_string(), cx);
                                     }
                                 }
                                 view.item_detail = Some(detail);
@@ -195,31 +282,38 @@ impl FabSearchWindow {
         }).detach();
     }
 
-    fn perform_search(&mut self, cx: &mut Context<Self>) {
-        if self.search_query.trim().is_empty() {
-            return;
-        }
-
-        let query = self.search_query.clone();
-        let ltype = self.filter_kind.clone().unwrap_or_else(|| "3d-model".to_string());
-        let encoded = urlencoding::encode(&query).into_owned();
-        let url = format!(
-            "https://www.fab.com/i/listings/search?listing_types={}&sort_by=-relevance&q={}",
-            ltype, encoded
+    fn build_search_url(&self) -> String {
+        let q = urlencoding::encode(self.search_query.trim()).into_owned();
+        let mut url = format!(
+            "https://api.sketchfab.com/v3/search?type=models&q={}&count=24",
+            q
         );
+        if let Some(s) = self.sort_by.api_value()       { url.push_str(&format!("&sort_by={}", s)); }
+        if self.filter_downloadable                      { url.push_str("&downloadable=true"); }
+        if self.filter_animated                         { url.push_str("&animated=true"); }
+        if self.filter_staffpicked                      { url.push_str("&staffpicked=true"); }
+        if let Some(l) = self.filter_license.api_value() { url.push_str(&format!("&license={}", l)); }
+        url
+    }
 
+    fn begin_search(&mut self, override_url: Option<String>, cx: &mut Context<Self>) {
+        if self.search_query.trim().is_empty() { return; }
+
+        let url = override_url.clone().unwrap_or_else(|| self.build_search_url());
         self.is_loading = true;
         self.results.clear();
         self.error = None;
         self.last_url = Some(url.clone());
+        if override_url.is_none() {
+            self.next_url = None;
+            self.prev_url = None;
+        }
         self.request_log.push(format!("GET {}", url));
         cx.notify();
 
-        let fetch_url = url.clone();
-        let (tx, rx) = smol::channel::bounded::<(Vec<String>, Result<Vec<FabListing>, String>)>(1);
+        let (tx, rx) = smol::channel::bounded::<(Vec<String>, Result<SearchPage, String>)>(1);
         std::thread::spawn(move || {
-            let result = fetch_fab_listings(&fetch_url);
-            smol::block_on(tx.send(result)).ok();
+            smol::block_on(tx.send(fetch_sketchfab_models(&url))).ok();
         });
 
         cx.spawn(async move |this, cx| {
@@ -229,18 +323,13 @@ impl FabSearchWindow {
                         view.is_loading = false;
                         view.request_log.extend(log_lines);
                         match result {
-                            Ok(listings) => {
-                                view.request_log.push(
-                                    format!("  ✓ {} result(s)", listings.len())
-                                );
-                                view.results = listings;
-                                // kick off thumbnail downloads
+                            Ok(page) => {
+                                view.request_log.push(format!("  ✓ {} model(s)", page.models.len()));
+                                view.next_url = page.next;
+                                view.prev_url = page.prev;
+                                view.results = page.models;
                                 let thumb_urls: Vec<String> = view.results.iter()
-                                    .filter_map(|l| {
-                                        l.thumbnails.first()
-                                            .and_then(|t| t.best_image_url(260))
-                                            .map(|s| s.to_string())
-                                    })
+                                    .filter_map(|m| m.thumb_url(260).map(|s| s.to_string()))
                                     .collect();
                                 for url in thumb_urls {
                                     view.ensure_image_loaded(url, cx);
@@ -259,14 +348,20 @@ impl FabSearchWindow {
     }
 }
 
-// ── response cache ──────────────────────────────────────────────────────────
+// ── Cache ────────────────────────────────────────────────────────────────────
 
-const CACHE_CAP: usize = 20;
+const CACHE_CAP: usize = 30;
 const CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 
+struct SearchPage {
+    models: Vec<SketchfabModel>,
+    next: Option<String>,
+    prev: Option<String>,
+}
+
 enum CacheValue {
-    Listings(Vec<FabListing>),
-    Detail(Box<FabItemDetail>),
+    Page { models: Vec<SketchfabModel>, next: Option<String>, prev: Option<String> },
+    Detail(Box<SketchfabModelDetail>),
 }
 
 struct CacheEntry {
@@ -275,211 +370,140 @@ struct CacheEntry {
     inserted_at: Instant,
 }
 
-struct FabCache {
-    entries: VecDeque<CacheEntry>,
-}
+struct SearchCache { entries: VecDeque<CacheEntry> }
 
-impl FabCache {
-    fn new() -> Self {
-        Self { entries: VecDeque::with_capacity(CACHE_CAP) }
+impl SearchCache {
+    fn new() -> Self { Self { entries: VecDeque::with_capacity(CACHE_CAP) } }
+
+    fn evict(&mut self) {
+        self.entries.retain(|e| e.inserted_at.elapsed() < CACHE_TTL);
     }
 
-    fn get_listings(&mut self, key: &str) -> Option<Vec<FabListing>> {
-        self.find(key).and_then(|e| {
-            if let CacheValue::Listings(ref v) = e.value { Some(v.clone()) } else { None }
-        })
-    }
-
-    fn get_detail(&mut self, key: &str) -> Option<Box<FabItemDetail>> {
-        self.find(key).and_then(|e| {
-            if let CacheValue::Detail(ref v) = e.value { Some(v.clone()) } else { None }
+    fn get_detail(&mut self, key: &str) -> Option<Box<SketchfabModelDetail>> {
+        self.evict();
+        self.entries.iter().find(|e| e.key == key).and_then(|e| {
+            if let CacheValue::Detail(ref d) = e.value { Some(d.clone()) } else { None }
         })
     }
 
     fn insert(&mut self, key: String, value: CacheValue) {
-        // Remove existing entry for the same key
         self.entries.retain(|e| e.key != key);
-        // Evict oldest if at capacity
-        if self.entries.len() >= CACHE_CAP {
-            self.entries.pop_front();
-        }
+        if self.entries.len() >= CACHE_CAP { self.entries.pop_front(); }
         self.entries.push_back(CacheEntry { key, value, inserted_at: Instant::now() });
     }
-
-    fn find(&mut self, key: &str) -> Option<&CacheEntry> {
-        // Evict expired entries first
-        self.entries.retain(|e| e.inserted_at.elapsed() < CACHE_TTL);
-        self.entries.iter().find(|e| e.key == key)
-    }
 }
 
-fn global_cache() -> &'static Mutex<FabCache> {
-    static CACHE: OnceLock<Mutex<FabCache>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(FabCache::new()))
+fn global_cache() -> &'static Mutex<SearchCache> {
+    static CACHE: OnceLock<Mutex<SearchCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(SearchCache::new()))
 }
 
-// ── fetch helpers ────────────────────────────────────────────────────────────
+// ── Fetch ────────────────────────────────────────────────────────────────────
 
-/// Perform a request impersonating Chrome's full TLS fingerprint (JA3/JA4 + HTTP/2 settings)
-/// via rquest's BoringSSL backend.  Must be called from an OS thread, not a GPUI/smol task.
-/// Returns `(log_lines, result)` so the caller can push all logs into the UI panel.
-fn fetch_fab_listings(url: &str) -> (Vec<String>, Result<Vec<FabListing>, String>) {
-    use rquest::Impersonate;
-
-    let mut log: Vec<String> = Vec::new();
-    macro_rules! log {
-        ($($arg:tt)*) => {{
-            let s = format!($($arg)*);
-            println!("{}", s);
-            log.push(s);
-        }}
-    }
-
-    // Check cache first
-    if let Ok(mut cache) = global_cache().lock() {
-        if let Some(cached) = cache.get_listings(url) {
-            log!("cache hit: {}", url);
-            return (log, Ok(cached));
-        }
-    }
-
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(e) => return (log, Err(format!("tokio error: {}", e))),
+fn fetch_sketchfab_models(url: &str) -> (Vec<String>, Result<SearchPage, String>) {
+    let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+        Ok(r) => r, Err(e) => return (vec![], Err(format!("tokio: {}", e))),
     };
+    let url = url.to_string();
+    let (log, result) = rt.block_on(async move {
+        let mut log: Vec<String> = Vec::new();
+        macro_rules! logv { ($($t:tt)*) => {{ let s = format!($($t)*); println!("{}", s); log.push(s); }} }
 
-    let result = rt.block_on(async {
-        log!("→ GET {}", url);
-
-        let client = rquest::Client::builder()
-            .impersonate(Impersonate::Chrome131)
+        logv!("→ GET {}", url);
+        let client = match reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
+            .user_agent("Pulsar-Native/1.0")
             .build()
-            .map_err(|e| { log!("client build: {}", e); e.to_string() })?;
+        {
+            Ok(c) => c,
+            Err(e) => { logv!("build: {}", e); return (log, Err(e.to_string())); }
+        };
 
-        let response = client.get(url).send().await
-            .map_err(|e| { log!("request error: {}", e); e.to_string() })?;
-
-        let status = response.status();
-        log!("← HTTP {}", status);
-        for (k, v) in response.headers() {
-            log!("  {}: {}", k, v.to_str().unwrap_or("?"));
-        }
-
-        let text = response.text().await
-            .map_err(|e| { log!("body read error: {}", e); e.to_string() })?;
-
-        log!("body ({} bytes): {}…", text.len(), &text[..text.len().min(300)]);
-
+        let resp = match client.get(&url).send().await {
+            Ok(r) => r,
+            Err(e) => { logv!("request: {}", e); return (log, Err(e.to_string())); }
+        };
+        let status = resp.status();
+        logv!("← HTTP {}", status);
+        let text = match resp.text().await {
+            Ok(t) => t,
+            Err(e) => return (log, Err(e.to_string())),
+        };
+        logv!("body {} bytes", text.len());
         if !status.is_success() {
-            return Err(format!("HTTP {} — blocked. Use 'Open in Browser' as fallback.", status));
+            return (log, Err(format!("HTTP {} — {}", status, &text[..text.len().min(120)])));
         }
-
-        let parsed: parser::FabSearchResponse = serde_json::from_str(&text)
-            .map_err(|e| { log!("parse error: {}", e); format!("Parse error: {e}") })?;
-
-        log!("parsed {} listings", parsed.results.len());
-        Ok(parsed.results)
+        let result = serde_json::from_str::<parser::SketchfabSearchResponse>(&text)
+            .map_err(|e| { logv!("parse: {}", e); format!("Parse error: {e}") })
+            .map(|parsed| {
+                logv!("parsed {} models", parsed.results.len());
+                SearchPage { next: parsed.next, prev: parsed.previous, models: parsed.results }
+            });
+        (log, result)
     });
-
-    // Store successful result in cache
-    if let Ok(listings) = &result {
-        if let Ok(mut cache) = global_cache().lock() {
-            cache.insert(url.to_string(), CacheValue::Listings(listings.clone()));
-        }
-    }
-
     (log, result)
 }
 
-/// Fetch full item detail from GET /i/listings/{uid}.
-/// Must be called from an OS thread (not a GPUI/smol task).
-fn fetch_fab_item_detail(uid: &str) -> (Vec<String>, Result<Box<FabItemDetail>, String>) {
-    use rquest::Impersonate;
+fn fetch_sketchfab_model_detail(uid: &str) -> (Vec<String>, Result<Box<SketchfabModelDetail>, String>) {
+    let url = format!("https://api.sketchfab.com/v3/models/{}", uid);
 
-    let mut log: Vec<String> = Vec::new();
-    macro_rules! log {
-        ($($arg:tt)*) => {{
-            let s = format!($($arg)*);
-            println!("{}", s);
-            log.push(s);
-        }}
-    }
-
-    let url = format!("https://www.fab.com/i/listings/{}", uid);
-
-    // Check cache first
     if let Ok(mut cache) = global_cache().lock() {
         if let Some(cached) = cache.get_detail(&url) {
-            log!("cache hit: {}", url);
-            return (log, Ok(cached));
+            return (vec!["cache hit".into()], Ok(cached));
         }
     }
 
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(e) => return (log, Err(format!("tokio error: {}", e))),
+    let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+        Ok(r) => r, Err(e) => return (vec![], Err(format!("tokio: {}", e))),
     };
+    let url2 = url.clone();
+    let (log, result) = rt.block_on(async move {
+        let mut log: Vec<String> = Vec::new();
+        macro_rules! logv { ($($t:tt)*) => {{ let s = format!($($t)*); println!("{}", s); log.push(s); }} }
 
-    let result = rt.block_on(async {
-        log!("→ GET {}", url);
-
-        let client = rquest::Client::builder()
-            .impersonate(Impersonate::Chrome131)
+        logv!("→ GET {}", url2);
+        let client = match reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
+            .user_agent("Pulsar-Native/1.0")
             .build()
-            .map_err(|e| { log!("client build: {}", e); e.to_string() })?;
-
-        let response = client.get(&url).send().await
-            .map_err(|e| { log!("request error: {}", e); e.to_string() })?;
-
-        let status = response.status();
-        log!("← HTTP {}", status);
-
-        let text = response.text().await
-            .map_err(|e| { log!("body read: {}", e); e.to_string() })?;
-
-        log!("body ({} bytes): {}…", text.len(), &text[..text.len().min(200)]);
-
-        if !status.is_success() {
-            return Err(format!("HTTP {}", status));
-        }
-
-        let parsed: FabItemDetail = serde_json::from_str(&text)
-            .map_err(|e| { log!("parse error: {}", e); format!("Parse error: {e}") })?;
-
-        log!("parsed item: {}", parsed.title);
-        Ok(Box::new(parsed))
+        {
+            Ok(c) => c,
+            Err(e) => return (log, Err(e.to_string())),
+        };
+        let resp = match client.get(&url2).send().await {
+            Ok(r) => r,
+            Err(e) => return (log, Err(e.to_string())),
+        };
+        let status = resp.status();
+        logv!("← HTTP {}", status);
+        let text = match resp.text().await {
+            Ok(t) => t,
+            Err(e) => return (log, Err(e.to_string())),
+        };
+        if !status.is_success() { return (log, Err(format!("HTTP {}", status))); }
+        let result = serde_json::from_str::<SketchfabModelDetail>(&text)
+            .map_err(|e| { logv!("parse: {}", e); format!("Parse error: {e}") })
+            .map(|parsed| { logv!("parsed: {}", parsed.name); Box::new(parsed) });
+        (log, result)
     });
-
-    // Store successful result in cache
-    if let Ok(detail) = &result {
+    if let Ok(ref d) = result {
         if let Ok(mut cache) = global_cache().lock() {
-            cache.insert(url.clone(), CacheValue::Detail(detail.clone()));
+            cache.insert(url, CacheValue::Detail(d.clone()));
         }
     }
-
     (log, result)
 }
 
+// ── Focusable + Render ───────────────────────────────────────────────────────
+
 impl Focusable for FabSearchWindow {
-    fn focus_handle(&self, _cx: &App) -> FocusHandle {
-        self.focus_handle.clone()
-    }
+    fn focus_handle(&self, _cx: &App) -> FocusHandle { self.focus_handle.clone() }
 }
 
 impl Render for FabSearchWindow {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let current_input = self.search_input.read(cx).value().to_string();
-        if current_input != self.search_query {
-            self.search_query = current_input;
-        }
+        if current_input != self.search_query { self.search_query = current_input; }
 
         let bg         = cx.theme().background;
         let card_bg    = cx.theme().sidebar;
@@ -488,414 +512,337 @@ impl Render for FabSearchWindow {
         let muted_fg   = cx.theme().muted_foreground;
         let accent_bg  = cx.theme().secondary;
         let accent_fg  = cx.theme().secondary_foreground;
+        let active_bg  = cx.theme().accent;
+        let active_fg  = cx.theme().accent_foreground;
 
-        // ── request log panel ──────────────────────────────────────────────
+        // ── Request log ───────────────────────────────────────────────────
         let log_panel = div()
-            .w(px(260.0))
-            .flex_shrink_0()
-            .min_h_0()
-            .border_r_1()
-            .border_color(border_col)
-            .flex()
-            .flex_col()
+            .w(px(260.0)).flex_shrink_0().min_h_0()
+            .border_r_1().border_color(border_col)
+            .flex().flex_col()
+            .child(div().px_3().py_2().border_b_1().border_color(border_col)
+                .text_sm().font_bold().text_color(muted_fg).child("Request Log"))
             .child(
-                div()
-                    .px_3()
-                    .py_2()
-                    .border_b_1()
-                    .border_color(border_col)
-                    .text_sm()
-                    .font_bold()
-                    .text_color(muted_fg)
-                    .child("Request Log")
-            )
-            .child(
-                div()
-                    .relative()
-                    .flex_1()
-                    .min_h_0()
-                    .overflow_hidden()
-                    .child(
-                        div()
-                            .id("log-scroll")
-                            .size_full()
-                            .overflow_y_scroll()
-                            .track_scroll(&self.log_scroll_handle)
-                            .p_2()
-                            .child(
-                                v_flex()
-                                    .gap_1()
-                                    .children(self.request_log.iter().rev().map(|entry| {
-                                        div()
-                                            .text_xs()
-                                            .text_color(muted_fg)
-                                            .font_family("monospace")
-                                            .child(entry.clone())
-                                    }))
-                            )
+                div().relative().flex_1().min_h_0().overflow_hidden()
+                    .child(div().id("log-scroll").size_full()
+                        .overflow_y_scroll()
+                        .track_scroll(&self.log_scroll_handle)
+                        .p_2()
+                        .child(v_flex().gap_1()
+                            .children(self.request_log.iter().rev().map(|e| {
+                                div().text_xs().text_color(muted_fg)
+                                    .font_family("monospace").child(e.clone())
+                            }))
+                        )
                     )
-                    .child(
-                        div()
-                            .absolute()
-                            .inset_0()
-                            .child(Scrollbar::vertical(&self.log_scroll_state, &self.log_scroll_handle))
-                    )
+                    .child(div().absolute().inset_0()
+                        .child(Scrollbar::vertical(&self.log_scroll_state, &self.log_scroll_handle)))
             );
 
-        // ── results body ───────────────────────────────────────────────────
+        // ── Body ──────────────────────────────────────────────────────────
         let body: AnyElement = if self.is_loading {
-            div()
-                .flex_1()
-                .flex()
-                .items_center()
-                .justify_center()
-                .child(div().text_color(muted_fg).child("Fetching results from Fab…"))
+            div().flex_1().flex().items_center().justify_center()
+                .child(div().text_color(muted_fg).child("Searching Sketchfab…"))
                 .into_any_element()
-        } else if let Some(ref err) = self.error {
-            let err_text = err.clone();
-            let has_url = self.last_url.is_some();
 
-            div()
-                .flex_1()
-                .min_h_0()
-                .flex()
-                .flex_col()
-                .items_center()
-                .justify_center()
-                .gap_2()
-                .child(div().text_color(gpui::red()).child(err_text))
-                .when(has_url, |el| {
-                    el.child(
-                        Button::new("open-in-browser")
-                            .label("Open in Browser")
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                if let Some(url) = &this.last_url {
-                                    cx.open_url(url);
-                                }
-                            })),
-                    )
-                })
+        } else if let Some(ref err) = self.error.clone() {
+            let has_url = self.last_url.is_some();
+            div().flex_1().min_h_0().flex().flex_col()
+                .items_center().justify_center().gap_2()
+                .child(div().text_color(gpui::red()).child(err.clone()))
+                .when(has_url, |el| el.child(
+                    Button::new("open-browser").label("Open in Browser")
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            if let Some(url) = &this.last_url { cx.open_url(url); }
+                        }))
+                ))
                 .into_any_element()
+
         } else if self.selected_item_uid.is_some() {
-            // ── item detail view ──────────────────────────────────────────────
             if self.detail_loading {
-                div()
-                    .flex_1()                    .min_h_0()                    .min_h_0()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .child(div().text_color(muted_fg).child("Loading item details…"))
+                div().flex_1().min_h_0().flex().items_center().justify_center()
+                    .child(div().text_color(muted_fg).child("Loading model details…"))
                     .into_any_element()
-            } else if let Some(ref err) = self.detail_error {
-                let err_text = err.clone();
-                div()
-                    .flex_1()
-                    .min_h_0()
-                    .flex()
-                    .flex_col()
-                    .items_center()
-                    .justify_center()
-                    .gap_2()
-                    .child(div().text_color(gpui::red()).child(err_text))
-                    .child(
-                        Button::new("back-from-error")
-                            .label("← Back")
-                            .on_click(cx.listener(|this, _, _, cx| this.go_back(cx)))
-                    )
+
+            } else if let Some(ref err) = self.detail_error.clone() {
+                div().flex_1().min_h_0().flex().flex_col()
+                    .items_center().justify_center().gap_2()
+                    .child(div().text_color(gpui::red()).child(err.clone()))
+                    .child(Button::new("back-err").label("← Back")
+                        .on_click(cx.listener(|this, _, _, cx| this.go_back(cx))))
                     .into_any_element()
+
             } else if let Some(ref detail) = self.item_detail {
                 let entity = cx.entity().clone();
-                // Collect only the fully-loaded images for this detail view
-                let mut loaded_images: std::collections::HashMap<String, std::sync::Arc<gpui::RenderImage>> = detail
-                    .medias
-                    .iter()
-                    .filter(|m| m.media_type == "image" || m.media_type.is_empty())
-                    .take(12)
-                    .filter_map(|m| {
-                        let url = m
-                            .images
-                            .iter()
-                            .max_by_key(|i| i.width)
-                            .map(|i| i.url.as_str())
-                            .filter(|s: &&str| !s.is_empty())
-                            .unwrap_or(m.media_url.as_str())
-                            .to_string();
-                        self.image_cache
-                            .get(&url)
-                            .and_then(|opt| opt.clone())
-                            .map(|arc| (url, arc))
-                    })
-                    .collect();
-                // Also include the seller avatar so MetaBar can render it synchronously
-                if let Some(avatar_url) = detail.user.profile_image_url.as_deref() {
-                    if let Some(Some(arc)) = self.image_cache.get(avatar_url) {
-                        loaded_images.insert(avatar_url.to_string(), arc.clone());
+
+                // collect loaded images keyed by URL
+                let mut loaded: HashMap<String, std::sync::Arc<gpui::RenderImage>> =
+                    detail.all_thumbnail_urls().into_iter().take(8).filter_map(|url| {
+                        self.image_cache.get(url).and_then(|o| o.clone())
+                            .map(|arc| (url.to_string(), arc))
+                    }).collect();
+
+                if let Some(ref user) = detail.user {
+                    if let Some(url) = user.avatar_url(128) {
+                        if let Some(Some(arc)) = self.image_cache.get(url) {
+                            loaded.insert(url.to_string(), arc.clone());
+                        }
                     }
                 }
+
                 item_detail::ItemDetailView::new(
                     detail.clone(),
-                    loaded_images,
+                    loaded,
                     self.detail_scroll_handle.clone(),
                     self.detail_scroll_state.clone(),
                     self.gallery_scroll_handle.clone(),
                     self.gallery_scroll_state.clone(),
-                    move |_window, cx| {
-                        entity.update(cx, |this, cx| this.go_back(cx));
-                    },
-                )
-                .into_any_element()
+                    move |_window, cx| { entity.update(cx, |this, cx| this.go_back(cx)); },
+                ).into_any_element()
+
             } else {
-                // selected but no detail yet (shouldn't happen, but guard)
-                div()
-                    .flex_1()
-                    .min_h_0()
-                    .flex()
-                    .items_center()
-                    .justify_center()
+                div().flex_1().min_h_0().flex().items_center().justify_center()
                     .child(div().text_color(muted_fg).child("Loading…"))
                     .into_any_element()
             }
+
         } else if self.results.is_empty() {
-            div()
-                .flex_1()
-                .min_h_0()
-                .flex()
-                .items_center()
-                .justify_center()
-                .child(div().text_color(muted_fg).child("Search Fab to discover assets"))
+            div().flex_1().min_h_0().flex().items_center().justify_center()
+                .child(div().text_color(muted_fg)
+                    .child("Search Sketchfab to browse free 3D models"))
                 .into_any_element()
+
         } else {
-            let cards: Vec<AnyElement> = self.results.iter().enumerate().map(|(idx, listing)| {
-                let price_text = if listing.is_free {
-                    "Free".to_string()
-                } else if let Some(ref sp) = listing.starting_price {
-                    format!("${:.2}", sp.price)
-                } else {
-                    "—".to_string()
-                };
+            // ── Results grid ──────────────────────────────────────────────
+            let next_url = self.next_url.clone();
+            let prev_url = self.prev_url.clone();
+            let has_next = next_url.is_some();
+            let has_prev = prev_url.is_some();
 
-                let rating_text = listing.ratings.as_ref().map(|r| {
-                    format!("★ {:.1}  ({} ratings)", r.average_rating, r.total)
-                }).unwrap_or_default();
+            let cards: Vec<AnyElement> = self.results.iter().enumerate().map(|(idx, model)| {
+                let name     = model.name.clone();
+                let author   = model.user.as_ref().map(|u| u.display().to_string()).unwrap_or_default();
+                let category = model.primary_category().map(|s| s.to_string()).unwrap_or_default();
+                let subtitle = if category.is_empty() { author.clone() }
+                               else { format!("{} · {}", author, category) };
+                let views    = fmt_count(model.view_count);
+                let likes    = fmt_count(model.like_count);
+                let is_dl    = model.is_downloadable;
+                let is_anim  = model.animation_count > 0;
+                let is_sp    = model.staffpicked_at.as_ref().map(|v| !v.is_null()).unwrap_or(false);
 
-                let seller   = listing.user.seller_name.clone();
-                let category = listing.category.as_ref().map(|c| c.name.clone()).unwrap_or_default();
-                let formats: Vec<String> = listing.asset_formats.iter()
-                    .map(|f| f.asset_format_type.name.clone())
-                    .take(3)
-                    .collect();
-
-                let card_uid = listing.uid.clone();
-                let listing_type = listing.listing_type.clone().unwrap_or_default();
-                let thumb_url: Option<String> = listing
-                    .thumbnails
-                    .first()
-                    .and_then(|t| t.best_image_url(260))
-                    .map(|s| s.to_string());
-                // Look up the cached RenderImage — None-value = still downloading
-                let thumb_image: Option<std::sync::Arc<gpui::RenderImage>> = thumb_url
-                    .as_deref()
-                    .and_then(|u| self.image_cache.get(u))
-                    .and_then(|opt| opt.clone());
+                let card_uid = model.uid.clone();
+                let thumb_url = model.thumb_url(260).map(|s| s.to_string());
+                let thumb_arc: Option<std::sync::Arc<gpui::RenderImage>> = thumb_url
+                    .as_deref().and_then(|u| self.image_cache.get(u)).and_then(|o| o.clone());
 
                 div()
-                    .id(SharedString::from(format!("fab-card-{}", idx)))
+                    .id(SharedString::from(format!("skfb-card-{}", idx)))
                     .cursor_pointer()
-                    .w(px(260.0))
-                    .rounded_lg()
-                    .bg(card_bg)
-                    .border_1()
-                    .border_color(border_col)
-                    .overflow_hidden()
-                    .flex()
-                    .flex_col()
-                    .on_click(cx.listener(move |this, _ev, _win, cx| {
+                    .w(px(260.0)).rounded_lg().bg(card_bg)
+                    .border_1().border_color(border_col)
+                    .overflow_hidden().flex().flex_col()
+                    .on_click(cx.listener(move |this, _, _, cx| {
                         this.open_item_detail(card_uid.clone(), cx);
                     }))
-                    // thumbnail — real image when available, muted placeholder otherwise
+                    // thumbnail
                     .child(
-                        div()
-                            .w_full()
-                            .h(px(140.0))
-                            .bg(card_bg)
-                            .overflow_hidden()
+                        div().w_full().h(px(146.0)).bg(card_bg).overflow_hidden().relative()
                             .map(|el| {
-                                if let Some(arc) = thumb_image {
-                                    el.child(
-                                        img(gpui::ImageSource::Render(arc))
-                                            .w_full()
-                                            .h_full()
-                                            .object_fit(gpui::ObjectFit::Cover),
-                                    )
+                                if let Some(arc) = thumb_arc {
+                                    el.child(img(gpui::ImageSource::Render(arc))
+                                        .w_full().h_full().object_fit(gpui::ObjectFit::Cover))
                                 } else {
-                                    el.bg(border_col)
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .child(
-                                            div()
-                                                .text_xs()
-                                                .text_color(muted_fg)
-                                                .child(listing_type),
-                                        )
+                                    el.bg(border_col).flex().items_center().justify_center()
+                                        .child(div().text_xs().text_color(muted_fg).child(""))
                                 }
-                            }),
+                            })
+                            .when(is_sp, |el| el.child(
+                                div().absolute().top(px(6.0)).left(px(6.0))
+                                    .px_2().py(px(2.0)).rounded_full()
+                                    .bg(gpui::rgb(0xFACC15))
+                                    .text_xs().font_bold().text_color(gpui::rgb(0x000000))
+                                    .child("★ Staff Pick")
+                            ))
+                            .when(is_dl, |el| el.child(
+                                div().absolute().bottom(px(6.0)).right(px(6.0))
+                                    .px_2().py(px(2.0)).rounded_full()
+                                    .bg(gpui::rgb(0x22C55E))
+                                    .text_xs().font_bold().text_color(gpui::rgb(0xFFFFFF))
+                                    .child("↓")
+                            ))
+                            .when(is_anim, |el| el.child(
+                                div().absolute().bottom(px(6.0)).left(px(6.0))
+                                    .px_2().py(px(2.0)).rounded_full()
+                                    .bg(gpui::rgb(0x6366F1))
+                                    .text_xs().font_bold().text_color(gpui::rgb(0xFFFFFF))
+                                    .child("▶")
+                            ))
                     )
-                    // card body
-                    .child(
-                        div()
-                            .p_3()
-                            .child(
-                                v_flex()
-                                    .gap_1()
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .font_bold()
-                                            .text_color(fg)
-                                            .line_clamp(2)
-                                            .child(listing.title.clone())
-                                    )
-                                    .child(
-                                        div()
-                                            .text_xs()
-                                            .text_color(muted_fg)
-                                            .child(if category.is_empty() {
-                                                seller.clone()
-                                            } else {
-                                                format!("{} · {}", seller, category)
-                                            })
-                                    )
-                                    .child(
-                                        h_flex()
-                                            .gap_2()
-                                            .items_center()
-                                            .justify_between()
-                                            .child(
-                                                div()
-                                                    .text_sm()
-                                                    .font_bold()
-                                                    .text_color(fg)
-                                                    .child(price_text)
-                                            )
-                                            .when(!rating_text.is_empty(), |el| {
-                                                el.child(
-                                                    div()
-                                                        .text_xs()
-                                                        .text_color(muted_fg)
-                                                        .child(rating_text)
-                                                )
-                                            })
-                                    )
-                                    .when(!formats.is_empty(), |el| {
-                                        el.child(
-                                            div()
-                                                .flex()
-                                                .flex_wrap()
-                                                .gap_1()
-                                                .mt_1()
-                                                .children(formats.iter().map(|f| {
-                                                    div()
-                                                        .text_xs()
-                                                        .px_2()
-                                                        .py(px(2.0))
-                                                        .rounded_sm()
-                                                        .bg(accent_bg)
-                                                        .text_color(accent_fg)
-                                                        .child(f.clone())
-                                                }))
-                                        )
-                                    })
-                            )
-                    )
+                    // body
+                    .child(div().p_3().child(v_flex().gap_1()
+                        .child(div().text_sm().font_bold().text_color(fg)
+                            .line_clamp(2).child(name))
+                        .child(div().text_xs().text_color(muted_fg).child(subtitle))
+                        .child(h_flex().gap_3().items_center().mt_1()
+                            .child(div().text_xs().text_color(muted_fg)
+                                .child(format!("👁 {}", views)))
+                            .child(div().text_xs().text_color(muted_fg)
+                                .child(format!("♥ {}", likes)))
+                        )
+                    ))
                     .into_any_element()
             }).collect();
 
-            div()
-                .relative()
-                .flex_1()
-                .min_h_0()
-                .overflow_hidden()
+            div().relative().flex_1().min_h_0().overflow_hidden()
                 .child(
-                    div()
-                        .id("results-scroll")
-                        .size_full()
+                    div().id("results-scroll").size_full()
                         .overflow_y_scroll()
                         .track_scroll(&self.results_scroll_handle)
                         .p_4()
-                        .child(
-                            div()
-                                .flex()
-                                .flex_wrap()
-                                .gap_4()
-                                .children(cards)
-                        )
+                        .child(div().flex().flex_wrap().gap_4().children(cards))
+                        .when(has_prev || has_next, |el| el.child(
+                            h_flex().w_full().justify_center().gap_4().mt_6().mb_2()
+                                .when(has_prev, |el| {
+                                    let pu = prev_url.clone().unwrap();
+                                    el.child(Button::new("prev-page").small().ghost()
+                                        .label("← Prev")
+                                        .on_click(cx.listener(move |this, _, _, cx| {
+                                            this.begin_search(Some(pu.clone()), cx);
+                                        })))
+                                })
+                                .when(has_next, |el| {
+                                    let nu = next_url.clone().unwrap();
+                                    el.child(Button::new("next-page").small()
+                                        .label("Next →")
+                                        .on_click(cx.listener(move |this, _, _, cx| {
+                                            this.begin_search(Some(nu.clone()), cx);
+                                        })))
+                                })
+                        ))
                 )
-                .child(
-                    div()
-                        .absolute()
-                        .inset_0()
-                        .child(Scrollbar::vertical(&self.results_scroll_state, &self.results_scroll_handle))
-                )
+                .child(div().absolute().inset_0()
+                    .child(Scrollbar::vertical(&self.results_scroll_state, &self.results_scroll_handle)))
                 .into_any_element()
         };
 
-        // ── root layout ────────────────────────────────────────────────────
-        let layout = v_flex()
-            .size_full()
-            .bg(bg)
-            .child(TitleBar::new().child("Fab Search"))
-            // search row
-            .child(
+        // ── Filter bar ────────────────────────────────────────────────────
+        let dl_active  = self.filter_downloadable;
+        let an_active  = self.filter_animated;
+        let sp_active  = self.filter_staffpicked;
+        let lic_active = self.filter_license != LicenseFilter::All;
+        let lic_label  = self.filter_license.label();
+        let show_lic   = self.show_license_menu;
+
+        let filter_bar = div()
+            .w_full().px_4().py_2()
+            .border_b_1().border_color(border_col)
+            .flex().flex_row().flex_wrap().gap_2().items_center()
+            .child(div().text_xs().font_bold().text_color(muted_fg).child("Sort:"))
+            .children(SortBy::all().into_iter().map(|s| {
+                let active = self.sort_by == s;
+                let lbl = s.label();
                 div()
-                    .w_full()
-                    .p_4()
-                    .border_b_1()
-                    .border_color(border_col)
-                    .child(
-                        h_flex()
-                            .w_full()
-                            .gap_2()
-                            .items_center()
-                            .child(
-                                div()
-                                    .flex_1()
-                                    .min_w(px(200.0))
-                                    .child(
-                                        TextInput::new(&self.search_input)
-                                            .w_full()
-                                            .prefix(
-                                                ui::Icon::new(IconName::Search)
-                                                    .size_4()
-                                                    .text_color(muted_fg)
-                                            )
-                                    )
-                            )
-                            .child(
-                                Button::new("Search")
-                                    .small()
-                                    .on_click(cx.listener(|this, _event, _window, cx| {
-                                        this.perform_search(cx);
-                                    }))
-                            )
+                    .id(SharedString::from(format!("sort-{}", lbl)))
+                    .cursor_pointer().px_2().py(px(3.0)).rounded_full()
+                    .text_xs().font_medium()
+                    .bg(if active { active_bg } else { accent_bg })
+                    .text_color(if active { active_fg } else { accent_fg })
+                    .child(lbl)
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.sort_by = s;
+                        if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                        else { cx.notify(); }
+                    }))
+            }))
+            .child(div().w(px(1.0)).h(px(16.0)).bg(border_col))
+            .child(div().id("f-dl").cursor_pointer().px_2().py(px(3.0)).rounded_full()
+                .text_xs().font_medium()
+                .bg(if dl_active { active_bg } else { accent_bg })
+                .text_color(if dl_active { active_fg } else { accent_fg })
+                .child("↓ Download")
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.filter_downloadable = !this.filter_downloadable;
+                    if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                    else { cx.notify(); }
+                }))
+            )
+            .child(div().id("f-an").cursor_pointer().px_2().py(px(3.0)).rounded_full()
+                .text_xs().font_medium()
+                .bg(if an_active { active_bg } else { accent_bg })
+                .text_color(if an_active { active_fg } else { accent_fg })
+                .child("▶ Animated")
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.filter_animated = !this.filter_animated;
+                    if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                    else { cx.notify(); }
+                }))
+            )
+            .child(div().id("f-sp").cursor_pointer().px_2().py(px(3.0)).rounded_full()
+                .text_xs().font_medium()
+                .bg(if sp_active { active_bg } else { accent_bg })
+                .text_color(if sp_active { active_fg } else { accent_fg })
+                .child("★ Staff Pick")
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.filter_staffpicked = !this.filter_staffpicked;
+                    if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                    else { cx.notify(); }
+                }))
+            )
+            .child(div().w(px(1.0)).h(px(16.0)).bg(border_col))
+            .child(div().id("f-lic").cursor_pointer().px_2().py(px(3.0)).rounded_full()
+                .text_xs().font_medium()
+                .bg(if lic_active { active_bg } else { accent_bg })
+                .text_color(if lic_active { active_fg } else { accent_fg })
+                .child(format!("© {}", lic_label))
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.show_license_menu = !this.show_license_menu;
+                    cx.notify();
+                }))
+            )
+            .when(show_lic, |el| el.children(LicenseFilter::all().into_iter().map(|lic| {
+                let sel = self.filter_license == lic;
+                let lbl = lic.label();
+                div()
+                    .id(SharedString::from(format!("lic-{}", lbl)))
+                    .cursor_pointer().px_2().py(px(3.0)).rounded_full()
+                    .text_xs().border_1().border_color(border_col)
+                    .bg(if sel { active_bg } else { cx.theme().background })
+                    .text_color(if sel { active_fg } else { muted_fg })
+                    .child(lbl)
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.filter_license = lic;
+                        this.show_license_menu = false;
+                        if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                        else { cx.notify(); }
+                    }))
+            })));
+
+        // ── Root ──────────────────────────────────────────────────────────
+        let layout = v_flex()
+            .size_full().bg(bg)
+            .child(TitleBar::new().child("Sketchfab"))
+            .child(
+                div().w_full().px_4().pt_4().pb_3()
+                    .border_b_1().border_color(border_col)
+                    .child(h_flex().w_full().gap_2().items_center()
+                        .child(div().flex_1().min_w(px(200.0))
+                            .child(TextInput::new(&self.search_input).w_full()
+                                .prefix(ui::Icon::new(IconName::Search)
+                                    .size_4().text_color(muted_fg))))
+                        .child(Button::new("search-btn")
+                            .label("Search")
+                            .on_click(cx.listener(|this, _, _, cx| this.begin_search(None, cx))))
                     )
             )
-            // log + results row
-            .child(
-                div()
-                    .flex_1()
-                    .min_h_0()
-                    .flex()
-                    .flex_row()
-                    .child(log_panel)
-                    .child(body)
+            .child(filter_bar)
+            .child(div().flex_1().min_h_0().flex().flex_row()
+                .child(log_panel)
+                .child(body)
             );
 
-        let modal_layer = Root::render_modal_layer(window, cx);
-
-        div()
-            .size_full()
+        div().size_full()
             .child(layout)
-            .children(modal_layer)
+            .children(Root::render_modal_layer(window, cx))
     }
 }

--- a/ui-crates/ui_fab_search/src/lib.rs
+++ b/ui-crates/ui_fab_search/src/lib.rs
@@ -10,13 +10,13 @@ use gpui::{prelude::*, *};
 use ui::{
     ActiveTheme,
     Root,
-    Sizable,
     TitleBar,
     v_flex,
     h_flex,
     button::{Button, ButtonVariants as _},
     input::{InputState, TextInput},
     scroll::{Scrollbar, ScrollbarState},
+    skeleton::Skeleton,
     IconName,
     StyledExt,
 };
@@ -161,7 +161,7 @@ impl FabSearchWindow {
 
         cx.subscribe(&search_input, |this, _input, event: &ui::input::InputEvent, cx| {
             if let ui::input::InputEvent::PressEnter { .. } = event {
-                this.begin_search(None, cx);
+                this.begin_search(cx);
             }
         }).detach();
 
@@ -742,7 +742,7 @@ impl Render for FabSearchWindow {
                             if this.is_loading || this.is_loading_more || this.next_url.is_none() {
                                 return;
                             }
-                            let max_off = this.results_scroll_handle.max_offset().y;
+                            let max_off = this.results_scroll_handle.max_offset().height;
                             let cur_off = this.results_scroll_handle.offset().y;
                             if max_off - cur_off < px(600.0) {
                                 this.load_more(cx);
@@ -751,8 +751,23 @@ impl Render for FabSearchWindow {
                         .p_4()
                         .child(div().flex().flex_wrap().gap_4().children(cards))
                         .when(is_loading_more, |el| el.child(
-                            h_flex().w_full().justify_center().py_4()
-                                .child(div().text_xs().text_color(muted_fg).child("Loading more…"))
+                            div().flex().flex_wrap().gap_4().pt_4()
+                                .children((0..6).map(|i| {
+                                    div()
+                                        .id(SharedString::from(format!("skel-{}", i)))
+                                        .w(px(260.0)).rounded_lg()
+                                        .border_1().border_color(border_col)
+                                        .overflow_hidden().flex().flex_col()
+                                        .child(Skeleton::new().w_full().h(px(146.0)))
+                                        .child(
+                                            div().p_3().child(
+                                                v_flex().gap_2()
+                                                    .child(Skeleton::new().w(px(160.0)).h_4())
+                                                    .child(Skeleton::new().secondary(true).w(px(100.0)).h_3())
+                                                    .child(Skeleton::new().secondary(true).w(px(120.0)).h_3())
+                                            )
+                                        )
+                                }))
                         ))
                         .when(!is_loading_more && !has_next && !self.results.is_empty(), |el| el.child(
                             h_flex().w_full().justify_center().py_3()
@@ -789,7 +804,7 @@ impl Render for FabSearchWindow {
                     .child(lbl)
                     .on_click(cx.listener(move |this, _, _, cx| {
                         this.sort_by = s;
-                        if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                        if !this.search_query.is_empty() { this.begin_search(cx); }
                         else { cx.notify(); }
                     }))
             }))
@@ -801,7 +816,7 @@ impl Render for FabSearchWindow {
                 .child("↓ Download")
                 .on_click(cx.listener(|this, _, _, cx| {
                     this.filter_downloadable = !this.filter_downloadable;
-                    if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                    if !this.search_query.is_empty() { this.begin_search(cx); }
                     else { cx.notify(); }
                 }))
             )
@@ -812,7 +827,7 @@ impl Render for FabSearchWindow {
                 .child("▶ Animated")
                 .on_click(cx.listener(|this, _, _, cx| {
                     this.filter_animated = !this.filter_animated;
-                    if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                    if !this.search_query.is_empty() { this.begin_search(cx); }
                     else { cx.notify(); }
                 }))
             )
@@ -823,7 +838,7 @@ impl Render for FabSearchWindow {
                 .child("★ Staff Pick")
                 .on_click(cx.listener(|this, _, _, cx| {
                     this.filter_staffpicked = !this.filter_staffpicked;
-                    if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                    if !this.search_query.is_empty() { this.begin_search(cx); }
                     else { cx.notify(); }
                 }))
             )
@@ -851,7 +866,7 @@ impl Render for FabSearchWindow {
                     .on_click(cx.listener(move |this, _, _, cx| {
                         this.filter_license = lic;
                         this.show_license_menu = false;
-                        if !this.search_query.is_empty() { this.begin_search(None, cx); }
+                        if !this.search_query.is_empty() { this.begin_search(cx); }
                         else { cx.notify(); }
                     }))
             })));
@@ -870,7 +885,7 @@ impl Render for FabSearchWindow {
                                     .size_4().text_color(muted_fg))))
                         .child(Button::new("search-btn")
                             .label("Search")
-                            .on_click(cx.listener(|this, _, _, cx| this.begin_search(None, cx))))
+                            .on_click(cx.listener(|this, _, _, cx| this.begin_search(cx))))
                     )
             )
             .child(filter_bar)

--- a/ui-crates/ui_fab_search/src/lib.rs
+++ b/ui-crates/ui_fab_search/src/lib.rs
@@ -3,6 +3,7 @@ pub mod item_detail;
 pub mod parser;
 
 use std::collections::{HashMap, VecDeque};
+use std::rc::Rc;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -17,6 +18,7 @@ use ui::{
     input::{InputState, TextInput},
     scroll::{Scrollbar, ScrollbarState},
     skeleton::Skeleton,
+    v_virtual_list, VirtualListScrollHandle,
     IconName,
     StyledExt,
 };
@@ -126,7 +128,7 @@ pub struct FabSearchWindow {
     // results
     results: Vec<SketchfabModel>,
     next_url: Option<String>,
-    request_log: Vec<String>,
+
     is_loading: bool,
     is_loading_more: bool,
     error: Option<String>,
@@ -141,10 +143,12 @@ pub struct FabSearchWindow {
     // image cache: None = in-flight, Some(arc) = ready
     image_cache: HashMap<String, Option<std::sync::Arc<gpui::RenderImage>>>,
 
+    // entity ref (needed for v_virtual_list)
+    entity: Option<Entity<Self>>,
+
     // scrollbars
-    log_scroll_handle: ScrollHandle,
-    log_scroll_state: ScrollbarState,
-    results_scroll_handle: ScrollHandle,
+
+    results_scroll_handle: VirtualListScrollHandle,
     results_scroll_state: ScrollbarState,
     detail_scroll_handle: ScrollHandle,
     detail_scroll_state: ScrollbarState,
@@ -165,7 +169,7 @@ impl FabSearchWindow {
             }
         }).detach();
 
-        Self {
+        let mut this = Self {
             focus_handle,
             search_query: String::new(),
             search_input,
@@ -177,7 +181,7 @@ impl FabSearchWindow {
             show_license_menu: false,
             results: Vec::new(),
             next_url: None,
-            request_log: Vec::new(),
+
             is_loading: false,
             is_loading_more: false,
             error: None,
@@ -187,15 +191,19 @@ impl FabSearchWindow {
             detail_loading: false,
             detail_error: None,
             image_cache: HashMap::new(),
-            log_scroll_handle: ScrollHandle::new(),
-            log_scroll_state: ScrollbarState::default(),
-            results_scroll_handle: ScrollHandle::new(),
+            entity: None,
+
+            results_scroll_handle: VirtualListScrollHandle::new(),
             results_scroll_state: ScrollbarState::default(),
             detail_scroll_handle: ScrollHandle::new(),
             detail_scroll_state: ScrollbarState::default(),
             gallery_scroll_handle: ScrollHandle::new(),
             gallery_scroll_state: ScrollbarState::default(),
-        }
+        };
+        // Store self-entity reference so v_virtual_list can capture it
+        let entity = cx.entity();
+        this.entity = Some(entity);
+        this
     }
 
     fn go_back(&mut self, cx: &mut Context<Self>) {
@@ -239,7 +247,6 @@ impl FabSearchWindow {
         self.item_detail = None;
         self.detail_loading = true;
         self.detail_error = None;
-        self.request_log.push(format!("GET /v3/models/{}", uid));
         cx.notify();
 
         let (tx, rx) = smol::channel::bounded::<(Vec<String>, Result<Box<SketchfabModelDetail>, String>)>(1);
@@ -248,14 +255,12 @@ impl FabSearchWindow {
         });
 
         cx.spawn(async move |this, cx| {
-            if let Ok((log_lines, result)) = rx.recv().await {
+            if let Ok((_, result)) = rx.recv().await {
                 cx.update(|cx| {
                     this.update(cx, |view, cx| {
                         view.detail_loading = false;
-                        view.request_log.extend(log_lines);
                         match result {
                             Ok(detail) => {
-                                view.request_log.push(format!("  ✓ model: {}", detail.name));
                                 // preload all thumbnail sizes as gallery images
                                 let urls: Vec<String> = detail.all_thumbnail_urls()
                                     .into_iter().take(8).map(|s| s.to_string()).collect();
@@ -271,7 +276,6 @@ impl FabSearchWindow {
                                 view.item_detail = Some(detail);
                             }
                             Err(e) => {
-                                view.request_log.push(format!("  ✗ {}", e));
                                 view.detail_error = Some(e);
                             }
                         }
@@ -306,7 +310,6 @@ impl FabSearchWindow {
         self.next_url = None;
         self.error = None;
         self.last_url = Some(url.clone());
-        self.request_log.push(format!("GET {}", url));
         cx.notify();
 
         let (tx, rx) = smol::channel::bounded::<(Vec<String>, Result<SearchPage, String>)>(1);
@@ -315,14 +318,12 @@ impl FabSearchWindow {
         });
 
         cx.spawn(async move |this, cx| {
-            if let Ok((log_lines, result)) = rx.recv().await {
+            if let Ok((_, result)) = rx.recv().await {
                 cx.update(|cx| {
                     this.update(cx, |view, cx| {
                         view.is_loading = false;
-                        view.request_log.extend(log_lines);
                         match result {
                             Ok(page) => {
-                                view.request_log.push(format!("  ✓ {} model(s)", page.models.len()));
                                 view.next_url = page.next;
                                 view.results = page.models;
                                 let thumb_urls: Vec<String> = view.results.iter()
@@ -333,7 +334,6 @@ impl FabSearchWindow {
                                 }
                             }
                             Err(e) => {
-                                view.request_log.push(format!("  ✗ {}", e));
                                 view.error = Some(e);
                             }
                         }
@@ -350,7 +350,6 @@ impl FabSearchWindow {
             None => return,
         };
         self.is_loading_more = true;
-        self.request_log.push(format!("GET {} (more)", url));
         cx.notify();
 
         let (tx, rx) = smol::channel::bounded::<(Vec<String>, Result<SearchPage, String>)>(1);
@@ -359,14 +358,12 @@ impl FabSearchWindow {
         });
 
         cx.spawn(async move |this, cx| {
-            if let Ok((log_lines, result)) = rx.recv().await {
+            if let Ok((_, result)) = rx.recv().await {
                 cx.update(|cx| {
                     this.update(cx, |view, cx| {
                         view.is_loading_more = false;
-                        view.request_log.extend(log_lines);
                         match result {
                             Ok(page) => {
-                                view.request_log.push(format!("  ✓ {} more model(s)", page.models.len()));
                                 view.next_url = page.next;
                                 let thumb_urls: Vec<String> = page.models.iter()
                                     .filter_map(|m| m.thumb_url(260).map(|s| s.to_string()))
@@ -377,7 +374,6 @@ impl FabSearchWindow {
                                 }
                             }
                             Err(e) => {
-                                view.request_log.push(format!("  ✗ {}", e));
                                 view.error = Some(e);
                             }
                         }
@@ -555,30 +551,6 @@ impl Render for FabSearchWindow {
         let active_bg  = cx.theme().accent;
         let active_fg  = cx.theme().accent_foreground;
 
-        // ── Request log ───────────────────────────────────────────────────
-        let log_panel = div()
-            .w(px(260.0)).flex_shrink_0().min_h_0()
-            .border_r_1().border_color(border_col)
-            .flex().flex_col()
-            .child(div().px_3().py_2().border_b_1().border_color(border_col)
-                .text_sm().font_bold().text_color(muted_fg).child("Request Log"))
-            .child(
-                div().relative().flex_1().min_h_0().overflow_hidden()
-                    .child(div().id("log-scroll").size_full()
-                        .overflow_y_scroll()
-                        .track_scroll(&self.log_scroll_handle)
-                        .p_2()
-                        .child(v_flex().gap_1()
-                            .children(self.request_log.iter().rev().map(|e| {
-                                div().text_xs().text_color(muted_fg)
-                                    .font_family("monospace").child(e.clone())
-                            }))
-                        )
-                    )
-                    .child(div().absolute().inset_0()
-                        .child(Scrollbar::vertical(&self.log_scroll_state, &self.log_scroll_handle)))
-            );
-
         // ── Body ──────────────────────────────────────────────────────────
         let body: AnyElement = if self.is_loading {
             div().flex_1().flex().items_center().justify_center()
@@ -653,126 +625,153 @@ impl Render for FabSearchWindow {
                 .into_any_element()
 
         } else {
-            // ── Results grid ──────────────────────────────────────────────
-            let next_url = self.next_url.clone();
-            let has_next = next_url.is_some();
-            let is_loading_more = self.is_loading_more;
+            // ── Virtual results grid ──────────────────────────────────────
+            const COLS: usize = 3;
+            const CARD_H: f32 = 260.0; // thumb(146) + body(114)
+            const ROW_H: f32 = CARD_H + 16.0; // + row gap
 
-            let cards: Vec<AnyElement> = self.results.iter().enumerate().map(|(idx, model)| {
-                let name     = model.name.clone();
-                let author   = model.user.as_ref().map(|u| u.display().to_string()).unwrap_or_default();
-                let category = model.primary_category().map(|s| s.to_string()).unwrap_or_default();
-                let subtitle = if category.is_empty() { author.clone() }
-                               else { format!("{} · {}", author, category) };
-                let views    = fmt_count(model.view_count);
-                let likes    = fmt_count(model.like_count);
-                let is_dl    = model.is_downloadable;
-                let is_anim  = model.animation_count > 0;
-                let is_sp    = model.staffpicked_at.as_ref().map(|v| !v.is_null()).unwrap_or(false);
+            let entity = self.entity.clone().unwrap();
+            let total_results = self.results.len();
+            let result_rows = total_results.div_ceil(COLS);
+            let skel_rows: usize = if self.is_loading_more { 2 } else { 0 };
+            let end_row: usize = if !self.is_loading_more && self.next_url.is_none() { 1 } else { 0 };
+            let total_items = result_rows + skel_rows + end_row;
 
-                let card_uid = model.uid.clone();
-                let thumb_url = model.thumb_url(260).map(|s| s.to_string());
-                let thumb_arc: Option<std::sync::Arc<gpui::RenderImage>> = thumb_url
-                    .as_deref().and_then(|u| self.image_cache.get(u)).and_then(|o| o.clone());
-
-                div()
-                    .id(SharedString::from(format!("skfb-card-{}", idx)))
-                    .cursor_pointer()
-                    .w(px(260.0)).rounded_lg().bg(card_bg)
-                    .border_1().border_color(border_col)
-                    .overflow_hidden().flex().flex_col()
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.open_item_detail(card_uid.clone(), cx);
-                    }))
-                    // thumbnail
-                    .child(
-                        div().w_full().h(px(146.0)).bg(card_bg).overflow_hidden().relative()
-                            .map(|el| {
-                                if let Some(arc) = thumb_arc {
-                                    el.child(img(gpui::ImageSource::Render(arc))
-                                        .w_full().h_full().object_fit(gpui::ObjectFit::Cover))
-                                } else {
-                                    el.bg(border_col).flex().items_center().justify_center()
-                                        .child(div().text_xs().text_color(muted_fg).child(""))
-                                }
-                            })
-                            .when(is_sp, |el| el.child(
-                                div().absolute().top(px(6.0)).left(px(6.0))
-                                    .px_2().py(px(2.0)).rounded_full()
-                                    .bg(gpui::rgb(0xFACC15))
-                                    .text_xs().font_bold().text_color(gpui::rgb(0x000000))
-                                    .child("★ Staff Pick")
-                            ))
-                            .when(is_dl, |el| el.child(
-                                div().absolute().bottom(px(6.0)).right(px(6.0))
-                                    .px_2().py(px(2.0)).rounded_full()
-                                    .bg(gpui::rgb(0x22C55E))
-                                    .text_xs().font_bold().text_color(gpui::rgb(0xFFFFFF))
-                                    .child("↓")
-                            ))
-                            .when(is_anim, |el| el.child(
-                                div().absolute().bottom(px(6.0)).left(px(6.0))
-                                    .px_2().py(px(2.0)).rounded_full()
-                                    .bg(gpui::rgb(0x6366F1))
-                                    .text_xs().font_bold().text_color(gpui::rgb(0xFFFFFF))
-                                    .child("▶")
-                            ))
-                    )
-                    // body
-                    .child(div().p_3().child(v_flex().gap_1()
-                        .child(div().text_sm().font_bold().text_color(fg)
-                            .line_clamp(2).child(name))
-                        .child(div().text_xs().text_color(muted_fg).child(subtitle))
-                        .child(h_flex().gap_3().items_center().mt_1()
-                            .child(div().text_xs().text_color(muted_fg)
-                                .child(format!("👁 {}", views)))
-                            .child(div().text_xs().text_color(muted_fg)
-                                .child(format!("♥ {}", likes)))
-                        )
-                    ))
-                    .into_any_element()
-            }).collect();
+            let item_sizes = Rc::new(
+                (0..total_items).map(|_| size(px(0.0), px(ROW_H))).collect::<Vec<_>>()
+            );
 
             div().relative().flex_1().min_h_0().overflow_hidden()
                 .child(
-                    div().id("results-scroll").size_full()
-                        .overflow_y_scroll()
-                        .track_scroll(&self.results_scroll_handle)
-                        .on_scroll_wheel(cx.listener(|this, _ev: &gpui::ScrollWheelEvent, _window, cx| {
-                            if this.is_loading || this.is_loading_more || this.next_url.is_none() {
-                                return;
+                    v_virtual_list(
+                        entity,
+                        "skfb-results-grid",
+                        item_sizes,
+                        move |view: &mut FabSearchWindow, range, _window, cx| {
+                            let theme = cx.theme().clone();
+                            let fg = theme.foreground;
+                            let muted_fg = theme.muted_foreground;
+                            let card_bg = theme.secondary;
+                            let border_col = theme.border;
+
+                            let total_res = view.results.len();
+                            let res_rows = total_res.div_ceil(COLS);
+                            let s_rows: usize = if view.is_loading_more { 2 } else { 0 };
+
+                            // Near-bottom detection: kick off load_more when
+                            // the visible range reaches the last result row.
+                            if !view.is_loading && !view.is_loading_more
+                                && view.next_url.is_some()
+                                && range.end >= res_rows.saturating_sub(1)
+                            {
+                                view.load_more(cx);
                             }
-                            let max_off = this.results_scroll_handle.max_offset().height;
-                            let cur_off = this.results_scroll_handle.offset().y;
-                            if max_off - cur_off < px(600.0) {
-                                this.load_more(cx);
-                            }
-                        }))
-                        .p_4()
-                        .child(div().flex().flex_wrap().gap_4().children(cards))
-                        .when(is_loading_more, |el| el.child(
-                            div().flex().flex_wrap().gap_4().pt_4()
-                                .children((0..6).map(|i| {
-                                    div()
-                                        .id(SharedString::from(format!("skel-{}", i)))
-                                        .w(px(260.0)).rounded_lg()
-                                        .border_1().border_color(border_col)
-                                        .overflow_hidden().flex().flex_col()
-                                        .child(Skeleton::new().w_full().h(px(146.0)))
-                                        .child(
-                                            div().p_3().child(
-                                                v_flex().gap_2()
+
+                            range.map(|row_idx| -> AnyElement {
+                                if row_idx < res_rows {
+                                    // ── Real card row ─────────────────────
+                                    let start = row_idx * COLS;
+                                    let end = (start + COLS).min(view.results.len());
+                                    let row_cards: Vec<AnyElement> = (start..end).map(|idx| {
+                                        let model = &view.results[idx];
+                                        let name     = model.name.clone();
+                                        let author   = model.user.as_ref().map(|u| u.display().to_string()).unwrap_or_default();
+                                        let category = model.primary_category().map(|s| s.to_string()).unwrap_or_default();
+                                        let subtitle = if category.is_empty() { author } else { format!("{} · {}", author, category) };
+                                        let views    = fmt_count(model.view_count);
+                                        let likes    = fmt_count(model.like_count);
+                                        let is_dl    = model.is_downloadable;
+                                        let is_anim  = model.animation_count > 0;
+                                        let is_sp    = model.staffpicked_at.as_ref().map(|v| !v.is_null()).unwrap_or(false);
+                                        let card_uid = model.uid.clone();
+                                        let thumb_arc = model.thumb_url(260)
+                                            .and_then(|u| view.image_cache.get(u))
+                                            .and_then(|o| o.clone());
+
+                                        div()
+                                            .id(SharedString::from(format!("skfb-card-{}", idx)))
+                                            .cursor_pointer()
+                                            .w(px(260.0)).rounded_lg().bg(card_bg)
+                                            .border_1().border_color(border_col)
+                                            .overflow_hidden().flex().flex_col()
+                                            .on_click(cx.listener(move |this, _, _, cx| {
+                                                this.open_item_detail(card_uid.clone(), cx);
+                                            }))
+                                            .child(
+                                                div().w_full().h(px(146.0)).overflow_hidden().relative()
+                                                    .map(|el| {
+                                                        if let Some(arc) = thumb_arc {
+                                                            el.child(img(gpui::ImageSource::Render(arc))
+                                                                .w_full().h_full().object_fit(gpui::ObjectFit::Cover))
+                                                        } else {
+                                                            el.bg(border_col).flex().items_center().justify_center()
+                                                                .child(div().text_xs().text_color(muted_fg).child(""))
+                                                        }
+                                                    })
+                                                    .when(is_sp, |el| el.child(
+                                                        div().absolute().top(px(6.0)).left(px(6.0))
+                                                            .px_2().py(px(2.0)).rounded_full()
+                                                            .bg(gpui::rgb(0xFACC15))
+                                                            .text_xs().font_bold().text_color(gpui::rgb(0x000000))
+                                                            .child("★ Staff Pick")
+                                                    ))
+                                                    .when(is_dl, |el| el.child(
+                                                        div().absolute().bottom(px(6.0)).right(px(6.0))
+                                                            .px_2().py(px(2.0)).rounded_full()
+                                                            .bg(gpui::rgb(0x22C55E))
+                                                            .text_xs().font_bold().text_color(gpui::rgb(0xFFFFFF))
+                                                            .child("↓")
+                                                    ))
+                                                    .when(is_anim, |el| el.child(
+                                                        div().absolute().bottom(px(6.0)).left(px(6.0))
+                                                            .px_2().py(px(2.0)).rounded_full()
+                                                            .bg(gpui::rgb(0x6366F1))
+                                                            .text_xs().font_bold().text_color(gpui::rgb(0xFFFFFF))
+                                                            .child("▶")
+                                                    ))
+                                            )
+                                            .child(div().p_3().child(v_flex().gap_1()
+                                                .child(div().text_sm().font_bold().text_color(fg).line_clamp(2).child(name))
+                                                .child(div().text_xs().text_color(muted_fg).child(subtitle))
+                                                .child(h_flex().gap_3().items_center().mt_1()
+                                                    .child(div().text_xs().text_color(muted_fg).child(format!("👁 {}", views)))
+                                                    .child(div().text_xs().text_color(muted_fg).child(format!("♥ {}", likes)))
+                                                )
+                                            ))
+                                            .into_any_element()
+                                    }).collect();
+
+                                    h_flex().px_4().py(px(8.0)).gap_4().items_start()
+                                        .children(row_cards)
+                                        .into_any_element()
+
+                                } else if row_idx < res_rows + s_rows {
+                                    // ── Skeleton row ──────────────────────
+                                    h_flex().px_4().py(px(8.0)).gap_4().items_start()
+                                        .children((0..COLS).map(|i| {
+                                            div()
+                                                .id(SharedString::from(format!("skel-{}-{}", row_idx, i)))
+                                                .w(px(260.0)).rounded_lg()
+                                                .border_1().border_color(border_col)
+                                                .overflow_hidden().flex().flex_col()
+                                                .child(Skeleton::new().w_full().h(px(146.0)))
+                                                .child(div().p_3().child(v_flex().gap_2()
                                                     .child(Skeleton::new().w(px(160.0)).h_4())
                                                     .child(Skeleton::new().secondary(true).w(px(100.0)).h_3())
                                                     .child(Skeleton::new().secondary(true).w(px(120.0)).h_3())
-                                            )
-                                        )
-                                }))
-                        ))
-                        .when(!is_loading_more && !has_next && !self.results.is_empty(), |el| el.child(
-                            h_flex().w_full().justify_center().py_3()
-                                .child(div().text_xs().text_color(muted_fg).child("End of results"))
-                        ))
+                                                ))
+                                        }))
+                                        .into_any_element()
+
+                                } else {
+                                    // ── End of results row ────────────────
+                                    h_flex().w_full().px_4().justify_center().py_3()
+                                        .child(div().text_xs().text_color(muted_fg).child("End of results"))
+                                        .into_any_element()
+                                }
+                            }).collect()
+                        },
+                    ).track_scroll(&self.results_scroll_handle)
                 )
                 .child(div().absolute().inset_0()
                     .child(Scrollbar::vertical(&self.results_scroll_state, &self.results_scroll_handle)))
@@ -889,10 +888,7 @@ impl Render for FabSearchWindow {
                     )
             )
             .child(filter_bar)
-            .child(div().flex_1().min_h_0().flex().flex_row()
-                .child(log_panel)
-                .child(body)
-            );
+            .child(body);
 
         div().size_full()
             .child(layout)

--- a/ui-crates/ui_fab_search/src/lib.rs
+++ b/ui-crates/ui_fab_search/src/lib.rs
@@ -126,9 +126,9 @@ pub struct FabSearchWindow {
     // results
     results: Vec<SketchfabModel>,
     next_url: Option<String>,
-    prev_url: Option<String>,
     request_log: Vec<String>,
     is_loading: bool,
+    is_loading_more: bool,
     error: Option<String>,
     last_url: Option<String>,
 
@@ -177,9 +177,9 @@ impl FabSearchWindow {
             show_license_menu: false,
             results: Vec::new(),
             next_url: None,
-            prev_url: None,
             request_log: Vec::new(),
             is_loading: false,
+            is_loading_more: false,
             error: None,
             last_url: None,
             selected_item_uid: None,
@@ -296,18 +296,16 @@ impl FabSearchWindow {
         url
     }
 
-    fn begin_search(&mut self, override_url: Option<String>, cx: &mut Context<Self>) {
+    fn begin_search(&mut self, cx: &mut Context<Self>) {
         if self.search_query.trim().is_empty() { return; }
 
-        let url = override_url.clone().unwrap_or_else(|| self.build_search_url());
+        let url = self.build_search_url();
         self.is_loading = true;
+        self.is_loading_more = false;
         self.results.clear();
+        self.next_url = None;
         self.error = None;
         self.last_url = Some(url.clone());
-        if override_url.is_none() {
-            self.next_url = None;
-            self.prev_url = None;
-        }
         self.request_log.push(format!("GET {}", url));
         cx.notify();
 
@@ -326,11 +324,54 @@ impl FabSearchWindow {
                             Ok(page) => {
                                 view.request_log.push(format!("  ✓ {} model(s)", page.models.len()));
                                 view.next_url = page.next;
-                                view.prev_url = page.prev;
                                 view.results = page.models;
                                 let thumb_urls: Vec<String> = view.results.iter()
                                     .filter_map(|m| m.thumb_url(260).map(|s| s.to_string()))
                                     .collect();
+                                for url in thumb_urls {
+                                    view.ensure_image_loaded(url, cx);
+                                }
+                            }
+                            Err(e) => {
+                                view.request_log.push(format!("  ✗ {}", e));
+                                view.error = Some(e);
+                            }
+                        }
+                        cx.notify();
+                    }).ok();
+                }).ok();
+            }
+        }).detach();
+    }
+
+    fn load_more(&mut self, cx: &mut Context<Self>) {
+        let url = match self.next_url.clone() {
+            Some(u) => u,
+            None => return,
+        };
+        self.is_loading_more = true;
+        self.request_log.push(format!("GET {} (more)", url));
+        cx.notify();
+
+        let (tx, rx) = smol::channel::bounded::<(Vec<String>, Result<SearchPage, String>)>(1);
+        std::thread::spawn(move || {
+            smol::block_on(tx.send(fetch_sketchfab_models(&url))).ok();
+        });
+
+        cx.spawn(async move |this, cx| {
+            if let Ok((log_lines, result)) = rx.recv().await {
+                cx.update(|cx| {
+                    this.update(cx, |view, cx| {
+                        view.is_loading_more = false;
+                        view.request_log.extend(log_lines);
+                        match result {
+                            Ok(page) => {
+                                view.request_log.push(format!("  ✓ {} more model(s)", page.models.len()));
+                                view.next_url = page.next;
+                                let thumb_urls: Vec<String> = page.models.iter()
+                                    .filter_map(|m| m.thumb_url(260).map(|s| s.to_string()))
+                                    .collect();
+                                view.results.extend(page.models);
                                 for url in thumb_urls {
                                     view.ensure_image_loaded(url, cx);
                                 }
@@ -356,11 +397,10 @@ const CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 struct SearchPage {
     models: Vec<SketchfabModel>,
     next: Option<String>,
-    prev: Option<String>,
 }
 
 enum CacheValue {
-    Page { models: Vec<SketchfabModel>, next: Option<String>, prev: Option<String> },
+    Page { models: Vec<SketchfabModel>, next: Option<String> },
     Detail(Box<SketchfabModelDetail>),
 }
 
@@ -437,7 +477,7 @@ fn fetch_sketchfab_models(url: &str) -> (Vec<String>, Result<SearchPage, String>
             .map_err(|e| { logv!("parse: {}", e); format!("Parse error: {e}") })
             .map(|parsed| {
                 logv!("parsed {} models", parsed.results.len());
-                SearchPage { next: parsed.next, prev: parsed.previous, models: parsed.results }
+                SearchPage { next: parsed.next, models: parsed.results }
             });
         (log, result)
     });
@@ -615,9 +655,8 @@ impl Render for FabSearchWindow {
         } else {
             // ── Results grid ──────────────────────────────────────────────
             let next_url = self.next_url.clone();
-            let prev_url = self.prev_url.clone();
             let has_next = next_url.is_some();
-            let has_prev = prev_url.is_some();
+            let is_loading_more = self.is_loading_more;
 
             let cards: Vec<AnyElement> = self.results.iter().enumerate().map(|(idx, model)| {
                 let name     = model.name.clone();
@@ -699,26 +738,25 @@ impl Render for FabSearchWindow {
                     div().id("results-scroll").size_full()
                         .overflow_y_scroll()
                         .track_scroll(&self.results_scroll_handle)
+                        .on_scroll_wheel(cx.listener(|this, _ev: &gpui::ScrollWheelEvent, _window, cx| {
+                            if this.is_loading || this.is_loading_more || this.next_url.is_none() {
+                                return;
+                            }
+                            let max_off = this.results_scroll_handle.max_offset().y;
+                            let cur_off = this.results_scroll_handle.offset().y;
+                            if max_off - cur_off < px(600.0) {
+                                this.load_more(cx);
+                            }
+                        }))
                         .p_4()
                         .child(div().flex().flex_wrap().gap_4().children(cards))
-                        .when(has_prev || has_next, |el| el.child(
-                            h_flex().w_full().justify_center().gap_4().mt_6().mb_2()
-                                .when(has_prev, |el| {
-                                    let pu = prev_url.clone().unwrap();
-                                    el.child(Button::new("prev-page").small().ghost()
-                                        .label("← Prev")
-                                        .on_click(cx.listener(move |this, _, _, cx| {
-                                            this.begin_search(Some(pu.clone()), cx);
-                                        })))
-                                })
-                                .when(has_next, |el| {
-                                    let nu = next_url.clone().unwrap();
-                                    el.child(Button::new("next-page").small()
-                                        .label("Next →")
-                                        .on_click(cx.listener(move |this, _, _, cx| {
-                                            this.begin_search(Some(nu.clone()), cx);
-                                        })))
-                                })
+                        .when(is_loading_more, |el| el.child(
+                            h_flex().w_full().justify_center().py_4()
+                                .child(div().text_xs().text_color(muted_fg).child("Loading more…"))
+                        ))
+                        .when(!is_loading_more && !has_next && !self.results.is_empty(), |el| el.child(
+                            h_flex().w_full().justify_center().py_3()
+                                .child(div().text_xs().text_color(muted_fg).child("End of results"))
                         ))
                 )
                 .child(div().absolute().inset_0()

--- a/ui-crates/ui_fab_search/src/parser.rs
+++ b/ui-crates/ui_fab_search/src/parser.rs
@@ -1,9 +1,12 @@
 //! Serde structs for the Sketchfab REST API v3.
 //!
 //! Endpoints used:
-//!   GET https://api.sketchfab.com/v3/search?type=models   – model search
-//!   GET https://api.sketchfab.com/v3/models/{uid}         – model detail
-//!   GET https://api.sketchfab.com/v3/categories           – category list
+//!   GET  https://api.sketchfab.com/v3/search?type=models   – model search
+//!   GET  https://api.sketchfab.com/v3/models/{uid}          – model detail
+//!   GET  https://api.sketchfab.com/v3/models/{uid}/download – download URLs
+//!   GET  https://api.sketchfab.com/v3/me                    – authenticated profile
+//!   POST https://api.sketchfab.com/v3/me/likes              – like a model
+//!   DELETE https://api.sketchfab.com/v3/me/likes/{uid}      – unlike a model
 
 use serde::{Deserialize, Serialize};
 
@@ -365,8 +368,6 @@ pub fn fmt_count(n: i64) -> String {
     }
 }
 
-use std::cmp::Reverse;
-
 
 /// Top-level API response.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -570,4 +571,54 @@ pub struct FabMedia {
     pub preview_uid: Option<String>,
 }
 
+// ── Download info (GET /v3/models/{uid}/download) ────────────────────────────
+
+/// Response from GET /v3/models/{uid}/download (requires auth).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabDownloadInfo {
+    pub gltf:   Option<SketchfabDownloadFormat>,
+    pub usdz:   Option<SketchfabDownloadFormat>,
+    pub source: Option<SketchfabDownloadFormat>,
+    pub glb:    Option<SketchfabDownloadFormat>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabDownloadFormat {
+    pub url:     String,
+    pub expires: Option<u32>,
+    pub size:    Option<u64>,
+}
+
+// ── Me (authenticated profile, GET /v3/me) ───────────────────────────────────
+
+/// Response from GET /v3/me (requires auth).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SketchfabMe {
+    pub uid:          Option<String>,
+    pub username:     String,
+    pub display_name: Option<String>,
+    pub email:        Option<String>,
+    /// Account plan: "basic", "plus", "pro", "business".
+    pub account:      Option<String>,
+    pub api_token:    Option<String>,
+    pub avatar:       Option<SketchfabAvatar>,
+    #[serde(default)]
+    pub model_count:  i32,
+    #[serde(default)]
+    pub like_count:   i64,
+    pub profile_url:  Option<String>,
+}
+
+impl SketchfabMe {
+    pub fn display(&self) -> &str {
+        self.display_name.as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&self.username)
+    }
+
+    pub fn avatar_url(&self, target_width: u32) -> Option<&str> {
+        self.avatar.as_ref()?.best_image_url(target_width)
+    }
+}
 

--- a/ui-crates/ui_fab_search/src/parser.rs
+++ b/ui-crates/ui_fab_search/src/parser.rs
@@ -1,9 +1,372 @@
-//! Serde structs for deserialising the Fab marketplace search API.
+//! Serde structs for the Sketchfab REST API v3.
 //!
-//! Endpoint: GET https://www.fab.com/i/listings/search
-//! Query params: `q`, `listing_types`, `sort_by`, `cursor`
+//! Endpoints used:
+//!   GET https://api.sketchfab.com/v3/search?type=models   – model search
+//!   GET https://api.sketchfab.com/v3/models/{uid}         – model detail
+//!   GET https://api.sketchfab.com/v3/categories           – category list
 
 use serde::{Deserialize, Serialize};
+
+// ── Pagination ───────────────────────────────────────────────────────────────
+
+/// Paginated search response returned by /v3/search?type=models.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabSearchResponse {
+    #[serde(default)]
+    pub results: Vec<SketchfabModel>,
+    pub next: Option<String>,
+    pub previous: Option<String>,
+    pub cursors: Option<SketchfabCursors>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabCursors {
+    pub next: Option<String>,
+    pub previous: Option<String>,
+}
+
+// ── Model (search list entry) ────────────────────────────────────────────────
+
+/// A model entry as returned by the search endpoint.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SketchfabModel {
+    pub uid: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub viewer_url: String,
+    pub embed_url: Option<String>,
+    #[serde(default)]
+    pub is_downloadable: bool,
+    #[serde(default)]
+    pub animation_count: i32,
+    #[serde(default)]
+    pub like_count: i64,
+    #[serde(default)]
+    pub view_count: i64,
+    pub published_at: Option<String>,
+    pub staffpicked_at: Option<serde_json::Value>,
+    pub thumbnails: Option<SketchfabThumbnails>,
+    pub user: Option<SketchfabUser>,
+    #[serde(default)]
+    pub categories: Vec<SketchfabCategory>,
+    #[serde(default)]
+    pub tags: Vec<SketchfabTag>,
+    /// Either a license slug string or an object with `label`/`slug` fields.
+    pub license: Option<serde_json::Value>,
+    pub archives: Option<SketchfabArchives>,
+}
+
+impl SketchfabModel {
+    /// Best thumbnail URL targeting `target_width` pixels.
+    pub fn thumb_url(&self, target_width: u32) -> Option<&str> {
+        self.thumbnails.as_ref()?.best_image_url(target_width)
+    }
+
+    /// Primary category name.
+    pub fn primary_category(&self) -> Option<&str> {
+        self.categories.first().map(|c| c.name.as_str())
+    }
+
+    /// Display-friendly license label.
+    pub fn license_label(&self) -> Option<String> {
+        license_value_label(self.license.as_ref())
+    }
+}
+
+// ── Model Detail ─────────────────────────────────────────────────────────────
+
+/// Full model detail from GET /v3/models/{uid}.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SketchfabModelDetail {
+    pub uid: String,
+    #[serde(default)]
+    pub name: String,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub viewer_url: String,
+    pub embed_url: Option<String>,
+    pub editor_url: Option<String>,
+    #[serde(default)]
+    pub is_downloadable: bool,
+    #[serde(default)]
+    pub is_age_restricted: bool,
+    #[serde(default)]
+    pub animation_count: i32,
+    #[serde(default)]
+    pub sound_count: i32,
+    #[serde(default)]
+    pub like_count: i64,
+    #[serde(default)]
+    pub view_count: i64,
+    #[serde(default)]
+    pub download_count: i64,
+    #[serde(default)]
+    pub comment_count: i32,
+    pub face_count: Option<i64>,
+    pub vertex_count: Option<i64>,
+    pub material_count: Option<i32>,
+    pub texture_count: Option<i32>,
+    pub pbr_type: Option<String>,
+    pub published_at: Option<String>,
+    pub staffpicked_at: Option<serde_json::Value>,
+    pub thumbnails: Option<SketchfabThumbnails>,
+    pub user: Option<SketchfabUser>,
+    #[serde(default)]
+    pub categories: Vec<SketchfabCategory>,
+    #[serde(default)]
+    pub tags: Vec<SketchfabTag>,
+    pub license: Option<serde_json::Value>,
+    pub archives: Option<SketchfabArchives>,
+    pub status: Option<serde_json::Value>,
+    pub source: Option<String>,
+}
+
+impl SketchfabModelDetail {
+    /// Display-friendly license label.
+    pub fn license_label(&self) -> Option<String> {
+        license_value_label(self.license.as_ref())
+    }
+
+    /// Hero thumbnail URL (largest available).
+    pub fn hero_thumbnail_url(&self) -> Option<&str> {
+        self.thumbnails.as_ref()?.best_image_url(1024)
+    }
+
+    /// All unique thumbnail image URLs sorted by width descending.
+    pub fn all_thumbnail_urls(&self) -> Vec<&str> {
+        let mut images = match self.thumbnails.as_ref() {
+            Some(t) => t.images.iter().collect::<Vec<_>>(),
+            None => return Vec::new(),
+        };
+        images.sort_by_key(|i| std::cmp::Reverse(i.width.unwrap_or(0)));
+        images.dedup_by_key(|i| i.width.unwrap_or(0));
+        images.iter().map(|i| i.url.as_str()).collect()
+    }
+}
+
+fn license_value_label(v: Option<&serde_json::Value>) -> Option<String> {
+    match v? {
+        serde_json::Value::String(s) => Some(license_slug_display(s)),
+        serde_json::Value::Object(o) => {
+            let label = o.get("label")
+                .or_else(|| o.get("fullName"))
+                .or_else(|| o.get("slug"))
+                .or_else(|| o.get("name"))
+                .and_then(|v| v.as_str())?;
+            Some(license_slug_display(label))
+        }
+        _ => None,
+    }
+}
+
+fn license_slug_display(slug: &str) -> String {
+    match slug {
+        "cc0"       => "CC0 (Public Domain)",
+        "by"        => "CC BY",
+        "by-sa"     => "CC BY-SA",
+        "by-nd"     => "CC BY-ND",
+        "by-nc"     => "CC BY-NC",
+        "by-nc-sa"  => "CC BY-NC-SA",
+        "by-nc-nd"  => "CC BY-NC-ND",
+        "ed"        => "Editorial",
+        "st"        => "Standard",
+        _           => slug,
+    }.to_string()
+}
+
+// ── Thumbnails ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabThumbnails {
+    #[serde(default)]
+    pub images: Vec<SketchfabThumbnailImage>,
+}
+
+impl SketchfabThumbnails {
+    /// URL of the image whose width is closest to `target_width`.
+    pub fn best_image_url(&self, target_width: u32) -> Option<&str> {
+        if self.images.is_empty() {
+            return None;
+        }
+        self.images
+            .iter()
+            .min_by_key(|i| i.width.unwrap_or(0).abs_diff(target_width))
+            .map(|i| i.url.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabThumbnailImage {
+    pub url: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub uid: Option<String>,
+    pub size: Option<i64>,
+}
+
+// ── User ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SketchfabUser {
+    pub uid: Option<String>,
+    #[serde(default)]
+    pub username: String,
+    pub display_name: Option<String>,
+    pub profile_url: Option<String>,
+    pub account: Option<String>,
+    pub uri: Option<String>,
+    pub avatar: Option<SketchfabAvatar>,
+}
+
+impl SketchfabUser {
+    /// Returns `displayName` if set and non-empty, otherwise `username`.
+    pub fn display(&self) -> &str {
+        self.display_name
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&self.username)
+    }
+
+    /// Best avatar image URL closest to `target_width`.
+    pub fn avatar_url(&self, target_width: u32) -> Option<&str> {
+        self.avatar.as_ref()?.best_image_url(target_width)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabAvatar {
+    pub uid: Option<String>,
+    pub uri: Option<String>,
+    #[serde(default)]
+    pub images: Vec<SketchfabThumbnailImage>,
+}
+
+impl SketchfabAvatar {
+    pub fn best_image_url(&self, target_width: u32) -> Option<&str> {
+        self.images
+            .iter()
+            .min_by_key(|i| i.width.unwrap_or(0).abs_diff(target_width))
+            .map(|i| i.url.as_str())
+    }
+}
+
+// ── Categories & Tags ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabCategory {
+    pub uid: Option<String>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub slug: String,
+    pub uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabTag {
+    #[serde(default)]
+    pub slug: String,
+    pub uri: Option<String>,
+}
+
+/// Response from GET /v3/categories.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabCategoryResponse {
+    #[serde(default)]
+    pub results: Vec<SketchfabCategory>,
+}
+
+// ── Archives ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SketchfabArchives {
+    pub source: Option<SketchfabArchiveNested>,
+    pub glb: Option<SketchfabArchiveNested>,
+    pub gltf: Option<SketchfabArchiveNested>,
+    pub usdz: Option<SketchfabArchiveNested>,
+}
+
+impl SketchfabArchives {
+    /// Returns list of (label, archive) for all present archive types.
+    pub fn available(&self) -> Vec<(&'static str, &SketchfabArchiveNested)> {
+        let mut out = Vec::new();
+        if let Some(ref a) = self.glb    { out.push(("GLB",    a)); }
+        if let Some(ref a) = self.gltf   { out.push(("glTF",   a)); }
+        if let Some(ref a) = self.usdz   { out.push(("USDZ",   a)); }
+        if let Some(ref a) = self.source { out.push(("Source", a)); }
+        out
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SketchfabArchiveNested {
+    pub face_count: Option<i64>,
+    pub texture_count: Option<i64>,
+    pub size: Option<i64>,
+    pub vertex_count: Option<i64>,
+    pub texture_max_resolution: Option<i64>,
+}
+
+impl SketchfabArchiveNested {
+    /// Human-readable size string (e.g. "12.3 MB").
+    pub fn size_label(&self) -> Option<String> {
+        let bytes = self.size?;
+        if bytes >= 1_000_000 {
+            Some(format!("{:.1} MB", bytes as f64 / 1_000_000.0))
+        } else if bytes >= 1_000 {
+            Some(format!("{:.0} KB", bytes as f64 / 1_000.0))
+        } else {
+            Some(format!("{} B", bytes))
+        }
+    }
+}
+
+// ── Utility ──────────────────────────────────────────────────────────────────
+
+/// Strip HTML tags and decode common HTML entities to plain text.
+pub fn strip_html(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_tag = false;
+    for c in s.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => {
+                in_tag = false;
+                out.push(' ');
+            }
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&nbsp;", " ")
+        .replace("&#39;", "'")
+        .replace("&quot;", "\"")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Format a large integer for display (e.g. 1234567 → "1.2M").
+pub fn fmt_count(n: i64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+use std::cmp::Reverse;
+
 
 /// Top-level API response.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -207,20 +570,4 @@ pub struct FabMedia {
     pub preview_uid: Option<String>,
 }
 
-/// Strip HTML tags from a string, leaving plain text.
-pub fn strip_html(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut in_tag = false;
-    for c in s.chars() {
-        match c {
-            '<' => in_tag = true,
-            '>' => {
-                in_tag = false;
-                out.push(' ');
-            }
-            _ if !in_tag => out.push(c),
-            _ => {}
-        }
-    }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
-}
+

--- a/upstream/sketchfabv3.yaml
+++ b/upstream/sketchfabv3.yaml
@@ -1,0 +1,5567 @@
+info:
+  version: 3.0.0
+  description: >
+    The Sketchfab REST API provide access to read and write Sketchfab data.
+    Users are authentified with their Sketchfab API Token or OAuth2 credentials.
+    Responses are formatted in JSON. Inputs are in JSON unless specified
+    otherwise.
+
+
+    ## How to make authenticated requests
+
+
+    Some endpoints require users to be authenticated. Users can log in with
+    OAuth2 (preferred), or an API Token.
+
+    When an endpoint requires authentication, you need to send an extra HTTP
+    header:
+
+
+    * for OAuth2: `Authorization: Bearer {INSERT_OAUTH_ACCESS_TOKEN_HERE}`
+
+    * for API Token: `Authorization: Token {INSERT_API_TOKEN_HERE}`
+
+
+    Some model endpoints referring to password-protected models require a
+    password encoded in base64 in request header: `x-skfb-model-pwd:
+    {base64(THE_PASSWORD)}`
+
+
+    See the [Sketchfab Login (OAuth2)
+    documentation](https://sketchfab.com/developers/oauth) for more information
+    on authentication.
+
+
+    ## Pagination
+
+
+    When a request gives many results, results are paginated using cursors.
+
+    Each response will contain these fields you can use to make subsequent
+    requests:
+
+
+    * next: full URL containing the next results.
+
+    * previous: full URL containing the previous results.
+
+    * cursors: an object containing the previous and next cursor that you can
+    use to build the URL to the previous/next results.
+
+
+    By default, pages contain 24 items. You can use the `count` parameter to
+    change the number of items per page. This parameter is capped to 24: it will
+    be ignored if a higher value is passed; the default value will be applied
+    instead.
+
+
+    ## Date format
+
+
+    Dates are formatted using the ISO 8601 format.
+
+
+    ## Limits and quotas
+
+
+    Calls to the API can be throttled to limit abuse. When your application is
+    being throttled, it will
+
+    receive a `429 Too Many Requests` response. This means that you must wait
+    before making more requests.
+  title: Sketchfab API
+paths:
+  /v3/orgs/{orgUid}:
+    get:
+      security:
+        - Token: []
+      description: Returns the detail of an organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgDetailResponse"
+      tags:
+        - orgs
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+    patch:
+      description: Returns the detail of an organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      parameters:
+        - description: Updates the organizations biography
+          in: formData
+          maxLength: 256
+          required: false
+          type: string
+          name: biography
+        - description: Updates the organizations city
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: city
+        - description: Updates the organnizations country
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: country
+        - description: Updates the organnizations display name
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: displayName
+        - description: Updates the organnizations twitter username
+          in: formData
+          maxLength: 15
+          required: false
+          type: string
+          name: twitterUsername
+        - description: Updates the organnizations facebook username
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: facebookUsername
+        - description: Updates the organnizations linkedin username
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: linkedinUsername
+        - description: Updates the organnizations tagline
+          in: formData
+          maxLength: 140
+          required: false
+          type: string
+          name: tagline
+        - description: Updates the organnizations website
+          in: formData
+          maxLength: 128
+          required: false
+          type: string
+          name: website
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+      consumes:
+        - multipart/form-data
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgDetailResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+  /v3/me/subscriptions/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: The collection UID
+        in: path
+        name: uid
+    delete:
+      security:
+        - Token: []
+      description: Unsubscribes to a collection.
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "404":
+          description: Not Found
+      tags:
+        - me
+        - collections
+      produces:
+        - application/json
+  /v3/models/{uid}/transfer-to-org:
+    post:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgModelDetailResponse"
+        "400":
+          description: Bad Request. Model cannot be transfered to the org.
+        "401":
+          description: Unauthorized. User token is not valid or missing.
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found. Model does not exist.
+        "429":
+          description: Too many requests. You must wait before making requests again.
+      parameters:
+        - required: true
+          type: string
+          description: The organization UID
+          in: formData
+          name: org
+        - required: true
+          type: string
+          description: The project UID
+          in: formData
+          name: project
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - models
+        - orgs
+      description: Move a model from an individual account to an organization
+    parameters:
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: uid
+  /v3/orgs/{orgUid}/matcaps/{matcapUid}:
+    delete:
+      security:
+        - Token: []
+      description: Deletes a matcap in the given organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - matcaps
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+      - required: true
+        type: string
+        description: The matcap UID
+        in: path
+        name: matcapUid
+    get:
+      security:
+        - Token: []
+      description: Retrieve a matcap in the given organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgMatcapDetail"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - matcaps
+      produces:
+        - application/json
+  /v3/users:
+    get:
+      description: Returns a list of users.
+      tags:
+        - users
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/UserResponse"
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - dateJoined
+            - -dateJoined
+            - followerCount
+            - -followerCount
+            - modelCount
+            - -modelCount
+          in: query
+        - required: false
+          type: string
+          name: account
+          enum:
+            - free
+            - pro
+            - biz
+          in: query
+      produces:
+        - application/json
+  /v3/comments:
+    post:
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "429":
+          description: Too many requests
+      parameters:
+        - required: true
+          type: string
+          description: <a href="#/models" target="_blank">Model</a> (uid) to comment
+          in: formData
+          name: model
+        - description: Sets a body
+          in: formData
+          maxLength: 3000
+          required: true
+          type: string
+          name: body
+      tags:
+        - comments
+      security:
+        - Token: []
+      consumes:
+        - multipart/form-data
+      description: Creates a comment
+    get:
+      tags:
+        - comments
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CommentResponse"
+      parameters:
+        - required: false
+          description: Sorts results
+          in: query
+          enum:
+            - createdAt
+            - -createdAt
+          type: string
+          name: sort_by
+        - required: false
+          type: string
+          description: Retrieves comments of a model (urlid)
+          in: query
+          name: model
+        - required: false
+          type: string
+          description: Retrieves comments of a <a href="#!/users/"
+            target="_blank">user</a> (username)
+          in: query
+          name: user
+      description: Returns a list of comments from public, published models
+  /v3/collections:
+    post:
+      description: Creates a collection.
+      parameters:
+        - description: Sets a name
+          in: formData
+          maxLength: 50
+          required: true
+          type: string
+          name: name
+        - description: Sets a description
+          in: formData
+          maxLength: 1024
+          required: true
+          type: string
+          name: description
+        - description: Sets <a href="#/models" target="_blank">models</a> (uid)
+          items:
+            type: string
+          required: false
+          name: models
+          in: formData
+          maxLength: 1024
+          type: array
+          collectionFormat: multi
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - collections
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CollectionResponse"
+      parameters:
+        - required: false
+          type: string
+          description: Retrieves collections created by <a href="#!/users/"
+            target="_blank">user</a> (username)
+          in: query
+          name: user
+        - description: Retrieves collections by uid
+          in: query
+          items:
+            type: string
+          required: false
+          type: array
+          name: uids
+        - in: query
+          description: Retrieves collections created since a date (ISO 8601 format)
+          format: date
+          required: false
+          type: string
+          name: created_since
+        - required: false
+          type: boolean
+          description: Retrieves restricted collections (off by default)
+          in: query
+          name: restricted
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - createdAt
+            - -createdAt
+            - subscriberCount
+            - -subscriberCount
+          in: query
+      produces:
+        - application/json
+      tags:
+        - collections
+      consumes:
+        - multipart/form-data
+      description: Returns a list of collections
+  /v3/me:
+    get:
+      security:
+        - Token: []
+      description: Returns your profile
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/MeDetail"
+      tags:
+        - me
+        - users
+      produces:
+        - application/json
+    patch:
+      description: Updates your profile.
+      parameters:
+        - required: false
+          type: string
+          description: Updates your password. Needs passwordConfirmation
+          in: formData
+          name: password
+        - required: false
+          type: string
+          name: passwordConfirmation
+          in: formData
+        - description: Updates your <a href="#/skills" target="_blank">skills</a> (uid)
+          name: skills
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - description: Updates your display name
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: displayName
+        - description: Updates your twitter username
+          in: formData
+          maxLength: 15
+          required: false
+          type: string
+          name: twitterUsername
+        - description: Updates your facebook username
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: facebookUsername
+        - description: Updates your linkedin username
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: linkedinUsername
+        - description: Updates your bio
+          in: formData
+          maxLength: 256
+          required: false
+          type: string
+          name: biography
+        - description: Updates your tagline
+          in: formData
+          maxLength: 140
+          required: false
+          type: string
+          name: tagline
+        - description: Updates your website
+          in: formData
+          maxLength: 128
+          required: false
+          type: string
+          name: website
+        - description: Updates your city
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: city
+        - description: Updates your country
+          in: formData
+          maxLength: 50
+          required: false
+          type: string
+          name: country
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - users
+      consumes:
+        - multipart/form-data
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+  /v3/orgs/{orgUid}/backgrounds:
+    post:
+      description: Creates a new background in the given organization. Can take either
+        the organization UID (orgUid) or name preceded by a @ (@orgName).
+      parameters:
+        - required: true
+          type: file
+          description: JPG or PNG image. Max 4mb
+          in: formData
+          name: image
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - backgrounds
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgBackgroundListResponse"
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - createdAt
+            - -createdAt
+          in: query
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - backgrounds
+      description: Returns a list of backgrounds from the given organization. Can take
+        either the organization UID (orgUid) or name preceded by a @ (@orgName).
+  /v3/models/{uid}:
+    put:
+      description: Reuploads a model. Accepts multipart/form-data only.
+      parameters:
+        - description: Sets a name
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: name
+        - required: false
+          type: boolean
+          description: Sets private (requires a pro plan or higher)
+          in: formData
+          name: private
+        - description: Enables 2D view in model inspector. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isInspectable
+        - description: Whether the model has restricted content.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isAgeRestricted
+        - description: Sets a password (requires a pro plan or higher)
+          in: formData
+          maxLength: 64
+          required: false
+          type: string
+          name: password
+        - in: formData
+          description: |
+            Sets a <a href=#!/licenses/ target='_blank'>license</a> (label). This makes the model downloadable to others. All <a href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable models must have isInspectable enabled</a>.
+          format: test
+          required: false
+          type: string
+          name: license
+        - description: Sets <a href=#!/tags/ target='_blank'>tags</a> (slug)
+          name: tags
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - description: Sets <a href=#!/categories/ target='_blank'>categories</a> (slug)
+          name: categories
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - description: Enables AR for a model (requires a premium plan or higher)
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isArEnabled
+        - description: Sets published after it is processed
+          in: formData
+          default: true
+          required: false
+          type: boolean
+          name: isPublished
+        - description: Sets a description
+          in: formData
+          maxLength: 1024
+          required: false
+          type: string
+          name: description
+        - required: true
+          type: file
+          description: Model archive. Max 50mb for basic users, 200mb for pro users, 500mb
+            for biz users
+          in: formData
+          name: modelFile
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - models
+      consumes:
+        - multipart/form-data
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+    get:
+      description: Returns the detail of a model
+      tags:
+        - models
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/ModelDetail"
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      parameters:
+        - required: false
+          type: string
+          description: Password when the model is password-protected
+          in: header
+          name: x-skfb-model-pwd
+      produces:
+        - application/json
+    patch:
+      description: Updates model information.
+      parameters:
+        - description: Sets a name
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: name
+        - required: false
+          type: boolean
+          description: Sets private (requires a pro plan or higher)
+          in: formData
+          name: private
+        - description: Enables 2D view in model inspector. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isInspectable
+        - description: Whether the model has restricted content.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isAgeRestricted
+        - description: Sets a password (requires a pro plan or higher)
+          in: formData
+          maxLength: 64
+          required: false
+          type: string
+          name: password
+        - in: formData
+          description: |
+            Sets a <a href=#!/licenses/ target='_blank'>license</a> (slug). This makes the model downloadable to others. All <a href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable models must have isInspectable enabled</a>.
+          format: test
+          required: false
+          type: string
+          name: license
+        - description: Sets <a href=#!/tags/ target='_blank'>tags</a> (slug)
+          name: tags
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - description: Sets <a href=#!/categories/ target='_blank'>categories</a> (slug)
+          name: categories
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - description: Enables AR for a model (requires a premium plan or higher)
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isArEnabled
+        - description: Sets published after it is processed
+          in: formData
+          default: true
+          required: false
+          type: boolean
+          name: isPublished
+        - description: Disables public comments for the model
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: hasCommentsDisabled
+        - description: Sets a description
+          in: formData
+          maxLength: 1024
+          required: false
+          type: string
+          name: description
+        - required: false
+          type: integer
+          description: Sets a price. Your model must have either standard or editorial
+            license.
+          in: formData
+          name: price
+        - required: false
+          type: string
+          description: Sets <a href=#!/models/patch_v3_models_uid_options
+            target='_blank'>options</a>
+          in: formData
+          name: options
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - models
+      consumes:
+        - multipart/form-data
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+    parameters:
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: uid
+    delete:
+      security:
+        - Token: []
+      tags:
+        - models
+      responses:
+        "204":
+          description: No Content
+      description: Deletes one of your models
+  /v3/me/environments:
+    post:
+      description: Creates an environment (pro only). Accepts multipart/form-data only.
+      parameters:
+        - description: Sets a name
+          in: formData
+          maxLength: 64
+          required: true
+          type: string
+          name: name
+        - required: true
+          type: file
+          name: environmentFile
+          in: formData
+      produces:
+        - aplication/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - environments
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+    get:
+      security:
+        - Token: []
+      description: Returns available environments for your models.
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/EnvironmentResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+      tags:
+        - me
+        - environments
+      produces:
+        - application/json
+  /v3/users/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: The user UID
+        in: path
+        name: uid
+    get:
+      description: Returns the detail of a user.
+      tags:
+        - users
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/UserDetail"
+        "404":
+          description: Not Found
+      produces:
+        - application/json
+  /v3/me/backgrounds:
+    post:
+      description: Creates a new background (requires a pro plan or higher). Accepts
+        multipart/form-data only.
+      parameters:
+        - required: true
+          type: file
+          description: JPG or PNG image. Max 4mb
+          in: formData
+          name: image
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - backgrounds
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/BackgroundResponse"
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - createdAt
+            - -createdAt
+          in: query
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - backgrounds
+      description: Returns available backgrounds for your models
+  /v3/models/{uid}/options:
+    parameters:
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: uid
+    patch:
+      responses:
+        "204":
+          description: No-Content
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+      parameters:
+        - required: false
+          description: Defines the shading type
+          in: formData
+          enum:
+            - lit
+            - shadeless
+          type: string
+          name: shading
+        - required: false
+          type: string
+          description: >
+            Defines the background used. Either a color, a <a
+            href="#/backgrounds" target="_blank">background</a> (uid), an <a
+            href="#/environment" target="_blank">environment</a> (uid) or
+            transparent.
+
+            eg: {"color": "#ffffff"}, {"environment": "uid"}, {"image": "uid"}
+            or {"transparent": 1}
+          in: formData
+          name: background
+        - required: false
+          type: string
+          description: >
+            Either a 4x4 matrix or an angle with an axis.
+
+            eg: {"axis": [1, 1, 0], "angle": 34} or {"matrix": [0.1, 0.2, 0.3
+            ... ], "axis": [1, 1, 0], "angle": 34.42}
+          in: formData
+          name: orientation
+      produces:
+        - application/json
+      tags:
+        - models
+      consumes:
+        - multipart/form-data
+      description: Updates the 3D options of a model
+  /v3/tags/{slug}:
+    parameters:
+      - required: true
+        type: string
+        description: The tag slug
+        in: path
+        name: slug
+    get:
+      tags:
+        - tags
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/TagRelated"
+      description: Returns the detail of a tag
+  /v3/me/subscriptions:
+    post:
+      description: Subscribes to a collection.
+      parameters:
+        - required: true
+          type: string
+          description: The <a href="#/collections" target="_blank">collection</a> (uid) to
+            subscribe to
+          in: formData
+          name: collection
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - collections
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+    get:
+      security:
+        - Token: []
+      description: Returns collections you subscribed to.
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CollectionResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+      tags:
+        - me
+        - collections
+      produces:
+        - application/json
+  /v3/orgs/{orgUid}/environments/{environmentUid}:
+    patch:
+      description: Updates an environment in the given organization. Can take either
+        the organization UID (orgUid) or name preceded by a @ (@orgName).
+      parameters:
+        - description: Updates the name
+          in: formData
+          maxLength: 64
+          required: true
+          type: string
+          name: name
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - environments
+      consumes:
+        - multipart/form-data
+      responses:
+        "204":
+          description: No Content
+    delete:
+      security:
+        - Token: []
+      description: Deletes an environment in the given organization. Can take either
+        the organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - environments
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+      - required: true
+        type: string
+        description: The environment UID
+        in: path
+        name: environmentUid
+    get:
+      security:
+        - Token: []
+      description: Retrieve an environment in the given organization. Can take either
+        the organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgEnvironmentDetail"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - environments
+      produces:
+        - application/json
+  /v3/collections/{uid}:
+    get:
+      description: Returns the detail of a collection
+      tags:
+        - collections
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CollectionDetail"
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The collection UID
+        in: path
+        name: uid
+    patch:
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+      parameters:
+        - description: Updates the name
+          in: formData
+          maxLength: 50
+          required: true
+          type: string
+          name: name
+        - description: Updates the description
+          in: formData
+          maxLength: 1024
+          required: false
+          type: string
+          name: description
+        - description: Sets <a href="#/models" target="_blank">models</a> (uid)
+          items:
+            type: string
+          required: false
+          name: models
+          in: formData
+          maxLength: 1024
+          type: array
+          collectionFormat: multi
+      produces:
+        - application/json
+      tags:
+        - collections
+      consumes:
+        - multipart/form-data
+      description: Updates a collection
+  /v3/comments/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: The comment UID
+        in: path
+        name: uid
+    delete:
+      security:
+        - Token: []
+      tags:
+        - comments
+      responses:
+        "204":
+          description: No Content
+      description: Deletes one of your comments
+  /v3/me/likes:
+    post:
+      description: Likes a model
+      parameters:
+        - required: true
+          type: string
+          description: <a href="#/models" target="_blank">Model</a> (uid) to like
+          in: formData
+          name: model
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - models
+        - likes
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+    get:
+      security:
+        - Token: []
+      tags:
+        - me
+        - models
+        - likes
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/LikeModelResponse"
+      parameters:
+        - required: false
+          description: Sorts results.
+          in: query
+          enum:
+            - likedAt
+            - -likedAt
+          type: string
+          name: sort_by
+      produces:
+        - application/json
+  /v3/licenses:
+    get:
+      description: Returns a list of licenses
+      tags:
+        - licenses
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/LicensesResponse"
+      produces:
+        - application/json
+  /v3/models:
+    post:
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+      parameters:
+        - description: Sets a name
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: name
+        - required: false
+          type: boolean
+          description: Sets private (requires a pro plan or higher)
+          in: formData
+          name: private
+        - description: Enables 2D view in model inspector. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isInspectable
+        - description: Sets a password (requires a pro plan or higher)
+          in: formData
+          maxLength: 64
+          required: false
+          type: string
+          name: password
+        - in: formData
+          description: Sets a <a href=#!/licenses/ target='_blank'>license</a> (slug).
+            This makes the model downloadable to others. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          format: test
+          required: false
+          type: string
+          name: license
+        - description: Sets <a href=#!/tags/ target='_blank'>tags</a> (slug)
+          name: tags
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - description: Sets <a href=#!/categories/ target='_blank'>categories</a> (slug)
+          name: categories
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - description: Enables AR for a model (requires a premium plan or higher)
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isArEnabled
+        - description: Sets published after it is processed
+          in: formData
+          default: true
+          required: false
+          type: boolean
+          name: isPublished
+        - description: Sets a description
+          in: formData
+          maxLength: 1024
+          required: false
+          type: string
+          name: description
+        - required: true
+          type: file
+          description: Model archive. Max 50mb for basic users, 200mb for pro users, 500mb
+            for biz users
+          in: formData
+          name: modelFile
+        - required: false
+          type: string
+          description: Sets <a href=#!/models/patch_v3_models_uid_options
+            target='_blank'>options</a> after it is processed
+          in: formData
+          name: options
+      tags:
+        - models
+      security:
+        - Token: []
+      consumes:
+        - multipart/form-data
+      description: Uploads a new model. Accepts multipart/form-data only.
+    get:
+      description: Returns a public, published list of models.
+      tags:
+        - models
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/ModelResponse"
+      parameters:
+        - required: false
+          description: Sorts results (likedAt is only usable with liked_by).
+          in: query
+          enum:
+            - createdAt
+            - -createdAt
+            - viewCount
+            - -viewCount
+            - likedAt
+            - -likedAt
+          type: string
+          name: sort_by
+        - required: false
+          type: string
+          description: Retrieves models filtered by a <a href="#!/users/"
+            target="_blank">user</a> (username)
+          in: query
+          name: user
+        - description: Retrieves models filtered by <a href="#!/tags/"
+            target="_blank">tags</a> (slug)
+          name: tags
+          in: query
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - description: Retrieves models filtered by <a
+            href=#!/categories/get_v3_categories target='_blank'>categories</a>
+            (uid)
+          name: categories
+          in: query
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - required: false
+          type: string
+          description: Retrieves models liked by a <a href="#!/users/"
+            target="_blank">user</a> (username). This can't be used with other
+            filters.
+          in: query
+          name: liked_by
+        - required: false
+          type: integer
+          name: max_face_count
+          in: query
+        - required: false
+          type: integer
+          name: max_vertex_count
+          in: query
+        - in: query
+          description: Retrieves the models published after published_since (ISO 8601
+            format)
+          format: date
+          required: false
+          type: string
+          name: published_since
+        - required: false
+          type: boolean
+          description: Retrieves staffpicked models
+          in: query
+          name: staffpicked
+        - required: false
+          type: boolean
+          description: Retrieves downloadable models
+          in: query
+          name: downloadable
+        - required: false
+          type: boolean
+          description: Retrieves animated models
+          in: query
+          name: animated
+        - required: false
+          type: boolean
+          description: Retrieves models with sound
+          in: query
+          name: has_sound
+        - required: false
+          type: boolean
+          description: Retrieves age restricted models (off by default)
+          in: query
+          name: restricted
+        - $ref: "#/parameters/archivesFlavoursFilter"
+        - $ref: "#/parameters/searchParamAvailableArchiveType"
+        - $ref: "#/parameters/searchParamArchivesMaxSize"
+        - $ref: "#/parameters/searchParamArchivesMaxFaceCount"
+        - $ref: "#/parameters/searchParamArchivesMaxVertexCount"
+        - $ref: "#/parameters/searchParamArchivesMaxTextureCount"
+        - $ref: "#/parameters/searchParamArchivesTextureMaxResolution"
+      produces:
+        - application/json
+  /v3/me/account:
+    get:
+      security:
+        - Token: []
+      description: Returns account information of the logged user
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/MeAccount"
+      tags:
+        - users
+      produces:
+        - application/json
+  /v3/orgs/{orgUid}/environments:
+    post:
+      description: Creates a new environment in the given organization. Can take
+        either the organization UID (orgUid) or name preceded by a @ (@orgName).
+      parameters:
+        - description: Sets a name
+          in: formData
+          maxLength: 64
+          required: true
+          type: string
+          name: name
+        - required: true
+          type: file
+          name: environmentFile
+          in: formData
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - environments
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgEnvironmentListResponse"
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - createdAt
+            - -createdAt
+          in: query
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - environments
+      description: Returns a list of environments from the given organization. Can
+        take either the organization UID (orgUid) or name preceded by a @
+        (@orgName).
+  /v3/orgs/{orgUid}/tags:
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgTagsListResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      parameters:
+        - required: false
+          description: Sorts projects by this param.
+          in: query
+          enum:
+            - createdAt
+            - -createdAt
+          type: string
+          name: sort_by
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - tags
+      description: Returns a list of tags used by the given organization. Can take
+        either the organization UID (orgUid) or name preceded by a @ (@orgName).
+  /v3/categories/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: The category UID
+        in: path
+        name: uid
+    get:
+      description: Return the details of a category
+      tags:
+        - categories
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CategoriesRelated"
+      produces:
+        - application/json
+  /v3/skills:
+    get:
+      description: Returns the list of skills
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/SkillsResponse"
+      produces:
+        - application/json
+  /v3/me/models/purchases:
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/MeModelResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+      parameters:
+        - required: false
+          type: string
+          description: Space separated keywords.
+          in: query
+          name: q
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - models
+        - purchases
+      description: Returns the list of models you bought on sketchfab's store
+  /v3/collections/{uid}/models:
+    post:
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not found
+      parameters:
+        - description: Adds <a href="#/models" target="_blank">models</a> (uid)
+          items:
+            type: string
+          required: false
+          name: models
+          in: formData
+          maxLength: 1024
+          type: array
+          collectionFormat: multi
+      produces:
+        - application/json
+      tags:
+        - collections
+        - models
+      consumes:
+        - multipart/form-data
+      description: Adds models to a collection.
+    get:
+      description: Returns a list of models for a collection
+      tags:
+        - collections
+        - models
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CollectionModelResponse"
+        "404":
+          description: Not found
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - createdAt
+            - -createdAt
+            - collectedAt
+            - -collectedAt
+          in: query
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The collection UID
+        in: path
+        name: uid
+    delete:
+      responses:
+        "204":
+          description: Success
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not found
+      parameters:
+        - description: Removes <a href="#/models" target="_blank">models</a> (uid)
+          name: models
+          in: query
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+      produces:
+        - application/json
+      tags:
+        - collections
+        - models
+      consumes:
+        - multipart/form-data
+      description: Removes models from a collection
+  /v3/users/{uid}/followings:
+    parameters:
+      - required: true
+        type: string
+        description: The user UID
+        in: path
+        name: uid
+    get:
+      description: Returns users followed by a user.
+      tags:
+        - users
+        - relationships
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/UserResponse"
+        "404":
+          description: Not Found
+      produces:
+        - application/json
+  /v3/models/{uid}/download:
+    parameters:
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: uid
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/ModelDownload"
+        "400":
+          description: Bad Request. Model is not downloadable.
+        "401":
+          description: Unauthorized. User token is not valid or missing.
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found. Model does not exist.
+        "429":
+          description: Too many requests. You must wait before making requests again.
+      parameters:
+        - required: false
+          type: string
+          description: Model password when the model is password-protected
+          in: header
+          name: x-skfb-model-pwd
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - models
+      description: Returns download information for downloadable models
+  /v3/me/orgs:
+    get:
+      security:
+        - Token: []
+      description: Returns the list of orgs the current user belongs to
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/MeOrgs"
+      tags:
+        - users
+        - orgs
+      produces:
+        - application/json
+  /v3/search?type=collections:
+    get:
+      tags:
+        - search
+        - collections
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CollectionSearchResponse"
+      parameters:
+        - required: false
+          type: string
+          name: q
+          in: query
+        - required: false
+          type: string
+          description: Searches collections by <a href="#!/users/"
+            target="_blank">user</a> (username)
+          in: query
+          name: user
+        - required: false
+          description: Limit search to a specific period only (in days)
+          in: query
+          enum:
+            - 1
+            - 7
+            - 31
+          type: integer
+          name: date
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - createdAt
+            - -createdAt
+            - modelCount
+            - subscriberCount
+          in: query
+      description: Search in collections
+  /v3/orgs/{orgUid}/models/{modelUid}/options:
+    parameters:
+      - required: true
+        type: string
+        description: TThe organization UID
+        in: path
+        name: orgUid
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: modelUid
+    patch:
+      description: Updates the 3D options of a model. Can take either the organization
+        UID (orgUid) or name preceded by a @ (@orgName).
+      parameters:
+        - required: false
+          description: Defines the shading type
+          in: formData
+          enum:
+            - lit
+            - shadeless
+          type: string
+          name: shading
+        - required: false
+          type: string
+          description: >
+            Defines the background used. Either a color, a <a
+            href="#/backgrounds" target="_blank">background</a> (uid), an <a
+            href="#/environment" target="_blank">environment</a> (uid) or
+            transparent.
+
+            eg: {"color": "#ffffff"}, {"environment": "uid"}, {"image": "uid"}
+            or {"transparent": 1}
+          in: formData
+          name: background
+        - required: false
+          type: string
+          description: >
+            Either a 4x4 matrix or an angle with an axis.
+
+            eg: {"axis": [1, 1, 0], "angle": 34} or {"matrix": [0.1, 0.2, 0.3
+            ... ], "axis": [1, 1, 0], "angle": 34.42}
+          in: formData
+          name: orientation
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+      consumes:
+        - multipart/form-data
+      responses:
+        "204":
+          description: No-Content
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+  /v3/me/matcaps:
+    post:
+      description: Creates a new matcap
+      parameters:
+        - required: true
+          type: file
+          description: JPG or PNG image. Max 4mb
+          in: formData
+          name: image
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - matcaps
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/MatcapsList"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - createdAt
+            - -createdAt
+          in: query
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - matcaps
+      description: Returns a list of matcaps for your models
+  /v3/avatars/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: The avatar UID
+        in: path
+        name: uid
+    get:
+      description: Returns a user avatar
+      tags:
+        - avatars
+        - users
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/AvatarRelated"
+      produces:
+        - application/json
+  /v3/me/environments/{uid}:
+    patch:
+      description: Updates an environment (requires a pro plan or higher).
+      parameters:
+        - description: Updates the name
+          in: formData
+          maxLength: 64
+          required: true
+          type: string
+          name: name
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - environments
+      consumes:
+        - multipart/form-data
+      responses:
+        "204":
+          description: No Content
+    parameters:
+      - required: true
+        type: string
+        description: The environment UID
+        in: path
+        name: uid
+    delete:
+      security:
+        - Token: []
+      description: Deletes an environment (requires a pro plan or higher)
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+      tags:
+        - me
+        - environments
+      produces:
+        - application/json
+  /v3/skills/{slug}:
+    parameters:
+      - required: true
+        type: string
+        description: The skill slug
+        in: path
+        name: slug
+    get:
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/SkillDetail"
+      description: Returns the detail of a skill
+  /v3/orgs/{orgUid}/matcaps:
+    post:
+      description: Creates a new matcap in the given organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      parameters:
+        - required: true
+          type: file
+          description: JPG or PNG image. Max 4mb
+          in: formData
+          name: image
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - matcaps
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          headers:
+            Location:
+              type: string
+          description: Created
+          schema:
+            $ref: "#/definitions/CreateResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgMatcapsListResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - createdAt
+            - -createdAt
+          in: query
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - matcaps
+      description: Returns a list of matcaps from the given organization. Can take
+        either the organization UID (orgUid) or name preceded by a @ (@orgName).
+  /v3/users/{uid}/followers:
+    parameters:
+      - required: true
+        type: string
+        description: The user UID
+        in: path
+        name: uid
+    get:
+      description: Returns the followers of a user.
+      tags:
+        - users
+        - relationships
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/UserResponse"
+        "404":
+          description: Not Found
+      produces:
+        - application/json
+  /v3/me/search?type=models:
+    get:
+      description: Search and filters in your own models
+      tags:
+        - me
+        - models
+      responses:
+        "200":
+          description: Models matching the search
+          schema:
+            $ref: "#/definitions/ModelSearchResponse"
+      parameters:
+        - $ref: "#/parameters/searchParamQ"
+        - $ref: "#/parameters/searchParamTags"
+        - $ref: "#/parameters/searchParamCategories"
+        - $ref: "#/parameters/searchParamProcessingStatus"
+        - $ref: "#/parameters/searchParamDate"
+        - $ref: "#/parameters/searchParamDownloadable"
+        - $ref: "#/parameters/searchParamAnimated"
+        - $ref: "#/parameters/searchParamStaffpicked"
+        - $ref: "#/parameters/searchParamSound"
+        - $ref: "#/parameters/searchParamMinFaceCount"
+        - $ref: "#/parameters/searchParamMaxFaceCount"
+        - $ref: "#/parameters/searchParamPbrType"
+        - $ref: "#/parameters/searchParamRigged"
+        - $ref: "#/parameters/searchParamCollection"
+        - $ref: "#/parameters/searchParamSortBy"
+        - $ref: "#/parameters/searchParamFileFormat"
+        - $ref: "#/parameters/searchParamLicense"
+        - $ref: "#/parameters/searchParamMaxUvLayerCount"
+        - $ref: "#/parameters/searchParamMaxFilesizes"
+        - $ref: "#/parameters/archivesFlavoursFilter"
+      consumes:
+        - multipart/form-data
+  /v3/orgs/{orgUid}/backgrounds/{backgroundUid}:
+    delete:
+      security:
+        - Token: []
+      description: Deletes a background in the given organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - backgrounds
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+      - required: true
+        type: string
+        description: The background UID
+        in: path
+        name: backgroundUid
+    get:
+      security:
+        - Token: []
+      description: Retrieve a background in the given organization. Can take either
+        the organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgBackgroundDetail"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - backgrounds
+      produces:
+        - application/json
+  /v3/me/followings/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: The user UID
+        in: path
+        name: uid
+    delete:
+      security:
+        - Token: []
+      description: Un-follows a user.
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+      tags:
+        - me
+        - users
+        - relationships
+      produces:
+        - application/json
+  /v3/models/{uid}/archives/extra/latest:
+    get:
+      security:
+        - Token: []
+      description: Retrieve a model's extra archive.
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/ArchiveExtra"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - models
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: uid
+    delete:
+      security:
+        - Token: []
+      description: Delete a model's extra archive, only for orgs and users with a paid plan.
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - models
+      produces:
+        - application/json
+  /v3/search?type=models:
+    get:
+      description: Search and filters in models
+      tags:
+        - search
+        - models
+      responses:
+        "200":
+          description: Models matching the search
+          schema:
+            $ref: "#/definitions/ModelSearchResponse"
+      parameters:
+        - $ref: "#/parameters/searchParamQ"
+        - $ref: "#/parameters/searchParamUser"
+        - $ref: "#/parameters/searchParamTags"
+        - $ref: "#/parameters/searchParamCategories"
+        - $ref: "#/parameters/searchParamDate"
+        - $ref: "#/parameters/searchParamDownloadable"
+        - $ref: "#/parameters/searchParamAnimated"
+        - $ref: "#/parameters/searchParamStaffpicked"
+        - $ref: "#/parameters/searchParamSound"
+        - $ref: "#/parameters/searchParamMinFaceCount"
+        - $ref: "#/parameters/searchParamMaxFaceCount"
+        - $ref: "#/parameters/searchParamPbrType"
+        - $ref: "#/parameters/searchParamRigged"
+        - $ref: "#/parameters/searchParamCollection"
+        - $ref: "#/parameters/searchParamSortBy"
+        - $ref: "#/parameters/searchParamFileFormat"
+        - $ref: "#/parameters/searchParamLicense"
+        - $ref: "#/parameters/searchParamMaxUvLayerCount"
+        - $ref: "#/parameters/searchParamAvailableArchiveType"
+        - $ref: "#/parameters/searchParamArchivesMaxSize"
+        - $ref: "#/parameters/searchParamArchivesMaxFaceCount"
+        - $ref: "#/parameters/searchParamArchivesMaxVertexCount"
+        - $ref: "#/parameters/searchParamArchivesMaxTextureCount"
+        - $ref: "#/parameters/searchParamArchivesTextureMaxResolution"
+        - $ref: "#/parameters/archivesFlavoursFilter"
+        - required: false
+          description: "DEPRECATED: This filter will have no impact on the returned results"
+          in: query
+          items:
+            type: string
+          enum:
+            - pending
+            - processing
+            - succeeded
+            - failed
+          type: string
+          name: processing_status
+      consumes:
+        - multipart/form-data
+  /v3/me/collections:
+    get:
+      security:
+        - Token: []
+      description: Returns a list of your collections
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CollectionResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+      tags:
+        - me
+        - collections
+      produces:
+        - application/json
+  /v3/orgs/{orgUid}/models/{modelUid}:
+    put:
+      description: Reuploads an organization model. Can take either the organization
+        UID (orgUid) or name preceded by a @ (@orgName).
+      parameters:
+        - description: Sets a model name
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: name
+        - description: Define the organization project you want to upload to
+          in: formData
+          maxLength: 48
+          required: true
+          type: string
+          name: orgProject
+        - description: Define the upload source
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: source
+        - required: false
+          name: visibility
+          in: formData
+          default: org
+          enum:
+            - public
+            - private
+            - protected
+            - org
+          type: string
+          description: Sets the model visibility
+        - description: Enables 2D view in model inspector. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isInspectable
+        - in: formData
+          type: string
+          description: Sets a password. This option can only be used when visibility is
+            protected.
+          name: password
+          maxLength: 64
+        - required: false
+          type: string
+          description: Sets a <a href=#!/licenses/ target='_blank'>license</a> (slug).
+            This makes the model downloadable to others. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          name: license
+        - name: tags
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+          description: Sets <a href=#!/tags/ target='_blank'>tags</a> (slug)
+        - name: categories
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+          description: Sets <a href=#!/categories/ target='_blank'>categories</a> (slug).
+            Two categories max for a model.
+        - description: Sets the model description
+          in: formData
+          maxLength: 1024
+          required: false
+          type: string
+          name: description
+        - required: true
+          type: file
+          description: Archive of the model to be processed.
+          in: formData
+          name: modelFile
+        - required: false
+          type: string
+          description: Sets <a href=#!/models/patch_v3_models_uid_options
+            target='_blank'>options</a> after it is processed
+          in: formData
+          name: options
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - models
+      consumes:
+        - multipart/form-data
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgModelDetailResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgModelDetailResponse"
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      parameters:
+        - required: false
+          type: string
+          description: Password when the model is password-protected
+          in: header
+          name: x-skfb-model-pwd
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - models
+      description: Returns the detail of an organization model. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+    patch:
+      description: Updates organization model information. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      parameters:
+        - description: Sets a model name
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: name
+        - description: Define the organization project you want to upload to
+          in: formData
+          maxLength: 48
+          required: true
+          type: string
+          name: orgProject
+        - description: Define the upload source
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: source
+        - required: false
+          name: visibility
+          in: formData
+          default: org
+          enum:
+            - public
+            - private
+            - protected
+            - org
+          type: string
+          description: Sets the model visibility
+        - description: Enables 2D view in model inspector. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isInspectable
+        - description: Whether the model has restricted content.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isAgeRestricted
+        - in: formData
+          type: string
+          description: Sets a password. This option can only be used when visibility is
+            protected.
+          name: password
+          maxLength: 64
+        - required: false
+          type: string
+          description: Sets a <a href=#!/licenses/ target='_blank'>license</a> (slug).
+            This makes the model downloadable to others. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          name: license
+        - name: tags
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+          description: Sets <a href=#!/tags/ target='_blank'>tags</a> (slug)
+        - name: categories
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+          description: Sets <a href=#!/categories/ target='_blank'>categories</a> (slug).
+            Two categories max for a model.
+        - description: Sets the model description
+          in: formData
+          maxLength: 1024
+          required: false
+          type: string
+          name: description
+        - required: true
+          type: file
+          description: Archive of the model to be processed.
+          in: formData
+          name: modelFile
+        - required: false
+          type: string
+          description: Sets <a href=#!/models/patch_v3_models_uid_options
+            target='_blank'>options</a> after it is processed
+          in: formData
+          name: options
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - models
+      consumes:
+        - multipart/form-data
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgModelDetailResponse"
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: modelUid
+    delete:
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - models
+      responses:
+        "204":
+          description: No Content
+      description: Deletes an organization model. Can take either the organization UID
+        (orgUid) or name preceded by a @ (@orgName).
+  /v3/search:
+    get:
+      tags:
+        - search
+        - models
+        - users
+        - collections
+      responses:
+        "200":
+          description: Models, collections, users matching the search
+          schema:
+            $ref: "#/definitions/GlobalSearchResponse"
+      parameters:
+        - required: false
+          type: string
+          description: Space separated keywords.
+          in: query
+          name: q
+      description: Search in models, collections, users
+  /v3/orgs/{orgUid}/projects:
+    post:
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: "#/definitions/OrgProjectListResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      parameters:
+        - required: true
+          type: string
+          name: name
+          in: query
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - projects
+      description: Creates projects within the given organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgProjectListResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      parameters:
+        - $ref: "#/parameters/queryFilter"
+        - required: false
+          description: Sorts projects by this param.
+          in: query
+          enum:
+            - name
+            - updatedAt
+          type: string
+          name: sort_by
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - projects
+      description: Returns a list of projects from the given organization. Can take
+        either the organization UID (orgUid) or name preceded by a @ (@orgName).
+  /v3/licences/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: The license UID
+        in: path
+        name: uid
+    get:
+      description: Returns the detail of a license.
+      tags:
+        - licenses
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/LicensesDetail"
+        "404":
+          description: Not Found
+      produces:
+        - application/json
+  /v3/me/backgrounds/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: The background UID
+        in: path
+        name: uid
+    delete:
+      security:
+        - Token: []
+      description: Deletes a background (requires a pro plan or higher)
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - me
+        - backgrounds
+      produces:
+        - application/json
+  /v3/orgs/{orgUid}/search?type=projects:
+    parameters:
+      - required: true
+        type: string
+        description: Can take either the organization UID (orgUid) or name preceded by a
+          @ (@orgName).
+        in: path
+        name: orgUid
+    get:
+      description: Search and filters in given org projects
+      tags:
+        - orgs
+        - projects
+        - search
+      responses:
+        "200":
+          description: Projects matching the search
+          schema:
+            $ref: "#/definitions/ProjectSearchResponse"
+      parameters:
+        - $ref: "#/parameters/queryFilter"
+        - $ref: "#/parameters/parentProjectFilter"
+        - $ref: "#/parameters/projectDepthFilter"
+      consumes:
+        - multipart/form-data
+  /v3/orgs/{orgUid}/search?type=models:
+    parameters:
+      - required: true
+        type: string
+        description: Can take either the organization UID (orgUid) or name preceded by a
+          @ (@orgName).
+        in: path
+        name: orgUid
+    get:
+      description: Search and filters in given org models
+      tags:
+        - orgs
+        - models
+        - search
+      responses:
+        "200":
+          description: Models matching the search
+          schema:
+            $ref: "#/definitions/ModelSearchResponse"
+      parameters:
+        - $ref: "#/parameters/queryFilter"
+        - $ref: "#/parameters/usersFilter"
+        - $ref: "#/parameters/foldersFilter"
+        - $ref: "#/parameters/projectsFilter"
+        - $ref: "#/parameters/minFaceCountFilter"
+        - $ref: "#/parameters/maxFaceCountFilter"
+        - $ref: "#/parameters/animatedFilter"
+        - $ref: "#/parameters/pbrFilter"
+        - $ref: "#/parameters/riggedFilter"
+        - $ref: "#/parameters/allVisibilitiesFilter"
+        - $ref: "#/parameters/downloadableFilter"
+        - $ref: "#/parameters/orgTagsFilter"
+        - $ref: "#/parameters/searchParamAvailableArchiveType"
+        - $ref: "#/parameters/searchParamArchivesMaxSize"
+        - $ref: "#/parameters/searchParamArchivesMaxFaceCount"
+        - $ref: "#/parameters/searchParamArchivesMaxVertexCount"
+        - $ref: "#/parameters/searchParamArchivesMaxTextureCount"
+        - $ref: "#/parameters/searchParamArchivesTextureMaxResolution"
+        - $ref: "#/parameters/searchParamFileFormat"
+        - $ref: "#/parameters/archivesFlavoursFilter"
+      consumes:
+        - multipart/form-data
+  /v3/me/matcaps/{matcapUid}:
+    delete:
+      security:
+        - Token: []
+      description: Deletes a matcap
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - me
+        - matcaps
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The matcap UID
+        in: path
+        name: matcapUid
+    get:
+      security:
+        - Token: []
+      description: Retrieve a matcap
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/MatcapDetail"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - me
+        - matcaps
+      produces:
+        - application/json
+  /v3/me/followings:
+    post:
+      description: Follows a new user.
+      parameters:
+        - required: true
+          type: string
+          description: <a href="#/users" target="_blank">User</a> (uid) to follow
+          in: formData
+          name: toUser
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - users
+        - relationships
+      consumes:
+        - multipart/form-data
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Authentication credentials were not provided or do not match
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/UserResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - dateJoined
+            - -dateJoined
+            - followerCount
+            - -followerCount
+          in: query
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - users
+        - relationships
+      description: Returns a list of users you follow.
+  /v3/categories:
+    get:
+      description: Returns a list of categories
+      tags:
+        - categories
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CategoriesResponse"
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - slug
+            - -slug
+          in: query
+      produces:
+        - application/json
+  /v3/models/{uid}/archives/extra:
+    post:
+      description: Adds or replace a model's extra archive, only for orgs and users
+        with a paid plan.
+      parameters:
+        - required: true
+          type: file
+          description: Model's extra archive. Max 2Gb.
+          in: formData
+          name: extraFile
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - models
+      consumes:
+        - multipart/form-data
+      responses:
+        "201":
+          description: Created
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+    parameters:
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: uid
+  /v3/me/models:
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/MeModelResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+      parameters:
+        - required: false
+          type: boolean
+          description: Retrieves downloadable models
+          in: query
+          name: downloadable
+        - $ref: "#/parameters/archivesFlavoursFilter"
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - models
+      description: Returns a list of your models
+  /v3/me/likes/{uid}:
+    parameters:
+      - required: true
+        type: string
+        description: <a href="#/models" target="_blank">Model</a> (uid) to un-like
+        in: path
+        name: uid
+    delete:
+      security:
+        - Token: []
+      description: Un-likes a model
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "401":
+          description: Authentication credentials were not provided or do not match
+      tags:
+        - users
+        - me
+        - likes
+      produces:
+        - application/json
+  /v3/orgs/{orgUid}/models:
+    post:
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: "#/definitions/OrgModelDetailResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match.
+        "403":
+          description: You're not allowed to post in this organization.
+      parameters:
+        - description: Sets a model name
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: name
+        - description: Define the organization project you want to upload to
+          in: formData
+          maxLength: 48
+          required: true
+          type: string
+          name: orgProject
+        - description: Define the upload source
+          in: formData
+          maxLength: 48
+          required: false
+          type: string
+          name: source
+        - required: false
+          name: visibility
+          in: formData
+          default: org
+          enum:
+            - public
+            - private
+            - protected
+            - org
+          type: string
+          description: Sets the model visibility
+        - description: Enables 2D view in model inspector. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isInspectable
+        - description: Whether the model has restricted content.
+          in: formData
+          default: false
+          required: false
+          type: boolean
+          name: isAgeRestricted
+        - in: formData
+          type: string
+          description: Sets a password. This option can only be used when visibility is
+            protected.
+          name: password
+          maxLength: 64
+        - required: false
+          type: string
+          description: Sets a <a href=#!/licenses/ target='_blank'>license</a> (slug).
+            This makes the model downloadable to others. All <a
+            href="https://help.sketchfab.com/hc/en-us/articles/115004862686-Inspector">downloadable
+            models must have isInspectable enabled</a>.
+          in: formData
+          name: license
+        - name: tags
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+          description: Sets <a href=#!/tags/ target='_blank'>tags</a> (slug)
+        - name: categories
+          in: formData
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+          description: Sets <a href=#!/categories/ target='_blank'>categories</a> (slug).
+            Two categories max for a model.
+        - description: Sets the model description
+          in: formData
+          maxLength: 1024
+          required: false
+          type: string
+          name: description
+        - required: true
+          type: file
+          description: Archive of the model to be processed.
+          in: formData
+          name: modelFile
+        - required: false
+          type: string
+          description: Sets <a href=#!/models/patch_v3_models_uid_options
+            target='_blank'>options</a> after it is processed
+          in: formData
+          name: options
+      tags:
+        - orgs
+        - models
+      security:
+        - Token: []
+      consumes:
+        - multipart/form-data
+      description: Uploads a new model to the given organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgModelListResponse"
+      parameters:
+        - $ref: "#/parameters/queryFilter"
+        - $ref: "#/parameters/usersFilter"
+        - $ref: "#/parameters/foldersFilter"
+        - $ref: "#/parameters/projectsFilter"
+        - $ref: "#/parameters/minFaceCountFilter"
+        - $ref: "#/parameters/maxFaceCountFilter"
+        - $ref: "#/parameters/animatedFilter"
+        - $ref: "#/parameters/pbrFilter"
+        - $ref: "#/parameters/riggedFilter"
+        - $ref: "#/parameters/allVisibilitiesFilter"
+        - $ref: "#/parameters/downloadableFilter"
+        - $ref: "#/parameters/orgTagsFilter"
+        - $ref: "#/parameters/searchParamAvailableArchiveType"
+        - $ref: "#/parameters/searchParamArchivesMaxSize"
+        - $ref: "#/parameters/searchParamArchivesMaxFaceCount"
+        - $ref: "#/parameters/searchParamArchivesMaxVertexCount"
+        - $ref: "#/parameters/searchParamArchivesMaxTextureCount"
+        - $ref: "#/parameters/searchParamArchivesTextureMaxResolution"
+        - $ref: "#/parameters/archivesFlavoursFilter"
+        - required: false
+          description: Sorts models by this param.
+          in: query
+          enum:
+            - createdAt
+            - faceCount
+            - likeCount
+            - title
+            - orgCommentCount
+            - processedAt
+            - publicCommentCount
+            - publishedAt
+            - staffpickedAt
+            - user
+            - vertexCount
+            - viewCount
+            - privacy
+          type: string
+          name: sort_by
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - orgs
+        - models
+      description: Returns a list of models from the given organization. Can take
+        either the organization UID (orgUid) or name preceded by a @ (@orgName).
+  /v3/orgs/{orgUid}/projects/{projectUid}:
+    get:
+      security:
+        - Token: []
+      description: Retrieve a project within the given organization. Can take either
+        the organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgProjectListResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - projects
+      produces:
+        - application/json
+    patch:
+      security:
+        - Token: []
+      description: Update a project within the given organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/OrgProjectListResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - projects
+      produces:
+        - application/json
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+      - required: true
+        type: string
+        description: The project UID
+        in: path
+        name: projectUid
+    delete:
+      security:
+        - Token: []
+      description: Remove a project within the given organization. Can take either the
+        organization UID (orgUid) or name preceded by a @ (@orgName).
+      responses:
+        "204":
+          description: No content
+        "401":
+          description: Authentication credentials were not provided or do not match
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      tags:
+        - orgs
+        - projects
+      produces:
+        - application/json
+  /v3/search?type=users:
+    get:
+      description: Search and filters in users
+      tags:
+        - search
+        - users
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/UserSearchResponse"
+        "400":
+          description: Bad Request
+      parameters:
+        - required: false
+          type: string
+          description: Space separated keywords
+          in: query
+          name: q
+        - required: false
+          type: string
+          description: Searches users by username
+          in: query
+          name: username
+        - required: false
+          type: string
+          description: Searches users by country or city
+          in: query
+          name: location
+        - required: false
+          description: Searches users by account type
+          in: query
+          enum:
+            - free
+            - pro
+            - biz
+          type: string
+          name: account
+        - description: Searches users by skills (slug)
+          name: skills
+          in: query
+          items:
+            type: string
+          required: false
+          type: array
+          collectionFormat: multi
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - followerCount
+            - -followerCount
+            - modelCount
+            - -modelCount
+            - username
+          in: query
+      consumes:
+        - multipart/form-data
+  /v3/orgs/{orgUid}/models/{modelUid}/download:
+    parameters:
+      - required: true
+        type: string
+        description: The organization UID
+        in: path
+        name: orgUid
+      - required: true
+        type: string
+        description: The model UID
+        in: path
+        name: modelUid
+    get:
+      description: Returns download information for downloadable models. Can take
+        either the organization UID (orgUid) or name preceded by a @ (@orgName).
+      tags:
+        - orgs
+        - models
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/ModelDownload"
+        "403":
+          description: Permission Denied
+        "404":
+          description: Not Found
+      produces:
+        - application/json
+  /v3/tags:
+    get:
+      tags:
+        - tags
+      responses:
+        "200":
+          description: Returns the list of tags
+          schema:
+            $ref: "#/definitions/TagsResponse"
+      description: Returns a list of tags
+  /v3/collections/thumbnails:
+    get:
+      tags:
+        - collections
+        - thumbnails
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CollectionsThumbnailsResponse"
+      parameters:
+        - name: uids
+          in: query
+          items:
+            type: string
+          required: true
+          type: array
+          collectionFormat: multi
+      description: Returns the popular thumbnails of collections
+  /v3/me/followers:
+    get:
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/UserResponse"
+        "401":
+          description: Authentication credentials were not provided or do not match
+      parameters:
+        - required: false
+          type: string
+          name: sort_by
+          enum:
+            - dateJoined
+            - -dateJoined
+            - followerCount
+            - -followerCount
+          in: query
+      produces:
+        - application/json
+      security:
+        - Token: []
+      tags:
+        - me
+        - users
+        - relationships
+      description: Returns a list of users following you.
+schemes:
+  - https
+parameters:
+  riggedFilter:
+    required: false
+    type: boolean
+    description: Retrieves rigged models.
+    in: query
+    name: rigged
+  searchParamStaffpicked:
+    required: false
+    type: boolean
+    name: staffpicked
+    in: query
+  projectsFilter:
+    name: projects
+    in: query
+    items:
+      type: string
+    required: false
+    type: array
+    collectionFormat: multi
+    description: Retrieve models uploaded to projects (uids).
+  searchParamRigged:
+    required: false
+    type: boolean
+    description: false by default. Set to true to search rigged models only. Set to
+      false to search all models
+    in: query
+    name: rigged
+  searchParamDate:
+    required: false
+    description: Limit search to a specific period only (in days)
+    in: query
+    enum:
+      - 1
+      - 7
+      - 31
+    type: integer
+    name: date
+  allVisibilitiesFilter:
+    enum:
+      - public
+      - private
+      - protected
+      - org
+    type: string
+    description: Sets the model visibility
+    in: query
+    name: visibility
+  searchParamPbrType:
+    required: false
+    description: Filter by PBR type. Set to `metalness` to search
+      Metalness/Roughness models only. Set to `specular` to search
+      Specular/Glossiness models only. Set to `true` to search PBR models only.
+      Set to `false` to search non-PBR models only.
+    in: query
+    enum:
+      - "false"
+      - "true"
+      - metalness
+      - specular
+    type: string
+    name: pbr_type
+  minFaceCountFilter:
+    required: false
+    type: integer
+    description: Retrieve models with at most x face count.
+    in: query
+    name: min_face_count
+  maxFaceCountFilter:
+    required: false
+    type: integer
+    description: Retrieve models with at least x face count.
+    in: query
+    name: max_face_count
+  searchParamDownloadable:
+    required: false
+    type: boolean
+    name: downloadable
+    in: query
+  usersFilter:
+    name: users
+    in: query
+    items:
+      type: string
+    required: false
+    type: array
+    collectionFormat: multi
+    description: Retrieve models uploaded by the given <a href="#!/users/"
+      target="_blank">users</a> (username).
+  pbrFilter:
+    required: false
+    type: boolean
+    description: Retrieves pbr models.
+    in: query
+    name: pbr
+  animatedFilter:
+    required: false
+    type: boolean
+    description: Retrieves animated models.
+    in: query
+    name: animated
+  downloadableFilter:
+    enum:
+      - free
+      - org
+    type: string
+    description: Retrieves models by download type
+    in: query
+    name: downloadable
+  foldersFilter:
+    name: folders
+    in: query
+    items:
+      type: string
+    required: false
+    type: array
+    collectionFormat: multi
+    description: Retrieve models uploaded to folders (uids).
+  searchParamUser:
+    required: false
+    type: string
+    description: Searches models by a <a href="#!/users/" target="_blank">user</a>
+      (username)
+    in: query
+    name: user
+  orgTagsFilter:
+    description: Retrieves models given a list of tags
+    name: orgTags
+    in: query
+    items:
+      type: string
+    type: array
+    collectionFormat: multi
+  queryFilter:
+    required: false
+    type: string
+    description: "The search query: words separated by spaces."
+    in: query
+    name: q
+  searchParamArchivesMaxTextureCount:
+    required: false
+    type: integer
+    name: archives_max_texture_count
+    in: query
+  searchParamMaxFilesizes:
+    required: false
+    type: string
+    description: "DEPRECATED: Use available_archive_type and archives_max_size filters."
+    in: query
+    name: max_filesizes
+  searchParamProcessingStatus:
+    required: false
+    description: Searches models by processing status
+    in: query
+    items:
+      type: string
+    enum:
+      - pending
+      - processing
+      - succeeded
+      - failed
+    type: string
+    name: processing_status
+  searchParamMaxUvLayerCount:
+    required: false
+    type: integer
+    name: max_uv_layer_count
+    in: query
+  searchParamCollection:
+    required: false
+    type: string
+    description: Searches models by collection (uid)
+    in: query
+    name: collection
+  searchParamTags:
+    description: Searches models by <a href="#!/tags/" target="_blank">tags</a> (slug)
+    in: query
+    items:
+      type: string
+    required: false
+    type: array
+    name: tags
+  searchParamSound:
+    required: false
+    type: boolean
+    name: sound
+    in: query
+  searchParamLicense:
+    required: false
+    type: string
+    name: license
+    enum:
+      - by
+      - by-sa
+      - by-nd
+      - by-nc
+      - by-nc-sa
+      - by-nc-nd
+      - cc0
+      - ed
+      - st
+    in: query
+  searchParamArchivesMaxVertexCount:
+    required: false
+    type: integer
+    name: archives_max_vertex_count
+    in: query
+  searchParamArchivesMaxFaceCount:
+    required: false
+    type: integer
+    name: archives_max_face_count
+    in: query
+  parentProjectFilter:
+    items:
+      type: string
+    in: query
+    type: string
+    description: Retrieves projects by parent (uid)
+    name: parent
+  searchParamQ:
+    required: false
+    type: string
+    description: Space separated keywords
+    in: query
+    name: q
+  searchParamMinFaceCount:
+    required: false
+    type: integer
+    description: Minimum number of faces
+    in: query
+    name: min_face_count
+  searchParamArchivesTextureMaxResolution:
+    required: false
+    type: integer
+    name: archives_texture_max_resolution
+    in: query
+  searchParamSortBy:
+    required: false
+    description: How to sort results. When omitted, results are sorted by relevance
+    in: query
+    enum:
+      - likeCount
+      - -likeCount
+      - viewCount
+      - -viewCount
+      - publishedAt
+      - -publishedAt
+      - processedAt
+      - -processedAt
+    type: string
+    name: sort_by
+  archivesFlavoursFilter:
+    description: If true, returns all archives flavours, listed by archive type, and
+      sorted by texture resolution (descending). If false, only the texture with
+      the highest reslution is returned for each archive type.
+    in: query
+    default: false
+    required: false
+    type: boolean
+    name: archives_flavours
+  searchParamArchivesMaxSize:
+    required: false
+    type: integer
+    name: archives_max_size
+    in: query
+  searchParamAnimated:
+    required: false
+    type: boolean
+    name: animated
+    in: query
+  searchParamCategories:
+    description: Searches models by categories (slug)
+    in: query
+    items:
+      type: string
+    required: false
+    type: array
+    name: categories
+  searchParamAvailableArchiveType:
+    required: false
+    type: string
+    name: available_archive_type
+    in: query
+  searchParamFileFormat:
+    required: false
+    type: string
+    description: "Searches models by <a
+      href='https://help.sketchfab.com/hc/en-us/articles/202508396-3D-File-Form\
+      ats' target='_blank'>file format</a>. Ex: obj, fbx, blend..."
+    in: query
+    name: file_format
+  searchParamMaxFaceCount:
+    required: false
+    type: integer
+    description: Maximum number of faces
+    in: query
+    name: max_face_count
+  projectDepthFilter:
+    items:
+      type: string
+    in: query
+    type: integer
+    description: Retrieves projects by depth
+    name: depth
+tags:
+  - name: models
+  - name: users
+  - name: me
+  - name: collections
+  - name: avatars
+  - name: categories
+  - name: skills
+  - name: environments
+  - name: tags
+  - name: relationships
+  - name: backgrounds
+  - name: matcaps
+  - name: thumbnails
+  - name: likes
+  - name: search
+  - name: comments
+  - name: licenses
+  - name: purchases
+  - name: orgs
+  - name: projects
+securityDefinitions:
+  Token:
+    type: apiKey
+    name: Authorization
+    in: header
+host: api.sketchfab.com
+definitions:
+  CollectionList:
+    type: object
+    properties:
+      createdAt:
+        type: string
+        format: date
+      description:
+        type:
+          - string
+          - "null"
+      hasRestrictedContent:
+        type: boolean
+      models:
+        type: string
+      isAgeRestricted:
+        type: boolean
+      uri:
+        type: string
+      modelCount:
+        type: integer
+      user:
+        type: string
+      updatedAt:
+        type: string
+        format: date
+      owner:
+        $ref: "#/definitions/UserDetail"
+      embedUrl:
+        type: string
+      uid:
+        type: string
+      slug:
+        type: string
+      thumbnails:
+        items:
+          $ref: "#/definitions/ThumbnailsRelated"
+        type: object
+      name:
+        type: string
+  MeDetail:
+    type: object
+    properties:
+      subscriptionCount:
+        type: integer
+      followerCount:
+        type: integer
+      uid:
+        type: string
+      modelsUrl:
+        type: string
+      likeCount:
+        type: integer
+      facebookUsername:
+        type: string
+      biography:
+        type: string
+      city:
+        type: string
+      tagline:
+        type: string
+      modelCount:
+        type: integer
+      twitterUsername:
+        type: string
+      email:
+        type: string
+      website:
+        type: string
+      billingCycle:
+        type: string
+      followersUrl:
+        type: string
+      collectionCount:
+        type: integer
+      dateJoined:
+        type: string
+        format: date
+      account:
+        type: string
+      displayName:
+        type: string
+      profileUrl:
+        type: string
+      followingsUrl:
+        type: string
+      skills:
+        items:
+          $ref: "#/definitions/SkillDetail"
+        type: array
+      country:
+        type: string
+      uri:
+        type: string
+      apiToken:
+        type: string
+      username:
+        type: string
+      linkedinUsername:
+        type: string
+      likesUrl:
+        type: string
+      avatar:
+        $ref: "#/definitions/AvatarRelated"
+      isLimited:
+        type: boolean
+      followingCount:
+        type: integer
+      collectionsUrl:
+        type: string
+  MePrivateModelsLimit:
+    type: object
+    properties:
+      count:
+        type: integer
+      since:
+        type: string
+      until:
+        type: string
+  OrgMatcapsListResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/OrgMatcapDetail"
+        type: array
+  TagsResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/TagRelated"
+        type: array
+  CollectionsThumbnailsResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/ThumbnailsRelated"
+        type: array
+  EnvironmentResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/Environment"
+        type: array
+  OrgBackgroundListResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/OrgBackgroundDetail"
+        type: array
+  Environment:
+    type: object
+    properties:
+      uid:
+        type: string
+      brightness:
+        type: integer
+      processing:
+        type: string
+      uri:
+        type: string
+      isDefault:
+        type: boolean
+      diffuseSPH:
+        type: string
+      createdAt:
+        type: string
+        format: date
+      name:
+        type: string
+  UserRelated:
+    type: object
+    properties:
+      username:
+        type: string
+      profileUrl:
+        type: string
+      account:
+        type: string
+      displayName:
+        type: string
+      uid:
+        type: string
+      uri:
+        type: string
+      avatar:
+        $ref: "#/definitions/AvatarRelated"
+  LicensesDetail:
+    type: object
+    properties:
+      slug:
+        type: string
+      requirements:
+        type: string
+      url:
+        type: string
+      fullName:
+        type: string
+      uri:
+        type: string
+      label:
+        type: string
+  OrgTextureImageDetail:
+    type: object
+    properties:
+      width:
+        type: integer
+      name:
+        type: string
+      uid:
+        type: string
+      file:
+        type: string
+      height:
+        type: integer
+  OrgModelDetailResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/OrgModelDetail"
+        type: array
+  OrgEnvironmentDetail:
+    type: object
+    properties:
+      textures:
+        $ref: "#/definitions/OrgTextureList"
+      uid:
+        type: string
+      brightness:
+        type: number
+      processing:
+        $ref: "#/definitions/ProcessingStatus"
+      uri:
+        type: string
+      lights:
+        $ref: "#/definitions/OrgLightList"
+      isDefault:
+        type: boolean
+      diffuseSPH:
+        items:
+          type: number
+        type: array
+      createdAt:
+        type: string
+        format: date
+      name:
+        type: string
+  UserDetail:
+    type: object
+    properties:
+      website:
+        type:
+          - string
+          - "null"
+      subscriptionCount:
+        type: integer
+      followerCount:
+        type: integer
+      uid:
+        type: string
+      modelsUrl:
+        type: string
+      portfolioUrl:
+        type: string
+      likeCount:
+        type: integer
+      facebookUsername:
+        type:
+          - string
+          - "null"
+      biography:
+        type:
+          - string
+          - "null"
+      dateJoined:
+        type: string
+        format: date
+      city:
+        type:
+          - string
+          - "null"
+      account:
+        type: string
+      displayName:
+        type: string
+      profileUrl:
+        type: string
+      followingsUrl:
+        type: string
+      skills:
+        items:
+          $ref: "#/definitions/SkillDetail"
+        type: array
+      tagline:
+        type:
+          - string
+          - "null"
+      uri:
+        type: string
+      modelCount:
+        type: integer
+      username:
+        type: string
+      linkedinUsername:
+        type:
+          - string
+          - "null"
+      likesUrl:
+        type: string
+      followersUrl:
+        type: string
+      collectionCount:
+        type: integer
+      country:
+        type:
+          - string
+          - "null"
+      followingCount:
+        type: integer
+      twitterUsername:
+        type:
+          - string
+          - "null"
+      collectionsUrl:
+        type: string
+      avatar:
+        $ref: "#/definitions/AvatarRelated"
+  OrgEnvironmentListResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/OrgEnvironmentDetail"
+        type: array
+  ModelResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/ModelList"
+        type: array
+  CollectionModelList:
+    type: object
+    properties:
+      uid:
+        type: string
+      tags:
+        items:
+          $ref: "#/definitions/TagRelated"
+        type: array
+      viewerUrl:
+        type: string
+      isProtected:
+        type: boolean
+      categories:
+        items:
+          $ref: "#/definitions/CategoriesRelated"
+        type: array
+      publishedAt:
+        type: string
+        format: date
+      likeCount:
+        type: integer
+      commentCount:
+        type: integer
+      viewCount:
+        type: integer
+      vertexCount:
+        type: integer
+      user:
+        $ref: "#/definitions/UserRelated"
+      isDownloadable:
+        type: boolean
+      description:
+        type:
+          - string
+          - "null"
+      animationCount:
+        type: integer
+      name:
+        type: string
+      soundCount:
+        type: integer
+      isAgeRestricted:
+        type: boolean
+      uri:
+        type: string
+      faceCount:
+        type: integer
+      staffpickedAt:
+        type:
+          - string
+          - "null"
+        format: date
+      createdAt:
+        type: string
+        format: date
+      thumbnails:
+        $ref: "#/definitions/ThumbnailsRelated"
+      embedUrl:
+        type: string
+  CollectionModelResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/CollectionModelList"
+        type: array
+  OrgTagsListResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/OrgTagList"
+        type: array
+  ModelList:
+    type: object
+    properties:
+      uid:
+        type: string
+      tags:
+        items:
+          $ref: "#/definitions/TagRelated"
+        type: array
+      viewerUrl:
+        type: string
+      isProtected:
+        type: boolean
+      price:
+        type: integer
+      categories:
+        items:
+          $ref: "#/definitions/CategoriesRelated"
+        type: array
+      publishedAt:
+        type: string
+        format: date
+      likeCount:
+        type: integer
+      commentCount:
+        type: integer
+      viewCount:
+        type: integer
+      vertexCount:
+        type: integer
+      user:
+        $ref: "#/definitions/UserRelated"
+      isDownloadable:
+        type: boolean
+      description:
+        type:
+          - string
+          - "null"
+      animationCount:
+        type: integer
+      name:
+        type: string
+      license:
+        type: string
+      soundCount:
+        type: integer
+      isAgeRestricted:
+        type: boolean
+      uri:
+        type: string
+      faceCount:
+        type: integer
+      staffpickedAt:
+        type:
+          - string
+          - "null"
+        format: date
+      createdAt:
+        type: string
+        format: date
+      thumbnails:
+        $ref: "#/definitions/ThumbnailsRelated"
+      embedUrl:
+        type: string
+      archives:
+        type: object
+        properties:
+          source:
+            $ref: "#/definitions/ArchiveNested"
+          glb:
+            $ref: "#/definitions/ArchiveNested"
+          usdz:
+            $ref: "#/definitions/ArchiveNested"
+          gltf:
+            $ref: "#/definitions/ArchiveNested"
+  OrgLightDetail:
+    type: object
+    properties:
+      direction:
+        items:
+          type: number
+        type: array
+      area:
+        type: object
+        properties:
+          y:
+            type: number
+          h:
+            type: number
+          z:
+            type: number
+          w:
+            type: number
+          x:
+            type: number
+      color:
+        items:
+          type: number
+        type: array
+      luminosity:
+        type: number
+      sum:
+        type: number
+      lum_ratio:
+        type: number
+      error:
+        type: integer
+      variance:
+        type: number
+  LikeModelList:
+    type: object
+    properties:
+      uid:
+        type: string
+      tags:
+        items:
+          $ref: "#/definitions/TagRelated"
+        type: array
+      viewerUrl:
+        type: string
+      isProtected:
+        type: boolean
+      categories:
+        items:
+          $ref: "#/definitions/CategoriesRelated"
+        type: array
+      publishedAt:
+        type: string
+        format: date
+      likeCount:
+        type: integer
+      commentCount:
+        type: integer
+      viewCount:
+        type: integer
+      vertexCount:
+        type: integer
+      user:
+        $ref: "#/definitions/UserRelated"
+      isDownloadable:
+        type: boolean
+      description:
+        type:
+          - string
+          - "null"
+      animationCount:
+        type: integer
+      name:
+        type: string
+      soundCount:
+        type: integer
+      isAgeRestricted:
+        type: boolean
+      uri:
+        type: string
+      faceCount:
+        type: integer
+      staffpickedAt:
+        type:
+          - string
+          - "null"
+        format: date
+      createdAt:
+        type: string
+        format: date
+      thumbnails:
+        $ref: "#/definitions/ThumbnailsRelated"
+      embedUrl:
+        type: string
+  ArchiveNested:
+    type: object
+    properties:
+      faceCount:
+        type: integer
+      textureCount:
+        type: integer
+      size:
+        type: integer
+        description: archive size (in bytes)
+      vertexCount:
+        type: integer
+      textureMaxResolution:
+        type: integer
+  ProcessingStatus:
+    enum:
+      - pending
+      - processing
+      - succeeded
+      - failed
+    type: string
+  CategoriesRelated:
+    type: object
+    properties:
+      uri:
+        type: string
+      uid:
+        type: string
+      name:
+        type: string
+      slug:
+        type: string
+  MatcapDetail:
+    type: object
+    properties:
+      uid:
+        type: string
+      name:
+        type: string
+      updatedAt:
+        type: string
+        format: date
+      images:
+        $ref: "#/definitions/ImagesList"
+      uri:
+        type:
+          - string
+          - "null"
+      createdAt:
+        type: string
+        format: date
+      isDefault:
+        type: boolean
+  ModelDetail:
+    type: object
+    properties:
+      uid:
+        type: string
+      publishedAt:
+        type: string
+        format: date
+      likeCount:
+        type: integer
+      commentCount:
+        type: integer
+      updatedAt:
+        type: string
+        format: date
+      isDownloadable:
+        type: boolean
+      isAgeRestricted:
+        type: boolean
+      pbrType:
+        type: string
+      materialCount:
+        type: integer
+      name:
+        type: string
+      source:
+        type: string
+      staffpickedAt:
+        type:
+          - string
+          - "null"
+        format: date
+      createdAt:
+        type: string
+        format: date
+      embedUrl:
+        type: string
+      status:
+        type: object
+      description:
+        type:
+          - string
+          - "null"
+      tags:
+        items:
+          $ref: "#/definitions/TagRelated"
+        type: array
+      viewerUrl:
+        type: string
+      isProtected:
+        type: boolean
+      price:
+        type: integer
+      textureCount:
+        type: integer
+      vertexCount:
+        type: integer
+      user:
+        $ref: "#/definitions/UserRelated"
+      categories:
+        items:
+          $ref: "#/definitions/CategoriesRelated"
+        type: array
+      animationCount:
+        type: integer
+      viewCount:
+        type: integer
+      thumbnails:
+        $ref: "#/definitions/ThumbnailsRelated"
+      license:
+        type: object
+      editorUrl:
+        type: string
+      soundCount:
+        type: integer
+      uri:
+        type: string
+      faceCount:
+        type: integer
+      hasCommentsDisabled:
+        type: boolean
+      downloadCount:
+        type: integer
+  CommentResponse:
+    type: object
+    properties:
+      body:
+        type: string
+      uid:
+        type: string
+      uri:
+        type: string
+      createdAt:
+        type: string
+        format: date
+      user:
+        $ref: "#/definitions/UserRelated"
+      updatedAt:
+        type: string
+        format: date
+      model:
+        $ref: "#/definitions/ModelRelated"
+      isDeleted:
+        type: boolean
+  GlobalSearchResponse:
+    type: object
+    properties:
+      results:
+        type: object
+        properties:
+          models:
+            items:
+              $ref: "#/definitions/ModelSearchList"
+            type: array
+          collections:
+            items:
+              $ref: "#/definitions/CollectionSearchList"
+            type: array
+          users:
+            items:
+              $ref: "#/definitions/UserSearchResponse"
+            type: array
+  MeAccount:
+    type: object
+    properties:
+      account:
+        type: string
+      uploadSizeLimit:
+        type: integer
+      viewOnlyLimit:
+        $ref: "#/definitions/MeViewOnlyLimit"
+      privateModelsLimit:
+        $ref: "#/definitions/MePrivateModelsLimit"
+      canProtectModels:
+        type: string
+      renewsAt:
+        type: string
+        format: date
+      joinedAt:
+        type: string
+        format: date
+      billingCycle:
+        type: string
+  CategoriesResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/CategoriesRelated"
+        type: array
+  CollectionSearchList:
+    type: object
+    properties:
+      description:
+        type:
+          - string
+          - "null"
+      collectionUrl:
+        type: string
+      modelCount:
+        type: integer
+      user:
+        $ref: "#/definitions/UserRelated"
+      updatedAt:
+        type: string
+        format: date
+      uid:
+        type: string
+      embedUrl:
+        type: string
+      slug:
+        type: string
+      createdAt:
+        type: string
+        format: date
+      name:
+        type: string
+  ModelSearchResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/ModelSearchList"
+        type: array
+  ArchiveExtra:
+    type: object
+    properties:
+      status:
+        type: string
+      size:
+        type: integer
+      uid:
+        type: string
+      name:
+        type: string
+      metadata:
+        type: object
+        properties:
+          count:
+            type: integer
+          image:
+            type: array
+          3d:
+            type: array
+          misc:
+            type: array
+          summary:
+            type: array
+  MeOrgs:
+    type: object
+    properties:
+      username:
+        type: string
+      membership:
+        items:
+          $ref: "#/definitions/MeOrgMembership"
+        type: array
+      orgUrl:
+        type: string
+      displayName:
+        type: string
+      uid:
+        type: string
+      publicProfileUrl:
+        type: string
+  OrgImagesList:
+    items:
+      $ref: "#/definitions/OrgImageDetail"
+    type: array
+  CollectionResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/CollectionList"
+        type: array
+  ModelRelated:
+    type: object
+    properties:
+      uid:
+        type: string
+  MeOrgMembership:
+    type: object
+    properties:
+      status:
+        type: string
+      role:
+        type: string
+      joinedAt:
+        type: string
+        format: date
+      uid:
+        type: string
+  SkillsResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/SkillDetail"
+        type: array
+  UserNested:
+    type: object
+    properties:
+      username:
+        type: string
+      account:
+        type: string
+      displayName:
+        type: string
+      uid:
+        type: string
+      avatar:
+        type: string
+  ProjectSearchList:
+    type: object
+    properties:
+      uid:
+        type: string
+      latestMembers:
+        type: object
+        properties:
+          status:
+            type: string
+          projectCount:
+            type: integer
+          uid:
+            type: string
+          modelCount:
+            type: integer
+          inviteEmail:
+            type: string
+          role:
+            type: string
+          user:
+            $ref: "#/definitions/UserRelated"
+          joinedAt:
+            type: string
+            format: date
+      memberCount:
+        type: integer
+      breadcrumbs:
+        type: object
+        properties:
+          url:
+            type: string
+          slug:
+            type: string
+          name:
+            type: string
+          uid:
+            type: string
+      depth:
+        type: integer
+      modelCount:
+        type: integer
+      name:
+        type: string
+      folderCount:
+        type: integer
+      updatedAt:
+        type: string
+        format: date
+      slug:
+        type: string
+      thumbnails:
+        $ref: "#/definitions/ThumbnailsRelated"
+  UserSearchList:
+    type: object
+    properties:
+      username:
+        type: string
+      city:
+        type:
+          - string
+          - "null"
+      followerCount:
+        type: integer
+      displayName:
+        type: string
+      uid:
+        type: string
+      skills:
+        items:
+          $ref: "#/definitions/SkillDetail"
+        type: array
+      country:
+        type:
+          - string
+          - "null"
+      account:
+        type: string
+      modelCount:
+        type: integer
+      profileUrl:
+        type: string
+      avatar:
+        $ref: "#/definitions/AvatarRelated"
+  MeModelResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/MeModelList"
+        type: array
+  OrgNested:
+    type: object
+    properties:
+      username:
+        type: string
+      project:
+        $ref: "#/definitions/OrgProjectNested"
+      displayName:
+        type: string
+      uid:
+        type: string
+      viewerUrl:
+        type: string
+      commentCount:
+        type: integer
+  ProjectSearchResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/ProjectSearchList"
+        type: array
+  ImagesList:
+    items:
+      $ref: "#/definitions/ImageDetail"
+    type: array
+  AvatarRelated:
+    type: object
+    properties:
+      images:
+        items:
+          type: object
+          properties:
+            url:
+              type: string
+            width:
+              type: integer
+            height:
+              type: integer
+            size:
+              type: integer
+        type: array
+      uid:
+        type: string
+      uri:
+        type: string
+  UserSearchResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/UserSearchList"
+        type: array
+  OrgModelList:
+    type: object
+    properties:
+      downloadType:
+        type: string
+      uid:
+        type: string
+      tags:
+        type: string
+      viewerUrl:
+        type: string
+      orgTags:
+        type: string
+      categories:
+        type: string
+      publishedAt:
+        type: string
+        format: date
+      likeCount:
+        type: integer
+      commentCount:
+        type: integer
+      visibility:
+        type: string
+      vertexCount:
+        type: integer
+      isArchivesReady:
+        type: boolean
+      org:
+        $ref: "#/definitions/OrgNested"
+      slug:
+        type: string
+      createdAt:
+        type: string
+        format: date
+      animationCount:
+        type: integer
+      viewCount:
+        type: integer
+      thumbnails:
+        type: string
+      license:
+        type: string
+      processingStatus:
+        type: string
+      soundCount:
+        type: integer
+      isAgeRestricted:
+        type: boolean
+      uri:
+        type: string
+      name:
+        type: string
+      faceCount:
+        type: integer
+      staffpickedAt:
+        type: string
+        format: date
+      archives:
+        type: object
+        properties:
+          source:
+            $ref: "#/definitions/ArchiveNested"
+          glb:
+            $ref: "#/definitions/ArchiveNested"
+          usdz:
+            $ref: "#/definitions/ArchiveNested"
+          gltf:
+            $ref: "#/definitions/ArchiveNested"
+      downloadCount:
+        type: integer
+      embedUrl:
+        type: string
+      user:
+        $ref: "#/definitions/UserNested"
+  ModelSearchList:
+    type: object
+    properties:
+      uid:
+        type: string
+      animationCount:
+        type: integer
+      viewerUrl:
+        type: string
+      publishedAt:
+        type: string
+        format: date
+      likeCount:
+        type: integer
+      commentCount:
+        type: integer
+      user:
+        $ref: "#/definitions/UserRelated"
+      isDownloadable:
+        type: boolean
+      name:
+        type: string
+      viewCount:
+        type: integer
+      thumbnails:
+        $ref: "#/definitions/ThumbnailsRelated"
+      license:
+        type: string
+      isPublished:
+        type: boolean
+      staffpickedAt:
+        type:
+          - string
+          - "null"
+        format: date
+      archives:
+        type: object
+        properties:
+          source:
+            $ref: "#/definitions/ArchiveNested"
+          glb:
+            $ref: "#/definitions/ArchiveNested"
+          usdz:
+            $ref: "#/definitions/ArchiveNested"
+          gltf:
+            $ref: "#/definitions/ArchiveNested"
+      embedUrl:
+        type: string
+  OrgDetailResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/OrgDetail"
+        type: array
+  MatcapsList:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/MatcapDetail"
+        type: array
+  BackgroundResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/BackgroundList"
+        type: array
+  LikeModelResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/LikeModelList"
+        type: array
+  OrgTextureList:
+    items:
+      $ref: "#/definitions/OrgTextureDetail"
+    type: array
+  OrgDetail:
+    type: object
+    properties:
+      username:
+        type: string
+      publicProfileUrl:
+        type: string
+      orgUrl:
+        type: string
+      displayName:
+        type: string
+      uid:
+        type: string
+  CollectionSearchResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/CollectionSearchList"
+        type: array
+  SkillDetail:
+    type: object
+    properties:
+      name:
+        type: string
+      uri:
+        type: string
+  UserList:
+    type: object
+    properties:
+      website:
+        type:
+          - string
+          - "null"
+      subscriptionCount:
+        type: integer
+      followerCount:
+        type: integer
+      uid:
+        type: string
+      modelsUrl:
+        type: string
+      portfolioUrl:
+        type: string
+      likeCount:
+        type: integer
+      facebookUsername:
+        type:
+          - string
+          - "null"
+      biography:
+        type:
+          - string
+          - "null"
+      dateJoined:
+        type: string
+        format: date
+      city:
+        type:
+          - string
+          - "null"
+      account:
+        type: string
+      displayName:
+        type: string
+      profileUrl:
+        type: string
+      followingsUrl:
+        type: string
+      skills:
+        items:
+          $ref: "#/definitions/SkillDetail"
+        type: array
+      tagline:
+        type:
+          - string
+          - "null"
+      uri:
+        type: string
+      modelCount:
+        type: integer
+      username:
+        type: string
+      linkedinUsername:
+        type:
+          - string
+          - "null"
+      likesUrl:
+        type: string
+      followersUrl:
+        type: string
+      collectionCount:
+        type: integer
+      country:
+        type:
+          - string
+          - "null"
+      followingCount:
+        type: integer
+      twitterUsername:
+        type:
+          - string
+          - "null"
+      collectionsUrl:
+        type: string
+      avatar:
+        $ref: "#/definitions/AvatarRelated"
+  OrgTagList:
+    type: object
+    properties:
+      slug:
+        type: string
+      name:
+        type: string
+  LicensesResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/Licenses"
+        type: array
+  ModelDownload:
+    type: object
+    properties:
+      gltf:
+        type: object
+        properties:
+          url:
+            type: string
+            description: temporary URL where the archive can be downloaded
+            example: <download_link>
+          expires:
+            type: integer
+            description: when the temporary URL will expire (in seconds)
+            example: 300
+  ImageDetail:
+    type: object
+    properties:
+      width:
+        type: string
+      updatedAt:
+        type: string
+        format: date
+      size:
+        type: string
+      uri:
+        type: string
+      createdAt:
+        type: string
+        format: date
+      height:
+        type: string
+  MeModelList:
+    type: object
+    properties:
+      uid:
+        type: string
+      tags:
+        items:
+          $ref: "#/definitions/TagRelated"
+        type: array
+      viewerUrl:
+        type: string
+      isProtected:
+        type: boolean
+      categories:
+        items:
+          $ref: "#/definitions/CategoriesRelated"
+        type: array
+      publishedAt:
+        type: string
+        format: date
+      likeCount:
+        type: integer
+      commentCount:
+        type: integer
+      viewCount:
+        type: integer
+      vertexCount:
+        type: integer
+      user:
+        $ref: "#/definitions/UserRelated"
+      isDownloadable:
+        type: boolean
+      description:
+        type:
+          - string
+          - "null"
+      animationCount:
+        type: integer
+      name:
+        type: string
+      soundCount:
+        type: integer
+      isAgeRestricted:
+        type: boolean
+      uri:
+        type: string
+      faceCount:
+        type: integer
+      staffpickedAt:
+        type:
+          - string
+          - "null"
+        format: date
+      createdAt:
+        type: string
+        format: date
+      thumbnails:
+        $ref: "#/definitions/ThumbnailsRelated"
+      embedUrl:
+        type: string
+      archives:
+        type: object
+        properties:
+          source:
+            $ref: "#/definitions/ArchiveNested"
+          glb:
+            $ref: "#/definitions/ArchiveNested"
+          usdz:
+            $ref: "#/definitions/ArchiveNested"
+          gltf:
+            $ref: "#/definitions/ArchiveNested"
+  OrgProjectListResponse:
+    type: object
+    properties:
+      uid:
+        type: string
+      updatedAt:
+        type: string
+      memberCount:
+        type: string
+      org:
+        $ref: "#/definitions/OrgDetail"
+      slug:
+        type: string
+      modelCount:
+        type: string
+      name:
+        type: string
+  OrgBackgroundDetail:
+    type: object
+    properties:
+      uid:
+        type: string
+      name:
+        type: string
+      updatedAt:
+        type: string
+        format: date
+      images:
+        $ref: "#/definitions/OrgImagesList"
+      uri:
+        type: string
+      createdAt:
+        type: string
+        format: date
+      isDefault:
+        type: boolean
+  CreateResponse:
+    type: object
+    properties:
+      uid:
+        type: string
+      uri:
+        type: string
+  OrgModelDetail:
+    type: object
+    properties:
+      uid:
+        type: string
+      publishedAt:
+        type: string
+        format: date
+      likeCount:
+        type: integer
+      commentCount:
+        type: integer
+      isArchivesReady:
+        type: boolean
+      isDownloadable:
+        type: boolean
+      processingStatus:
+        type: string
+      isAgeRestricted:
+        type: boolean
+      pbrType:
+        type: string
+      materialCount:
+        type: integer
+      name:
+        type: string
+      staffpickedAt:
+        type: string
+        format: date
+      createdAt:
+        type: string
+        format: date
+      embedUrl:
+        type: string
+      downloadType:
+        type: string
+      description:
+        type: string
+      tags:
+        type: string
+      viewerUrl:
+        type: string
+      isProtected:
+        type: boolean
+      orgTags:
+        type: string
+      visibility:
+        type: string
+      textureCount:
+        type: integer
+      vertexCount:
+        type: integer
+      user:
+        $ref: "#/definitions/UserNested"
+      org:
+        $ref: "#/definitions/OrgNested"
+      categories:
+        type: string
+      animationCount:
+        type: integer
+      viewCount:
+        type: integer
+      thumbnails:
+        type: string
+      license:
+        type: string
+      soundCount:
+        type: integer
+      uri:
+        type: string
+      faceCount:
+        type: integer
+      hasCommentsDisabled:
+        type: boolean
+      downloadCount:
+        type: string
+  OrgLightList:
+    items:
+      $ref: "#/definitions/OrgLightDetail"
+    type: array
+  OrgImageDetail:
+    type: object
+    properties:
+      width:
+        type: string
+      updatedAt:
+        type: string
+        format: date
+      size:
+        type: string
+      uri:
+        type: string
+      createdAt:
+        type: string
+        format: date
+      height:
+        type: string
+  ThumbnailsRelated:
+    type: object
+    properties:
+      images:
+        items:
+          type: object
+          properties:
+            url:
+              type: string
+            width:
+              type: integer
+            size:
+              type:
+                - integer
+                - "null"
+            uid:
+              type: string
+            height:
+              type: integer
+        type: array
+  OrgModelListResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/OrgModelList"
+        type: array
+  OrgMatcapDetail:
+    type: object
+    properties:
+      uid:
+        type: string
+      name:
+        type: string
+      updatedAt:
+        type: string
+        format: date
+      images:
+        $ref: "#/definitions/OrgImagesList"
+      uri:
+        type:
+          - string
+          - "null"
+      createdAt:
+        type: string
+        format: date
+      isDefault:
+        type: boolean
+  BackgroundList:
+    type: object
+    properties:
+      name:
+        type: string
+      updatedAt:
+        type: string
+        format: date
+      images:
+        type: string
+      uri:
+        type: string
+      createdAt:
+        type: string
+        format: date
+      isDefault:
+        type: boolean
+  MeViewOnlyLimit:
+    type: object
+    properties:
+      type:
+        type: string
+      remaining:
+        type: integer
+      renews_at:
+        type: string
+        format: date
+  UserResponse:
+    type: object
+    properties:
+      results:
+        items:
+          $ref: "#/definitions/UserList"
+        type: array
+  CollectionDetail:
+    type: object
+    properties:
+      createdAt:
+        type: string
+        format: date
+      description:
+        type:
+          - string
+          - "null"
+      hasRestrictedContent:
+        type: boolean
+      models:
+        type: string
+      isAgeRestricted:
+        type: boolean
+      uri:
+        type: string
+      modelCount:
+        type: integer
+      user:
+        type: string
+      updatedAt:
+        type: string
+        format: date
+      owner:
+        $ref: "#/definitions/UserDetail"
+      embedUrl:
+        type: string
+      uid:
+        type: string
+      slug:
+        type: string
+      thumbnails:
+        items:
+          $ref: "#/definitions/ThumbnailsRelated"
+        type: object
+      name:
+        type: string
+  OrgTextureDetail:
+    type: object
+    properties:
+      images:
+        items:
+          $ref: "#/definitions/OrgTextureImageDetail"
+        type: array
+      format:
+        type: string
+      type:
+        type: string
+      encoding:
+        type: string
+  TagRelated:
+    type: object
+    properties:
+      slug:
+        type: string
+      uri:
+        type: string
+  OrgProjectNested:
+    type: object
+    properties:
+      uid:
+        type: string
+      name:
+        type: string
+  Licenses:
+    type: object
+    properties:
+      slug:
+        type: string
+      requirements:
+        type: string
+      url:
+        type: string
+      fullName:
+        type: string
+      uri:
+        type: string
+      label:
+        type: string
+swagger: "2.0"


### PR DESCRIPTION
This pull request introduces a new download manager feature to the UI, including a drawer panel for tracking downloads with per-item progress, speed graphs, and status badges. It also adds utility components for visualizing speed, formatting stats, and handling download actions. Additionally, it updates dependencies and adds token persistence for Sketchfab API authentication. The most important changes are grouped below.

**Download Manager UI Components:**

* Added `DownloadManagerDrawer` (side-panel drawer) and `DownloadItem` (individual row component) for visualizing active and completed downloads, including speed sparklines, progress bars, status badges, and stats. (`crates/ui/src/download_manager.rs`, `crates/ui/src/download_item.rs`) [[1]](diffhunk://#diff-9534c77b9ca06ac99002330cd79247f545dd4e2ac5225bc383645a55e9a8d5dcR1-R191) [[2]](diffhunk://#diff-05d5a79fe3c3c0041f204a051c3086334bc20d58a636b249220540ee91e01620R1-R248)
* Introduced `SpeedGraph` component for rendering download speed history as a sparkline, along with helper functions for formatting speed and byte counts. (`crates/ui/src/speed_graph.rs`)

**Integration and Re-exports:**

* Registered new modules (`download_item`, `download_manager`, `speed_graph`) and re-exported their types and helpers in `crates/ui/src/lib.rs` for easy access throughout the UI codebase. [[1]](diffhunk://#diff-a655e74761c719cd159d39c1b6f166fda47376e48b95f3de000103e64660859dR51-R53) [[2]](diffhunk://#diff-a655e74761c719cd159d39c1b6f166fda47376e48b95f3de000103e64660859dR140-R144)

**Dependency Updates:**

* Replaced the deprecated `rquest` dependency with `reqwest` for HTTP requests, and added the `dirs` crate for platform-agnostic directory handling. (`ui-crates/ui_fab_search/Cargo.toml`)

**Sketchfab API Token Persistence:**

* Added utility functions for loading, saving, and deleting Sketchfab API tokens, storing them in a platform-appropriate config directory. (`ui-crates/ui_fab_search/src/auth.rs`)

**Image Loader Refactor:**

* Updated the image loader to use `reqwest` for downloading thumbnails, simplifying the code and removing Chrome TLS impersonation logic. (`ui-crates/ui_fab_search/src/image_loader.rs`)