### PR TITLE
component system: ScriptComponent, pulsar_events, generic ComponentRuntimeContext

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -70,7 +70,8 @@
       "Bash(sed -i '' 's|rev = \"723116aabe695ff6198fbc9317d983fda05b5e21\"|rev = \"4c05ad0b146c6d3cc82d850212b64b9b91a5f3a1\"|g' /Users/tristanpoland/Documents/GitHub/Pulsar-Native/ui-crates/ui_core/Cargo.toml)",
       "Bash(python3 *)",
       "Bash(sed -n 1039,1340p /Users/tristanpoland/Documents/GitHub/Pulsar-Native/crates/engine_backend/src/subsystems/render/helio_renderer/renderer.rs)",
-      "Read(//tmp/**)"
+      "Read(//tmp/**)",
+      "Bash(git *)"
     ]
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7962,6 +7962,7 @@ name = "plugin_editor_api"
 version = "0.1.0"
 dependencies = [
  "gpui-ce",
+ "schemars",
  "serde",
  "serde_json",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,7 +4553,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.17.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4596,6 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "glam 0.33.0",
@@ -4617,7 +4615,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4628,7 +4625,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4639,7 +4635,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4650,7 +4645,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-depth-prepass"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4662,7 +4656,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4673,7 +4666,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4685,7 +4677,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4696,7 +4687,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "glam 0.33.0",
@@ -4708,7 +4698,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4718,7 +4707,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4729,7 +4717,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4739,7 +4726,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4750,7 +4736,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4762,7 +4747,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4772,7 +4756,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4782,7 +4765,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4793,7 +4775,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4804,7 +4785,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4815,7 +4795,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-smaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4826,7 +4805,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssao"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4837,7 +4815,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-taa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4848,7 +4825,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4859,7 +4835,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4871,7 +4846,6 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4882,7 +4856,6 @@ dependencies = [
 [[package]]
 name = "helio-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "futures-channel",
@@ -4899,7 +4872,6 @@ dependencies = [
 [[package]]
 name = "helio-v3"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "glam 0.33.0",
@@ -5850,7 +5822,6 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2dce3e5e28c1ef751c46d58fd197264e381d7b50#2dce3e5e28c1ef751c46d58fd197264e381d7b50"
 dependencies = [
  "bytemuck",
  "glam 0.33.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,6 +4553,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.17.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4596,6 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "glam 0.33.0",
@@ -4615,6 +4617,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4625,6 +4628,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4635,6 +4639,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4645,6 +4650,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-depth-prepass"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4656,6 +4662,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4666,6 +4673,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4677,6 +4685,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4687,6 +4696,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "glam 0.33.0",
@@ -4698,6 +4708,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4707,6 +4718,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4717,6 +4729,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4726,6 +4739,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4736,6 +4750,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4747,6 +4762,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4756,6 +4772,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4765,6 +4782,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4775,6 +4793,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4785,6 +4804,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4795,6 +4815,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-smaa"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4805,6 +4826,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssao"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4815,6 +4837,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-taa"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4825,6 +4848,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4835,6 +4859,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4846,6 +4871,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "helio-v3",
@@ -4856,6 +4882,7 @@ dependencies = [
 [[package]]
 name = "helio-snapshot"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "futures-channel",
@@ -4872,6 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-v3"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "glam 0.33.0",
@@ -5822,6 +5850,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6e5a6c75df312b9595db532a0f7a20bf9e5c62fc#6e5a6c75df312b9595db532a0f7a20bf9e5c62fc"
 dependencies = [
  "bytemuck",
  "glam 0.33.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ dependencies = [
  "parking_lot",
  "profiling 0.1.0",
  "pulsar_diagnostics",
+ "pulsar_events",
  "pulsar_lsp",
  "pulsar_reflection",
  "pulsar_scene",
@@ -8605,6 +8606,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulsar_events"
+version = "0.1.0"
+dependencies = [
+ "once_cell",
+ "parking_lot",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "pulsar_game"
 version = "0.1.0"
 dependencies = [
@@ -8711,6 +8722,7 @@ dependencies = [
  "engine_class_derive",
  "glam 0.33.0",
  "helio",
+ "pulsar_events",
  "pulsar_reflection",
  "serde",
  "serde_json",
@@ -8735,6 +8747,7 @@ dependencies = [
  "glam 0.33.0",
  "helio",
  "helio-asset-compat",
+ "pulsar_events",
  "pulsar_reflection",
  "pulsar_rendering",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ plugin_editor_api = { path = "crates/plugin_editor_api"}
 plugin_manager    = { path = "crates/plugin_manager" }
 
 # ---------- Helio Renderer (wgpu-based) ----------
-helio          = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2dce3e5e28c1ef751c46d58fd197264e381d7b50" }
-helio-snapshot = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2dce3e5e28c1ef751c46d58fd197264e381d7b50" }
+helio          = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "6e5a6c75df312b9595db532a0f7a20bf9e5c62fc" }
+helio-snapshot = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "6e5a6c75df312b9595db532a0f7a20bf9e5c62fc" }
 glam           = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- PulsarConfig ----------
@@ -179,7 +179,7 @@ rand = "0.10"
 core-foundation-sys = "0.8"
 libloading = "0.9"
 uuid = { version = "1.4", features = ["v4"] }
-helio-asset-compat = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2dce3e5e28c1ef751c46d58fd197264e381d7b50" }
+helio-asset-compat = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "6e5a6c75df312b9595db532a0f7a20bf9e5c62fc" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 sha2 = "0.11"
@@ -234,11 +234,6 @@ files.extend-exclude = ["**/fixtures/*"]
 # from git revs. Without patching, Cargo compiles a second copy of
 # every crate, causing duplicate linkme slices and trait mismatches.
 ###################################
-
-[patch."https://github.com/Far-Beyond-Pulsar/Helio"]
-helio          = { path = "/Users/tristanpoland/Documents/GitHub/Helio/crates/helio" }
-helio-snapshot = { path = "/Users/tristanpoland/Documents/GitHub/Helio/crates_other/helio-snapshot" }
-helio-asset-compat = { path = "/Users/tristanpoland/Documents/GitHub/Helio/crates/helio-asset-compat" }
 
 [patch."https://github.com/Far-Beyond-Pulsar/Pulsar-Native"]
 # Core engine crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,11 @@ files.extend-exclude = ["**/fixtures/*"]
 # every crate, causing duplicate linkme slices and trait mismatches.
 ###################################
 
+[patch."https://github.com/Far-Beyond-Pulsar/Helio"]
+helio          = { path = "/Users/tristanpoland/Documents/GitHub/Helio/crates/helio" }
+helio-snapshot = { path = "/Users/tristanpoland/Documents/GitHub/Helio/crates_other/helio-snapshot" }
+helio-asset-compat = { path = "/Users/tristanpoland/Documents/GitHub/Helio/crates/helio-asset-compat" }
+
 [patch."https://github.com/Far-Beyond-Pulsar/Pulsar-Native"]
 # Core engine crates
 ui                    = { path = "crates/ui" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ agent_provider_cohere              = { path = "agent-providers/agent_provider_co
 
 # ---------- Reflection System ----------
 pulsar_reflection     = { path = "crates/pulsar_reflection" }
+pulsar_events         = { path = "crates/pulsar_events" }
 engine_class_derive   = { path = "crates/engine_class_derive" }
 
 # ---------- Component Crates ----------

--- a/crates/engine_backend/Cargo.toml
+++ b/crates/engine_backend/Cargo.toml
@@ -27,6 +27,7 @@ dashmap = { workspace = true }
 
 # Reflection system
 pulsar_reflection.workspace = true
+pulsar_events.workspace = true
 engine_state.workspace = true
 
 # Shared scene loading — canonical implementation used by both engine and game

--- a/crates/engine_backend/src/scene/mod.rs
+++ b/crates/engine_backend/src/scene/mod.rs
@@ -55,6 +55,7 @@ pub enum ObjectType {
     Mesh(MeshType),
     ParticleSystem,
     AudioSource,
+    Blueprint,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
+++ b/crates/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
@@ -7,16 +7,16 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::time::Instant;
 
 use helio::{
-    Camera, EditorState, GizmoMode, GpuLight, GpuMaterial, GroupMask, LightId, LightType,
-    MaterialId, MeshId, MeshUpload, Movability, ObjectDescriptor, ObjectId, PackedVertex, Renderer,
-    RendererConfig, SceneActor, ScenePicker, SkyActor,
+    Camera, EditorState, GizmoMode, GpuMaterial, GroupMask, LightId,
+    MaterialId, MeshId, MeshUpload, Movability, ObjectDescriptor, ObjectId, PackedVertex,
+    Renderer, RendererConfig, SceneActor, SceneActorId, ScenePicker, SkyActor,
 };
 use helio_asset_compat::ConvertedScene;
 use engine_fs::virtual_fs;
 use pulsar_scene::{component_instances_from_props, build_transform_parts};
 use pulsar_reflection::{
     apply_runtime_behavior_for_class, ComponentRuntimeContext, RuntimeComponentOwner,
-    SceneRenderPayload,
+    scene_id_to_tag,
 };
 use pulsar_events::SCRIPT_REGISTRY;
 
@@ -277,26 +277,10 @@ pub struct HelioRenderer {
 }
 
 struct HelioInner {
-    renderer: Renderer,
-    device: Arc<wgpu::Device>,
-    queue: Arc<wgpu::Queue>,
-    /// SceneDb id → (helio ObjectId, MeshId) — mesh objects only.
-    object_map: HashMap<String, (ObjectId, MeshId)>,
-    /// SceneDb id → helio LightId — lights only, for illumination.
-    /// Helio renders its own billboard for each light; this map lets us
-    /// reverse-lookup SceneDb IDs from the actor the user clicks.
-    light_map: HashMap<String, LightId>,
-    /// LightId → SceneDb id reverse index (built alongside light_map).
-    light_id_to_scene: HashMap<LightId, String>,
-    /// MeshKey → (MeshId, MaterialId) shared across objects of that shape/file.
-    mesh_cache: HashMap<MeshKey, (MeshId, MaterialId)>,
-    /// Raw mesh_asset path → resolved mesh key (or None if unresolved).
-    mesh_asset_resolution_cache: HashMap<String, Option<MeshKey>>,
-    /// Tracks unresolved mesh paths that have already been reported.
-    reported_mesh_asset_errors: HashSet<String>,
-    /// Helio editor state for gizmo management
+    renderer:     Renderer,
+    device:       Arc<wgpu::Device>,
+    queue:        Arc<wgpu::Queue>,
     editor_state: EditorState,
-    /// Scene picker for raycasting object selection
     scene_picker: ScenePicker,
 }
 
@@ -312,9 +296,9 @@ impl HelioRenderer {
             pending_deselect: Arc::new(AtomicBool::new(false)),
             inner: None,
             pending_errors: Arc::new(Mutex::new(Vec::new())),
-            cam_pos: Vec3::new(8.0, 6.0, 12.0), // Better view angle
-            cam_yaw: -0.5,                      // Look left a bit
-            cam_pitch: -0.3,                    // Look down to see objects
+            cam_pos: Vec3::new(8.0, 6.0, 12.0),
+            cam_yaw: -0.5,
+            cam_pitch: -0.3,
             cam_local_velocity: Vec3::ZERO,
             viewport_size: (0, 0),
             metrics: Arc::new(Mutex::new(RenderMetrics::default())),
@@ -383,15 +367,9 @@ impl HelioRenderer {
             r.set_ambient([0.0, 0.0, 0.0], 0.0);
 
             let mut inner = HelioInner {
-                renderer: r,
-                device: device_arc,
-                queue: queue_arc,
-                object_map: HashMap::new(),
-                light_map: HashMap::new(),
-                light_id_to_scene: HashMap::new(),
-                mesh_cache: HashMap::new(),
-                mesh_asset_resolution_cache: HashMap::new(),
-                reported_mesh_asset_errors: HashSet::new(),
+                renderer:     r,
+                device:       device_arc,
+                queue:        queue_arc,
                 editor_state: EditorState::new(),
                 scene_picker: ScenePicker::new(),
             };
@@ -633,6 +611,7 @@ impl HelioRenderer {
                             flags: 0,
                             groups: GroupMask::NONE,
                             movability: Some(Movability::Movable),
+                            user_tag: 0,
                         }));
 
                 inserted_any = true;
@@ -687,6 +666,7 @@ impl HelioRenderer {
                             flags: 0,
                             groups: GroupMask::NONE,
                             movability: Some(Movability::Movable),
+                            user_tag: 0,
                         }));
 
                 inserted_any = true;
@@ -757,38 +737,38 @@ impl HelioRenderer {
     pub fn get_selected_scene_db_id(&self) -> Option<String> {
         use helio::SceneActorId;
         let inner = self.inner.as_ref()?;
-        let selected = inner.editor_state.selected()?;
-        match selected {
-            SceneActorId::Object(obj_id) => inner
-                .object_map
-                .iter()
-                .find(|(_, (oid, _))| *oid == obj_id)
-                .map(|(id, _)| scene_id_from_actor_key(id).to_string()),
-            SceneActorId::Light(light_id) => inner.light_id_to_scene.get(&light_id).cloned(),
-            _ => None,
-        }
+        let tag = match inner.editor_state.selected()? {
+            SceneActorId::Object(obj_id) => inner.renderer.scene()
+                .iter_objects_for_editor()
+                .find(|(id, _, _, _)| *id == obj_id)
+                .map(|(_, _, _, t)| t)?,
+            SceneActorId::Light(light_id) => inner.renderer.scene()
+                .iter_lights()
+                .find(|(id, _, _)| *id == light_id)
+                .map(|(_, _, t)| t)?,
+            _ => return None,
+        };
+        self.scene_db.get_all_snapshots()
+            .into_iter()
+            .find(|snap| scene_id_to_tag(&snap.id) == tag)
+            .map(|snap| snap.id)
     }
 
     /// Select an object or light by its SceneDb ID.
     pub fn select_by_scene_db_id(&mut self, scene_db_id: &str) -> bool {
         use helio::SceneActorId;
-        let Some(inner) = &mut self.inner else {
-            return false;
-        };
+        let Some(inner) = &mut self.inner else { return false };
+        let tag = scene_id_to_tag(scene_db_id);
 
-        if let Some((obj_id, _)) = inner
-            .object_map
-            .iter()
-            .find(|(key, _)| scene_id_from_actor_key(key) == scene_db_id)
-            .map(|(_, value)| value)
+        if let Some((obj_id, _, _, _)) = inner.renderer.scene()
+            .iter_objects_for_editor()
+            .find(|(_, _, _, t)| *t == tag)
         {
-            inner.editor_state.select(SceneActorId::Object(*obj_id));
+            inner.editor_state.select(SceneActorId::Object(obj_id));
             true
-        } else if let Some(&light_id) = inner
-            .light_map
-            .iter()
-            .find(|(key, _)| scene_id_from_actor_key(key) == scene_db_id)
-            .map(|(_, value)| value)
+        } else if let Some((light_id, _, _)) = inner.renderer.scene()
+            .iter_lights()
+            .find(|(_, _, t)| *t == tag)
         {
             inner.editor_state.select(SceneActorId::Light(light_id));
             true
@@ -820,20 +800,23 @@ impl HelioRenderer {
         };
 
         if let Some(ref id) = scene_db_id {
-            // Look up the Helio ObjectId from the scene_db_id
-            if let Some((helio_obj_id, _)) = inner
-                .object_map
-                .iter()
-                .find(|(key, _)| scene_id_from_actor_key(key) == id.as_str())
-                .map(|(_, value)| value)
+            let tag = scene_id_to_tag(id);
+            if let Some((obj_id, _, _, _)) = inner.renderer.scene()
+                .iter_objects_for_editor()
+                .find(|(_, _, _, t)| *t == tag)
             {
-                inner
-                    .editor_state
-                    .select(SceneActorId::Object(*helio_obj_id));
-                tracing::info!("[ATOMIC] Selected object: {} -> {:?}", id, helio_obj_id);
+                inner.editor_state.select(SceneActorId::Object(obj_id));
+                tracing::info!("[ATOMIC] Selected object: {}", id);
+                true
+            } else if let Some((light_id, _, _)) = inner.renderer.scene()
+                .iter_lights()
+                .find(|(_, _, t)| *t == tag)
+            {
+                inner.editor_state.select(SceneActorId::Light(light_id));
+                tracing::info!("[ATOMIC] Selected light: {}", id);
                 true
             } else {
-                tracing::warn!("[ATOMIC] Object not found in object_map: {}", id);
+                tracing::warn!("[ATOMIC] Actor not found for scene ID: {}", id);
                 false
             }
         } else {
@@ -886,29 +869,13 @@ impl HelioRenderer {
                     .cast_ray(inner.renderer.scene(), ray_o, ray_d)
                 {
                     match hit.actor_id {
-                        SceneActorId::Object(helio_obj_id) => {
-                            if let Some(scene_db_id) = inner
-                                .object_map
-                                .iter()
-                                .find(|(_, (oid, _))| *oid == helio_obj_id)
-                                .map(|(id, _)| scene_id_from_actor_key(id).to_string())
-                            {
-                                Some(Some(scene_db_id))
-                            } else {
-                                inner.editor_state.select(hit.actor_id);
-                                None
-                            }
-                        }
-                        SceneActorId::Light(light_id) => {
-                            // Light billboard clicked — resolve to SceneDb ID.
-                            if let Some(scene_db_id) =
-                                inner.light_id_to_scene.get(&light_id).cloned()
-                            {
-                                Some(Some(scene_db_id))
-                            } else {
-                                inner.editor_state.select(hit.actor_id);
-                                None
-                            }
+                        SceneActorId::Object(_) | SceneActorId::Light(_) => {
+                            // Resolve SceneDb ID by scanning for matching user_tag.
+                            let scene_db_id = self.scene_db.get_all_snapshots()
+                                .into_iter()
+                                .find(|snap| scene_id_to_tag(&snap.id) == hit.user_tag)
+                                .map(|snap| snap.id);
+                            Some(scene_db_id)
                         }
                         _ => {
                             inner.editor_state.select(hit.actor_id);
@@ -969,11 +936,15 @@ impl HelioRenderer {
                     if let Ok(mat) = inner.renderer.scene().get_object_transform(obj_id) {
                         let (scale_v, quat, pos_v) = mat.to_scale_rotation_translation();
                         let (yaw, pitch, roll) = quat.to_euler(EulerRot::YXZ);
-                        if let Some(scene_id) = inner
-                            .object_map
-                            .iter()
-                            .find(|(_, &(oid, _))| oid == obj_id)
-                            .map(|(id, _)| scene_id_from_actor_key(id).to_string())
+                        let tag = inner.renderer.scene()
+                            .iter_objects_for_editor()
+                            .find(|(id, _, _, _)| *id == obj_id)
+                            .map(|(_, _, _, t)| t)
+                            .unwrap_or(0);
+                        if let Some(scene_id) = self.scene_db.get_all_snapshots()
+                            .into_iter()
+                            .find(|snap| scene_id_to_tag(&snap.id) == tag)
+                            .map(|snap| snap.id)
                         {
                             self.scene_db.apply_transform(
                                 &scene_id,
@@ -991,8 +962,16 @@ impl HelioRenderer {
                             gpu_light.position_range[1],
                             gpu_light.position_range[2],
                         ];
-                        if let Some(scene_id) = inner.light_id_to_scene.get(&light_id).cloned() {
-                            // Lights have no meaningful rotation or scale — preserve existing values.
+                        let tag = inner.renderer.scene()
+                            .iter_lights()
+                            .find(|(id, _, _)| *id == light_id)
+                            .map(|(_, _, t)| t)
+                            .unwrap_or(0);
+                        if let Some(scene_id) = self.scene_db.get_all_snapshots()
+                            .into_iter()
+                            .find(|snap| scene_id_to_tag(&snap.id) == tag)
+                            .map(|snap| snap.id)
+                        {
                             self.scene_db.apply_transform(
                                 &scene_id,
                                 pos,
@@ -1041,158 +1020,33 @@ impl HelioRenderer {
         }
 
         struct HelioRuntimeContext<'a> {
-            inner:            &'a mut HelioInner,
+            renderer:         &'a mut Renderer,
             owner_snap:       &'a SceneObjectSnapshot,
-            live_mesh_ids:    &'a mut std::collections::HashSet<String>,
-            live_light_ids:   &'a mut std::collections::HashSet<String>,
             live_script_keys: &'a mut std::collections::HashSet<String>,
-            dragged_obj_id:   Option<ObjectId>,
-            dragged_light_id: Option<LightId>,
-            picker_dirty:     &'a mut bool,
             error_queue:      &'a Arc<Mutex<Vec<String>>>,
         }
 
         impl<'a> ComponentRuntimeContext for HelioRuntimeContext<'a> {
-            fn upsert_actor(&mut self, actor_key: String, payload: SceneRenderPayload) {
-                match payload {
-                    SceneRenderPayload::Light(gpu_light) => {
-                        self.live_light_ids.insert(actor_key.clone());
-
-                        if let Some(&light_id) = self.inner.light_map.get(&actor_key) {
-                            // Skip updating if this light is currently being dragged —
-                            // Helio owns its position while the gizmo is active.
-                            if Some(light_id) != self.dragged_light_id {
-                                let _ = self.inner.renderer.scene_mut()
-                                    .update_light(light_id, gpu_light);
-                            }
-                        } else if let Some(light_id) = self.inner.renderer.scene_mut()
-                            .insert_actor(SceneActor::light(gpu_light))
-                            .as_light()
-                        {
-                            self.inner.light_map.insert(actor_key.clone(), light_id);
-                            self.inner.light_id_to_scene
-                                .insert(light_id, self.owner_snap.id.clone());
-                        }
-                    }
-
-                    SceneRenderPayload::Mesh(upload) => {
-                        self.live_mesh_ids.insert(actor_key.clone());
-
-                        // The mesh cache key is derived from the MeshUpload content.
-                        // We use the actor_key itself as the cache key so that each
-                        // unique scene object keeps its own mesh entry.
-                        //
-                        // If the mesh for this actor_key is not yet cached, insert it
-                        // into the Helio scene and cache the resulting IDs.
-                        if !self.inner.mesh_cache.contains_key(&MeshKey::File(actor_key.clone())) {
-                            let mid = match self.inner.renderer.scene_mut()
-                                .insert_actor(SceneActor::mesh(upload.clone()))
-                                .as_mesh()
-                            {
-                                Some(m) => m,
-                                None => {
-                                    self.report_error(format!(
-                                        "Failed to insert mesh for actor '{}'", actor_key
-                                    ));
-                                    return;
-                                }
-                            };
-                            let mat = make_material([0.6, 0.6, 0.65, 1.0], 0.7, 0.0);
-                            let matid = self.inner.renderer.scene_mut().insert_material(mat);
-                            self.inner.scene_picker.register_mesh(mid, &upload);
-                            self.inner.mesh_cache.insert(
-                                MeshKey::File(actor_key.clone()),
-                                (mid, matid),
-                            );
-                        }
-
-                        let (mesh_id, mat_id) =
-                            self.inner.mesh_cache[&MeshKey::File(actor_key.clone())];
-                        let transform = build_transform(self.owner_snap);
-                        let radius = Vec3::from_array(self.owner_snap.scale).length() * 0.5;
-                        let pos    = transform.w_axis.truncate();
-                        let existing = self.inner.object_map.get(&actor_key).copied();
-
-                        if let Some((obj_id, existing_mesh_id)) = existing {
-                            let skip = self.dragged_obj_id.map_or(false, |did| did == obj_id);
-                            if existing_mesh_id != mesh_id {
-                                // Mesh changed — remove old object and re-insert.
-                                let _ = self.inner.renderer.scene_mut().remove_object(obj_id);
-                                if let Some(new_obj_id) = self.inner.renderer.scene_mut()
-                                    .insert_actor(SceneActor::object(ObjectDescriptor {
-                                        mesh: mesh_id, material: mat_id, transform,
-                                        bounds: [pos.x, pos.y, pos.z, radius.max(0.1)],
-                                        flags: 0, groups: GroupMask::NONE,
-                                        movability: Some(Movability::Movable),
-                                    }))
-                                    .as_object()
-                                {
-                                    self.inner.object_map.insert(actor_key, (new_obj_id, mesh_id));
-                                    *self.picker_dirty = true;
-                                }
-                            } else if !skip {
-                                let _ = self.inner.renderer.scene_mut()
-                                    .update_object_transform(obj_id, transform);
-                            }
-                        } else if let Some(obj_id) = self.inner.renderer.scene_mut()
-                            .insert_actor(SceneActor::object(ObjectDescriptor {
-                                mesh: mesh_id, material: mat_id, transform,
-                                bounds: [pos.x, pos.y, pos.z, radius.max(0.1)],
-                                flags: 0, groups: GroupMask::NONE,
-                                movability: Some(Movability::Movable),
-                            }))
-                            .as_object()
-                        {
-                            self.inner.object_map.insert(actor_key, (obj_id, mesh_id));
-                            *self.picker_dirty = true;
-                        }
-                    }
-                }
+            fn renderer_mut(&mut self) -> &mut Renderer {
+                self.renderer
             }
 
             fn project_root(&self) -> &std::path::Path {
-                // The editor resolves paths via engine_state; load_mesh_file handles
-                // this internally.  Return an empty path as the canonical fallback.
+                // Editor resolves paths via engine_state inside load_mesh_file.
                 std::path::Path::new("")
             }
 
             fn load_mesh_file(&mut self, path: &std::path::Path) -> Option<MeshUpload> {
-                let path_str = path.to_str().unwrap_or("");
-                if path_str.is_empty() {
-                    return None;
-                }
-                let mesh_key = mesh_key_from_asset_path(path_str)?;
-
-                // Cache resolved MeshUpload so repeated sync passes don't reload disk.
-                if !self.inner.mesh_cache.contains_key(&mesh_key) {
-                    match mesh_for_key(&mesh_key) {
-                        Ok(upload) => {
-                            let mid = self.inner.renderer.scene_mut()
-                                .insert_actor(SceneActor::mesh(upload.clone()))
-                                .as_mesh()
-                                .expect("mesh actor handle");
-                            let mat  = make_material([0.6, 0.6, 0.65, 1.0], 0.7, 0.0);
-                            let matid = self.inner.renderer.scene_mut().insert_material(mat);
-                            self.inner.scene_picker.register_mesh(mid, &upload);
-                            self.inner.mesh_cache.insert(mesh_key.clone(), (mid, matid));
-                            // Return the upload for the caller to wrap in SceneRenderPayload.
-                            return Some(upload);
-                        }
-                        Err(e) => {
-                            if self.inner.reported_mesh_asset_errors.insert(path_str.to_string()) {
-                                self.report_error(format!(
-                                    "Failed to load mesh '{}': {}", path_str, e
-                                ));
-                            }
-                            return None;
-                        }
+                let key = mesh_key_from_asset_path(path.to_str().unwrap_or(""))?;
+                match mesh_for_key(&key) {
+                    Ok(u)  => Some(u),
+                    Err(e) => {
+                        self.report_error(format!(
+                            "Failed to load mesh '{}': {e}", path.display()
+                        ));
+                        None
                     }
                 }
-                // Already in cache — we need to return a MeshUpload for upsert_actor to use.
-                // Re-load from disk to get a fresh upload (the cache is for MeshId/MatId, not
-                // the raw geometry).  This is only reached on the first frame after a hot-reload.
-                self.inner.reported_mesh_asset_errors.remove(path_str);
-                mesh_for_key(&mesh_key).ok()
             }
 
             fn mark_live(&mut self, actor_key: &str) {
@@ -1207,35 +1061,38 @@ impl HelioRenderer {
             }
         }
 
+        // Skip sync while the gizmo is actively dragging — helio owns transforms
+        // during drag, and re-inserting from SceneDb would fight the gizmo.
+        // Drag-end (`handle_left_release`) writes the final position back to SceneDb.
+        if inner.editor_state.is_dragging() {
+            return;
+        }
+
+        // ── Clear all lights and objects from the helio scene ─────────────────
+        // Collect IDs before mutating (iterators are invalidated by removal).
+        let light_ids: Vec<LightId> = inner.renderer.scene()
+            .iter_lights()
+            .map(|(id, _, _)| id)
+            .collect();
+        for id in light_ids {
+            let _ = inner.renderer.scene_mut().remove_light(id);
+        }
+
+        let object_ids: Vec<ObjectId> = inner.renderer.scene()
+            .iter_objects_for_editor()
+            .map(|(id, _, _, _)| id)
+            .collect();
+        for id in object_ids {
+            let _ = inner.renderer.scene_mut().remove_object(id);
+        }
+
+        // ── Component sync pass ───────────────────────────────────────────────
         let snapshots = scene_db.get_all_snapshots();
-        let mut picker_dirty = false;
-
-        let gizmo_dragging = inner.editor_state.is_dragging();
-        let dragged_obj_id: Option<ObjectId> = if gizmo_dragging {
-            inner.editor_state.selected_object()
-        } else {
-            None
-        };
-        // When a light is being dragged Helio owns its position — don't overwrite it.
-        let dragged_light_id: Option<LightId> = if gizmo_dragging {
-            use helio::SceneActorId;
-            if let Some(SceneActorId::Light(lid)) = inner.editor_state.selected() {
-                Some(lid)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        let mut live_mesh_ids    = std::collections::HashSet::new();
-        let mut live_light_ids   = std::collections::HashSet::new();
         let mut live_script_keys = std::collections::HashSet::new();
 
         for snap in &snapshots {
-            if !snap.visible {
-                continue;
-            }
+            if !snap.visible { continue; }
+
             let owner = RuntimeComponentOwner {
                 scene_object_id: snap.id.as_str(),
                 position: snap.position,
@@ -1245,15 +1102,10 @@ impl HelioRenderer {
             };
 
             let component_instances = component_instances_from_snap(snap);
-            let mut runtime_context = HelioRuntimeContext {
-                inner,
+            let mut ctx = HelioRuntimeContext {
+                renderer:         &mut inner.renderer,
                 owner_snap:       snap,
-                live_mesh_ids:    &mut live_mesh_ids,
-                live_light_ids:   &mut live_light_ids,
                 live_script_keys: &mut live_script_keys,
-                dragged_obj_id,
-                dragged_light_id,
-                picker_dirty:     &mut picker_dirty,
                 error_queue,
             };
 
@@ -1263,45 +1115,15 @@ impl HelioRenderer {
                     &owner,
                     component_index,
                     &data,
-                    &mut runtime_context,
+                    &mut ctx,
                 );
             }
         }
 
-        // ── Stale removal ────────────────────────────────────────────────────
-
-        // Meshes and objects no longer referenced by any live component.
-        let stale_meshes: Vec<(String, ObjectId)> = inner
-            .object_map
-            .iter()
-            .filter(|(key, _)| !live_mesh_ids.contains(*key))
-            .map(|(id, &(oid, _))| (id.clone(), oid))
-            .collect();
-        for (sid, oid) in stale_meshes {
-            let _ = inner.renderer.scene_mut().remove_object(oid);
-            inner.object_map.remove(&sid);
-            inner.mesh_cache.remove(&MeshKey::File(sid));
-            picker_dirty = true;
-        }
-
-        // Lights no longer referenced by any live component.
-        let stale_lights: Vec<(String, LightId)> = inner
-            .light_map
-            .iter()
-            .filter(|(key, _)| !live_light_ids.contains(*key))
-            .map(|(id, &lid)| (id.clone(), lid))
-            .collect();
-        for (sid, lid) in stale_lights {
-            let _ = inner.renderer.scene_mut().remove_light(lid);
-            inner.light_id_to_scene.remove(&lid);
-            inner.light_map.remove(&sid);
-        }
-
-        // Script registrations no longer referenced by any live ScriptComponent.
+        // Cull script registrations for objects no longer in the scene.
         SCRIPT_REGISTRY.lock().retain_keys(&live_script_keys);
 
-        if picker_dirty {
-            inner.scene_picker.rebuild_instances(inner.renderer.scene());
-        }
+        // Rebuild scene picker BVH from the freshly inserted objects.
+        inner.scene_picker.rebuild_instances(inner.renderer.scene());
     }
 }

--- a/crates/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
+++ b/crates/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
@@ -16,8 +16,9 @@ use engine_fs::virtual_fs;
 use pulsar_scene::{component_instances_from_props, build_transform_parts};
 use pulsar_reflection::{
     apply_runtime_behavior_for_class, ComponentRuntimeContext, RuntimeComponentOwner,
-    RuntimeMeshDesc,
+    SceneRenderPayload,
 };
+use pulsar_events::SCRIPT_REGISTRY;
 
 use crate::scene::{ObjectType, SceneObjectSnapshot};
 
@@ -1040,149 +1041,162 @@ impl HelioRenderer {
         }
 
         struct HelioRuntimeContext<'a> {
-            inner: &'a mut HelioInner,
-            owner_snap: &'a SceneObjectSnapshot,
-            live_mesh_ids: &'a mut std::collections::HashSet<String>,
-            live_light_ids: &'a mut std::collections::HashSet<String>,
-            dragged_obj_id: Option<ObjectId>,
+            inner:            &'a mut HelioInner,
+            owner_snap:       &'a SceneObjectSnapshot,
+            live_mesh_ids:    &'a mut std::collections::HashSet<String>,
+            live_light_ids:   &'a mut std::collections::HashSet<String>,
+            live_script_keys: &'a mut std::collections::HashSet<String>,
+            dragged_obj_id:   Option<ObjectId>,
             dragged_light_id: Option<LightId>,
-            picker_dirty: &'a mut bool,
-            error_queue: &'a Arc<Mutex<Vec<String>>>,
+            picker_dirty:     &'a mut bool,
+            error_queue:      &'a Arc<Mutex<Vec<String>>>,
         }
 
         impl<'a> ComponentRuntimeContext for HelioRuntimeContext<'a> {
-            fn upsert_light(&mut self, actor_key: String, gpu_light: GpuLight) {
-                self.live_light_ids.insert(actor_key.clone());
+            fn upsert_actor(&mut self, actor_key: String, payload: SceneRenderPayload) {
+                match payload {
+                    SceneRenderPayload::Light(gpu_light) => {
+                        self.live_light_ids.insert(actor_key.clone());
 
-                // GpuLight is built by the component — no translation here.
-                if let Some(&light_id) = self.inner.light_map.get(&actor_key) {
-                    if Some(light_id) == self.dragged_light_id {
-                        return;
+                        if let Some(&light_id) = self.inner.light_map.get(&actor_key) {
+                            // Skip updating if this light is currently being dragged —
+                            // Helio owns its position while the gizmo is active.
+                            if Some(light_id) != self.dragged_light_id {
+                                let _ = self.inner.renderer.scene_mut()
+                                    .update_light(light_id, gpu_light);
+                            }
+                        } else if let Some(light_id) = self.inner.renderer.scene_mut()
+                            .insert_actor(SceneActor::light(gpu_light))
+                            .as_light()
+                        {
+                            self.inner.light_map.insert(actor_key.clone(), light_id);
+                            self.inner.light_id_to_scene
+                                .insert(light_id, self.owner_snap.id.clone());
+                        }
                     }
-                    let _ = self.inner.renderer.scene_mut().update_light(light_id, gpu_light);
-                } else if let Some(light_id) = self
-                    .inner
-                    .renderer
-                    .scene_mut()
-                    .insert_actor(SceneActor::light(gpu_light))
-                    .as_light()
-                {
-                    self.inner.light_map.insert(actor_key, light_id);
-                    self.inner
-                        .light_id_to_scene
-                        .insert(light_id, self.owner_snap.id.clone());
-                }
-            }
 
-            fn upsert_mesh(&mut self, desc: RuntimeMeshDesc) {
-                self.live_mesh_ids.insert(desc.actor_key.clone());
+                    SceneRenderPayload::Mesh(upload) => {
+                        self.live_mesh_ids.insert(actor_key.clone());
 
-                let mesh_key_opt = if let Some(cached) = self
-                    .inner
-                    .mesh_asset_resolution_cache
-                    .get(&desc.mesh_asset)
-                {
-                    cached.clone()
-                } else {
-                    let resolved = mesh_key_from_asset_path(desc.mesh_asset.as_str());
-                    self.inner
-                        .mesh_asset_resolution_cache
-                        .insert(desc.mesh_asset.clone(), resolved.clone());
-                    resolved
-                };
-
-                let Some(mesh_key) = mesh_key_opt else {
-                    if self
-                        .inner
-                        .reported_mesh_asset_errors
-                        .insert(desc.mesh_asset.clone())
-                    {
-                        self.report_error(format!(
-                            "Failed to resolve mesh asset path '{}' for object {}",
-                            desc.mesh_asset, self.owner_snap.id
-                        ));
-                    }
-                    return;
-                };
-                self.inner.reported_mesh_asset_errors.remove(&desc.mesh_asset);
-
-                if !self.inner.mesh_cache.contains_key(&mesh_key) {
-                    match mesh_for_key(&mesh_key) {
-                        Ok(upload) => {
-                            let mid = self
-                                .inner
-                                .renderer
-                                .scene_mut()
+                        // The mesh cache key is derived from the MeshUpload content.
+                        // We use the actor_key itself as the cache key so that each
+                        // unique scene object keeps its own mesh entry.
+                        //
+                        // If the mesh for this actor_key is not yet cached, insert it
+                        // into the Helio scene and cache the resulting IDs.
+                        if !self.inner.mesh_cache.contains_key(&MeshKey::File(actor_key.clone())) {
+                            let mid = match self.inner.renderer.scene_mut()
                                 .insert_actor(SceneActor::mesh(upload.clone()))
                                 .as_mesh()
-                                .expect("mesh");
+                            {
+                                Some(m) => m,
+                                None => {
+                                    self.report_error(format!(
+                                        "Failed to insert mesh for actor '{}'", actor_key
+                                    ));
+                                    return;
+                                }
+                            };
                             let mat = make_material([0.6, 0.6, 0.65, 1.0], 0.7, 0.0);
                             let matid = self.inner.renderer.scene_mut().insert_material(mat);
                             self.inner.scene_picker.register_mesh(mid, &upload);
-                            self.inner.mesh_cache.insert(mesh_key.clone(), (mid, matid));
+                            self.inner.mesh_cache.insert(
+                                MeshKey::File(actor_key.clone()),
+                                (mid, matid),
+                            );
                         }
-                        Err(e) => {
-                            self.report_error(e);
-                            return;
-                        }
-                    }
-                }
 
-                let (mesh_id, mat_id) = self.inner.mesh_cache[&mesh_key];
-                let transform = build_transform(self.owner_snap);
-                let radius = Vec3::from_array(self.owner_snap.scale).length() * 0.5;
-                let pos = transform.w_axis.truncate();
-                let existing = self.inner.object_map.get(&desc.actor_key).copied();
+                        let (mesh_id, mat_id) =
+                            self.inner.mesh_cache[&MeshKey::File(actor_key.clone())];
+                        let transform = build_transform(self.owner_snap);
+                        let radius = Vec3::from_array(self.owner_snap.scale).length() * 0.5;
+                        let pos    = transform.w_axis.truncate();
+                        let existing = self.inner.object_map.get(&actor_key).copied();
 
-                if let Some((obj_id, existing_mesh_id)) = existing {
-                    let skip = self.dragged_obj_id.map_or(false, |did| did == obj_id);
-                    if existing_mesh_id != mesh_id {
-                        let _ = self.inner.renderer.scene_mut().remove_object(obj_id);
-                        if let Some(new_obj_id) = self
-                            .inner
-                            .renderer
-                            .scene_mut()
+                        if let Some((obj_id, existing_mesh_id)) = existing {
+                            let skip = self.dragged_obj_id.map_or(false, |did| did == obj_id);
+                            if existing_mesh_id != mesh_id {
+                                // Mesh changed — remove old object and re-insert.
+                                let _ = self.inner.renderer.scene_mut().remove_object(obj_id);
+                                if let Some(new_obj_id) = self.inner.renderer.scene_mut()
+                                    .insert_actor(SceneActor::object(ObjectDescriptor {
+                                        mesh: mesh_id, material: mat_id, transform,
+                                        bounds: [pos.x, pos.y, pos.z, radius.max(0.1)],
+                                        flags: 0, groups: GroupMask::NONE,
+                                        movability: Some(Movability::Movable),
+                                    }))
+                                    .as_object()
+                                {
+                                    self.inner.object_map.insert(actor_key, (new_obj_id, mesh_id));
+                                    *self.picker_dirty = true;
+                                }
+                            } else if !skip {
+                                let _ = self.inner.renderer.scene_mut()
+                                    .update_object_transform(obj_id, transform);
+                            }
+                        } else if let Some(obj_id) = self.inner.renderer.scene_mut()
                             .insert_actor(SceneActor::object(ObjectDescriptor {
-                                mesh: mesh_id,
-                                material: mat_id,
-                                transform,
+                                mesh: mesh_id, material: mat_id, transform,
                                 bounds: [pos.x, pos.y, pos.z, radius.max(0.1)],
-                                flags: 0,
-                                groups: GroupMask::NONE,
+                                flags: 0, groups: GroupMask::NONE,
                                 movability: Some(Movability::Movable),
                             }))
                             .as_object()
                         {
-                            self.inner
-                                .object_map
-                                .insert(desc.actor_key, (new_obj_id, mesh_id));
+                            self.inner.object_map.insert(actor_key, (obj_id, mesh_id));
                             *self.picker_dirty = true;
                         }
-                    } else if !skip {
-                        let _ = self
-                            .inner
-                            .renderer
-                            .scene_mut()
-                            .update_object_transform(obj_id, transform);
                     }
-                } else if let Some(obj_id) = self
-                    .inner
-                    .renderer
-                    .scene_mut()
-                    .insert_actor(SceneActor::object(ObjectDescriptor {
-                        mesh: mesh_id,
-                        material: mat_id,
-                        transform,
-                        bounds: [pos.x, pos.y, pos.z, radius.max(0.1)],
-                        flags: 0,
-                        groups: GroupMask::NONE,
-                        movability: Some(Movability::Movable),
-                    }))
-                    .as_object()
-                {
-                    self.inner.object_map.insert(desc.actor_key, (obj_id, mesh_id));
-                    *self.picker_dirty = true;
                 }
+            }
+
+            fn project_root(&self) -> &std::path::Path {
+                // The editor resolves paths via engine_state; load_mesh_file handles
+                // this internally.  Return an empty path as the canonical fallback.
+                std::path::Path::new("")
+            }
+
+            fn load_mesh_file(&mut self, path: &std::path::Path) -> Option<MeshUpload> {
+                let path_str = path.to_str().unwrap_or("");
+                if path_str.is_empty() {
+                    return None;
+                }
+                let mesh_key = mesh_key_from_asset_path(path_str)?;
+
+                // Cache resolved MeshUpload so repeated sync passes don't reload disk.
+                if !self.inner.mesh_cache.contains_key(&mesh_key) {
+                    match mesh_for_key(&mesh_key) {
+                        Ok(upload) => {
+                            let mid = self.inner.renderer.scene_mut()
+                                .insert_actor(SceneActor::mesh(upload.clone()))
+                                .as_mesh()
+                                .expect("mesh actor handle");
+                            let mat  = make_material([0.6, 0.6, 0.65, 1.0], 0.7, 0.0);
+                            let matid = self.inner.renderer.scene_mut().insert_material(mat);
+                            self.inner.scene_picker.register_mesh(mid, &upload);
+                            self.inner.mesh_cache.insert(mesh_key.clone(), (mid, matid));
+                            // Return the upload for the caller to wrap in SceneRenderPayload.
+                            return Some(upload);
+                        }
+                        Err(e) => {
+                            if self.inner.reported_mesh_asset_errors.insert(path_str.to_string()) {
+                                self.report_error(format!(
+                                    "Failed to load mesh '{}': {}", path_str, e
+                                ));
+                            }
+                            return None;
+                        }
+                    }
+                }
+                // Already in cache — we need to return a MeshUpload for upsert_actor to use.
+                // Re-load from disk to get a fresh upload (the cache is for MeshId/MatId, not
+                // the raw geometry).  This is only reached on the first frame after a hot-reload.
+                self.inner.reported_mesh_asset_errors.remove(path_str);
+                mesh_for_key(&mesh_key).ok()
+            }
+
+            fn mark_live(&mut self, actor_key: &str) {
+                self.live_script_keys.insert(actor_key.to_string());
             }
 
             fn report_error(&mut self, message: String) {
@@ -1214,8 +1228,9 @@ impl HelioRenderer {
             None
         };
 
-        let mut live_mesh_ids = std::collections::HashSet::new();
-        let mut live_light_ids = std::collections::HashSet::new();
+        let mut live_mesh_ids    = std::collections::HashSet::new();
+        let mut live_light_ids   = std::collections::HashSet::new();
+        let mut live_script_keys = std::collections::HashSet::new();
 
         for snap in &snapshots {
             if !snap.visible {
@@ -1225,19 +1240,20 @@ impl HelioRenderer {
                 scene_object_id: snap.id.as_str(),
                 position: snap.position,
                 rotation: snap.rotation,
-                scale: snap.scale,
-                props: &snap.props,
+                scale:    snap.scale,
+                props:    &snap.props,
             };
 
             let component_instances = component_instances_from_snap(snap);
             let mut runtime_context = HelioRuntimeContext {
                 inner,
-                owner_snap: snap,
-                live_mesh_ids: &mut live_mesh_ids,
-                live_light_ids: &mut live_light_ids,
+                owner_snap:       snap,
+                live_mesh_ids:    &mut live_mesh_ids,
+                live_light_ids:   &mut live_light_ids,
+                live_script_keys: &mut live_script_keys,
                 dragged_obj_id,
                 dragged_light_id,
-                picker_dirty: &mut picker_dirty,
+                picker_dirty:     &mut picker_dirty,
                 error_queue,
             };
 
@@ -1252,7 +1268,9 @@ impl HelioRenderer {
             }
         }
 
-        // Stale removal.
+        // ── Stale removal ────────────────────────────────────────────────────
+
+        // Meshes and objects no longer referenced by any live component.
         let stale_meshes: Vec<(String, ObjectId)> = inner
             .object_map
             .iter()
@@ -1262,8 +1280,11 @@ impl HelioRenderer {
         for (sid, oid) in stale_meshes {
             let _ = inner.renderer.scene_mut().remove_object(oid);
             inner.object_map.remove(&sid);
+            inner.mesh_cache.remove(&MeshKey::File(sid));
             picker_dirty = true;
         }
+
+        // Lights no longer referenced by any live component.
         let stale_lights: Vec<(String, LightId)> = inner
             .light_map
             .iter()
@@ -1275,6 +1296,9 @@ impl HelioRenderer {
             inner.light_id_to_scene.remove(&lid);
             inner.light_map.remove(&sid);
         }
+
+        // Script registrations no longer referenced by any live ScriptComponent.
+        SCRIPT_REGISTRY.lock().retain_keys(&live_script_keys);
 
         if picker_dirty {
             inner.scene_picker.rebuild_instances(inner.renderer.scene());

--- a/crates/plugin_editor_api/Cargo.toml
+++ b/crates/plugin_editor_api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+schemars = { workspace = true }
 tracing = { workspace = true }
 gpui-ce.workspace = true
 window_manager = { workspace = true }

--- a/crates/plugin_editor_api/src/lib.rs
+++ b/crates/plugin_editor_api/src/lib.rs
@@ -127,6 +127,19 @@ use std::sync::Arc;
 
 pub mod asset_payload;
 pub use asset_payload::{AssetDropArea, AssetDropAreaExt, AssetPayload};
+
+// ── Cross-crate asset actions ─────────────────────────────────────────────────
+
+/// Dispatch this action to open a file or directory in its default editor.
+///
+/// Any crate that has `plugin_editor_api` as a dependency can dispatch this
+/// action; the application layer (`ui_core`) registers the handler that routes
+/// it to the correct in-engine editor or falls back to the OS default.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, schemars::JsonSchema, gpui::Action)]
+#[action(namespace = pulsar_app)]
+pub struct OpenAsset {
+    pub path: PathBuf,
+}
 // Re-export AssetKind at crate root for convenience.
 pub use ui_types_common::AssetKind;
 

--- a/crates/pulsar_events/Cargo.toml
+++ b/crates/pulsar_events/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pulsar_events"
+version = "0.1.0"
+edition = "2024"
+description = "Central script-event registry for Pulsar Engine blueprint dispatch"
+
+[dependencies]
+parking_lot = { workspace = true }
+once_cell   = { workspace = true }
+serde       = { workspace = true, features = ["derive"] }
+tracing     = { workspace = true }

--- a/crates/pulsar_events/src/lib.rs
+++ b/crates/pulsar_events/src/lib.rs
@@ -1,0 +1,100 @@
+//! Central script-event registry for Pulsar Engine.
+//!
+//! [`SCRIPT_REGISTRY`] is a process-global, lock-protected map from actor keys
+//! to [`ScriptRegistration`] entries.  It is written by [`ScriptComponent`]'s
+//! `sync_component` every render/sync pass and read by the game runtime's
+//! [`BlueprintDispatcher`] to know which scene objects have scripts attached and
+//! where their bytecode lives.
+//!
+//! The registry is intentionally free of execution logic — it is a pure
+//! registry.  Dispatching `BeginPlay`, `Tick`, and other events is the
+//! responsibility of the consumer (`pulsar_game`).
+
+use std::collections::{HashMap, HashSet};
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+
+// ── Registration entry ────────────────────────────────────────────────────────
+
+/// A single script attached to a scene object.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScriptRegistration {
+    /// Unique actor key — formatted as `"<scene_object_id>::script::<component_index>"`.
+    pub actor_key: String,
+
+    /// The scene object that owns this script.
+    pub scene_object_id: String,
+
+    /// Absolute or project-relative path to the blueprint directory
+    /// (the directory containing `graph_save.json`).
+    pub script_path: String,
+}
+
+// ── Registry ──────────────────────────────────────────────────────────────────
+
+/// Thread-safe registry of all currently live [`ScriptRegistration`] entries.
+pub struct ScriptRegistry {
+    entries: HashMap<String, ScriptRegistration>,
+}
+
+impl ScriptRegistry {
+    fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Insert or replace the registration for `reg.actor_key`.
+    pub fn register(&mut self, reg: ScriptRegistration) {
+        self.entries.insert(reg.actor_key.clone(), reg);
+    }
+
+    /// Remove the registration for `actor_key`, if present.
+    pub fn unregister(&mut self, actor_key: &str) {
+        self.entries.remove(actor_key);
+    }
+
+    /// Retain only entries whose `actor_key` is in `live_keys`.
+    ///
+    /// Called at the end of each sync pass to cull stale script registrations
+    /// (scene objects that were removed or had their ScriptComponent detached).
+    pub fn retain_keys(&mut self, live_keys: &HashSet<String>) {
+        self.entries.retain(|k, _| live_keys.contains(k));
+    }
+
+    /// Remove all entries.  Used when a scene is unloaded.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Iterate over all registered scripts.
+    pub fn iter(&self) -> impl Iterator<Item = &ScriptRegistration> {
+        self.entries.values()
+    }
+
+    /// Look up a registration by actor key.
+    pub fn get(&self, actor_key: &str) -> Option<&ScriptRegistration> {
+        self.entries.get(actor_key)
+    }
+
+    /// Return the number of registered scripts.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if no scripts are registered.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+// ── Global singleton ──────────────────────────────────────────────────────────
+
+/// Process-global script registry.
+///
+/// Written each sync/render pass by [`ScriptComponent::sync_component`].
+/// Read by the game runtime to build its [`BlueprintDispatcher`] instance map.
+pub static SCRIPT_REGISTRY: Lazy<Mutex<ScriptRegistry>> =
+    Lazy::new(|| Mutex::new(ScriptRegistry::new()));

--- a/crates/pulsar_reflection/src/lib.rs
+++ b/crates/pulsar_reflection/src/lib.rs
@@ -170,43 +170,71 @@ pub struct RuntimeComponentOwner<'a> {
     pub props: &'a HashMap<String, Value>,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum RuntimeLightType {
-    Directional,
-    Point,
-    Spot,
-    Area,
-}
-
-#[derive(Clone, Debug)]
-pub struct RuntimeLightDesc {
-    pub actor_key: String,
-    pub light_type: RuntimeLightType,
-    pub color: [f32; 4],
-    pub intensity: f32,
-    pub range: f32,
-    pub inner_cone_angle_deg: f32,
-    pub outer_cone_angle_deg: f32,
-}
-
-#[derive(Clone, Debug)]
-pub struct RuntimeMeshDesc {
-    pub actor_key: String,
-    pub mesh_asset: String,
-}
-
-/// Runtime context implemented by renderer-side systems.
+/// The render data a component hands to the context for GPU insertion.
 ///
-/// `upsert_light` receives a fully-constructed [`helio::GpuLight`] — the
-/// component (e.g. `LightComponent`) is responsible for building it from its
-/// own fields.  The context just inserts it; there is no translation layer
-/// where values can silently diverge between engine and game.
+/// The component constructs this entirely from its own fields; the context
+/// never inspects component data.  The variants map to helio-level renderer
+/// concepts, not to component class names, so new components that reuse an
+/// existing primitive require no trait changes.
+#[cfg(feature = "prims-helio")]
+pub enum SceneRenderPayload {
+    /// A fully constructed GPU light.  The context handles insert-vs-update
+    /// and all internal tracking (light_map, drag-guard, etc.).
+    Light(helio::GpuLight),
+
+    /// Loaded mesh geometry.  The context handles the two-step helio insert
+    /// (mesh upload → object descriptor) and all internal tracking
+    /// (mesh_cache, object_map, scene-picker, etc.).
+    Mesh(helio::MeshUpload),
+}
+
+/// Context provided to every component's [`ComponentRuntimeBehavior::sync_component`].
+///
+/// Exposes **generic services only** — no knowledge of what any specific
+/// component does.  Each component is fully self-contained: it parses its own
+/// data, constructs any GPU payloads, and calls the appropriate methods here.
+///
+/// # Implementing this trait
+///
+/// * **Editor (`HelioRuntimeContext`)** — full incremental sync with per-actor
+///   tracking maps, drag-guard, mesh caching, and scene-picker rebuilds.
+/// * **Game (`SceneObjectContext`)** — one-shot scene load; actors are inserted
+///   once and never updated.
 pub trait ComponentRuntimeContext {
-    /// Insert or update a light.  The component builds the [`helio::GpuLight`]
-    /// directly so there is exactly one code path for all light construction.
+    /// Insert or update a named render actor.
+    ///
+    /// The component builds the [`SceneRenderPayload`] from its own fields.
+    /// The context owns all tracking maps and helio insertion details.
+    ///
+    /// Calling this method implicitly marks `actor_key` as live for the current
+    /// sync pass; there is no need to also call [`mark_live`].
     #[cfg(feature = "prims-helio")]
-    fn upsert_light(&mut self, actor_key: String, gpu: helio::GpuLight);
-    fn upsert_mesh(&mut self, desc: RuntimeMeshDesc);
+    fn upsert_actor(&mut self, actor_key: String, payload: SceneRenderPayload);
+
+    /// Project root for resolving relative asset paths.
+    fn project_root(&self) -> &std::path::Path;
+
+    /// Load a mesh file, with optional context-level caching.
+    ///
+    /// The path may be absolute or relative to [`project_root`].
+    /// Returns `None` when the file cannot be loaded; the component should
+    /// call [`report_error`] and return early in that case.
+    ///
+    /// Default implementation returns `None`; override in contexts that
+    /// support mesh loading.
+    #[cfg(feature = "prims-helio")]
+    fn load_mesh_file(&mut self, _path: &std::path::Path) -> Option<helio::MeshUpload> {
+        None
+    }
+
+    /// Mark an actor key as live in the current sync pass **without** inserting
+    /// a render actor.
+    ///
+    /// Used by components (e.g. `ScriptComponent`) that register with
+    /// non-renderer systems and still need stale-cleanup semantics.
+    fn mark_live(&mut self, _actor_key: &str) {}
+
+    /// Report a non-fatal component error.
     fn report_error(&mut self, message: String);
 }
 

--- a/crates/pulsar_reflection/src/lib.rs
+++ b/crates/pulsar_reflection/src/lib.rs
@@ -170,46 +170,42 @@ pub struct RuntimeComponentOwner<'a> {
     pub props: &'a HashMap<String, Value>,
 }
 
-/// The render data a component hands to the context for GPU insertion.
+/// Hash a SceneDb string ID to a compact `u64` tag for storage in helio actors.
 ///
-/// The component constructs this entirely from its own fields; the context
-/// never inspects component data.  The variants map to helio-level renderer
-/// concepts, not to component class names, so new components that reuse an
-/// existing primitive require no trait changes.
-#[cfg(feature = "prims-helio")]
-pub enum SceneRenderPayload {
-    /// A fully constructed GPU light.  The context handles insert-vs-update
-    /// and all internal tracking (light_map, drag-guard, etc.).
-    Light(helio::GpuLight),
-
-    /// Loaded mesh geometry.  The context handles the two-step helio insert
-    /// (mesh upload → object descriptor) and all internal tracking
-    /// (mesh_cache, object_map, scene-picker, etc.).
-    Mesh(helio::MeshUpload),
+/// Components call this to compute the [`ObjectDescriptor::user_tag`] /
+/// [`SceneActor::light_with_tag`] value before inserting an actor.  The picker
+/// returns the same tag in [`PickHit::user_tag`], allowing the engine to
+/// identify the owning SceneDb object without any reverse-lookup maps.
+///
+/// The hash uses Rust's default hasher (SipHash) which is stable within a
+/// single process run.  It is not persisted to disk.
+pub fn scene_id_to_tag(id: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    id.hash(&mut h);
+    h.finish()
 }
 
 /// Context provided to every component's [`ComponentRuntimeBehavior::sync_component`].
 ///
 /// Exposes **generic services only** — no knowledge of what any specific
 /// component does.  Each component is fully self-contained: it parses its own
-/// data, constructs any GPU payloads, and calls the appropriate methods here.
+/// data, constructs any GPU payloads, and writes directly to the renderer.
 ///
 /// # Implementing this trait
 ///
-/// * **Editor (`HelioRuntimeContext`)** — full incremental sync with per-actor
-///   tracking maps, drag-guard, mesh caching, and scene-picker rebuilds.
-/// * **Game (`SceneObjectContext`)** — one-shot scene load; actors are inserted
-///   once and never updated.
+/// * **Editor (`HelioRuntimeContext`)** — clears the helio scene each sync pass
+///   and lets components re-insert fresh.  Rebuilds reverse-lookup maps from the
+///   inserted actor IDs reported via [`track_actor`].
+/// * **Game (`SceneObjectContext`)** — one-shot scene load; components insert
+///   once and the loader records the resulting IDs.
 pub trait ComponentRuntimeContext {
-    /// Insert or update a named render actor.
+    /// Raw mutable access to the Helio renderer.
     ///
-    /// The component builds the [`SceneRenderPayload`] from its own fields.
-    /// The context owns all tracking maps and helio insertion details.
-    ///
-    /// Calling this method implicitly marks `actor_key` as live for the current
-    /// sync pass; there is no need to also call [`mark_live`].
+    /// Components use this to insert lights, meshes, and objects directly.
+    /// The context owns no knowledge of what they insert or how.
     #[cfg(feature = "prims-helio")]
-    fn upsert_actor(&mut self, actor_key: String, payload: SceneRenderPayload);
+    fn renderer_mut(&mut self) -> &mut helio::Renderer;
 
     /// Project root for resolving relative asset paths.
     fn project_root(&self) -> &std::path::Path;

--- a/crates/pulsar_rendering/Cargo.toml
+++ b/crates/pulsar_rendering/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 engine_class_derive = { workspace = true }
 pulsar_reflection = { workspace = true }
+pulsar_events = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/pulsar_rendering/src/components/light_component.rs
+++ b/crates/pulsar_rendering/src/components/light_component.rs
@@ -1,10 +1,10 @@
 //! Light component for scene lighting
 
 use engine_class_derive::{EngineClass, RegisterRuntimeBehavior};
-use helio::{GpuLight, LightType as HelioLightType};
+use helio::{GpuLight, LightType as HelioLightType, SceneActor};
 use pulsar_reflection::{
     ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner,
-    ScenePropsProjector, SceneRenderPayload, Reflectable,
+    ScenePropsProjector, Reflectable, scene_id_to_tag,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -181,8 +181,11 @@ impl ComponentRuntimeBehavior for LightComponent {
             _pad:            0,
         };
 
-        let actor_key = format!("{}::light::{}", owner.scene_object_id, component_index);
-        context.upsert_actor(actor_key, SceneRenderPayload::Light(gpu));
+        // Tag the actor with a hash of the SceneDb ID so the picker can
+        // identify it without any external reverse-lookup map.
+        let tag = scene_id_to_tag(owner.scene_object_id);
+        context.renderer_mut().scene_mut()
+            .insert_actor(SceneActor::light_with_tag(gpu, tag));
     }
 }
 

--- a/crates/pulsar_rendering/src/components/light_component.rs
+++ b/crates/pulsar_rendering/src/components/light_component.rs
@@ -3,8 +3,8 @@
 use engine_class_derive::{EngineClass, RegisterRuntimeBehavior};
 use helio::{GpuLight, LightType as HelioLightType};
 use pulsar_reflection::{
-    ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner, RuntimeLightDesc,
-    RuntimeLightType, ScenePropsProjector, Reflectable,
+    ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner,
+    ScenePropsProjector, SceneRenderPayload, Reflectable,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -168,9 +168,9 @@ impl ComponentRuntimeBehavior for LightComponent {
 
         let [px, py, pz] = owner.position;
 
-        // Build the GpuLight directly — this is the single source of truth for
-        // how a LightComponent maps to the GPU.  No intermediate RuntimeLightDesc
-        // or build_gpu_light translation step means engine and game are identical.
+        // Build the GpuLight directly — single source of truth for how a
+        // LightComponent maps to the GPU.  The context handles insert-vs-update
+        // and all internal helio tracking.
         let gpu = GpuLight {
             position_range:  [px, py, pz, light.range],
             direction_outer: [0.0, -1.0, 0.0, light.outer_cone_angle.to_radians()],
@@ -181,10 +181,8 @@ impl ComponentRuntimeBehavior for LightComponent {
             _pad:            0,
         };
 
-        context.upsert_light(
-            format!("{}::light::{}", owner.scene_object_id, component_index),
-            gpu,
-        );
+        let actor_key = format!("{}::light::{}", owner.scene_object_id, component_index);
+        context.upsert_actor(actor_key, SceneRenderPayload::Light(gpu));
     }
 }
 

--- a/crates/pulsar_rendering/src/components/mod.rs
+++ b/crates/pulsar_rendering/src/components/mod.rs
@@ -1,9 +1,11 @@
 mod light_component;
 mod lod_component;
 mod material_override;
+mod script_component;
 mod static_mesh_component;
 
 pub use light_component::*;
 pub use lod_component::*;
 pub use material_override::*;
+pub use script_component::*;
 pub use static_mesh_component::*;

--- a/crates/pulsar_rendering/src/components/script_component.rs
+++ b/crates/pulsar_rendering/src/components/script_component.rs
@@ -1,0 +1,179 @@
+//! Script component — attaches a blueprint actor script to a scene object.
+
+use engine_class_derive::{EngineClass, RegisterRuntimeBehavior};
+use pulsar_events::{ScriptRegistration, SCRIPT_REGISTRY};
+use pulsar_reflection::{
+    ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner,
+    ReflectError, ScenePropsProjector,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+// ── ScriptAssetPath ───────────────────────────────────────────────────────────
+
+/// Strongly-typed wrapper for blueprint asset paths.
+///
+/// The underlying value is the absolute or project-relative path to the
+/// blueprint directory — the directory that contains `graph_save.json`.
+///
+/// Serialises transparently as a JSON string so scene files require no
+/// migration if the wrapper is introduced after the fact.
+///
+/// Using this as a field type causes the reflection property inspector to
+/// render a blueprint-asset picker instead of a plain text box.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ScriptAssetPath(pub String);
+
+impl ScriptAssetPath {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self(path.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for ScriptAssetPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for ScriptAssetPath {
+    fn from(s: String) -> Self { Self(s) }
+}
+
+impl From<&str> for ScriptAssetPath {
+    fn from(s: &str) -> Self { Self(s.to_string()) }
+}
+
+// ── Reflection registration ───────────────────────────────────────────────────
+
+fn serialize_script_asset_path_json(
+    value: &ScriptAssetPath,
+) -> pulsar_reflection::ReflectResult<serde_json::Value> {
+    Ok(serde_json::json!(value.0))
+}
+
+fn deserialize_script_asset_path_json(
+    value: serde_json::Value,
+) -> pulsar_reflection::ReflectResult<ScriptAssetPath> {
+    value
+        .as_str()
+        .map(|s| ScriptAssetPath(s.to_string()))
+        .ok_or_else(|| ReflectError::TypeMismatch {
+            expected: "ScriptAssetPath",
+            found: format!("{:?}", value),
+        })
+}
+
+/// Register `ScriptAssetPath` with the reflection system.
+///
+/// `structure = String` makes `type_info.is_string()` return `true`, which
+/// lets the property inspector detect this type and render a blueprint-asset
+/// browser UI (analogous to the mesh-asset browser for `MeshAssetPath`).
+#[pulsar_reflection::pulsar_type(
+    primitive,
+    structure = String,
+    serialize_json_with = serialize_script_asset_path_json,
+    deserialize_json_with = deserialize_script_asset_path_json
+)]
+#[allow(dead_code)]
+type RegisteredScriptAssetPath = ScriptAssetPath;
+
+// ── ScriptComponent ───────────────────────────────────────────────────────────
+
+/// Attaches a blueprint script to a scene object.
+///
+/// Stores an immutable path to the backing blueprint directory (the one
+/// containing `graph_save.json`).  Each sync pass `sync_component` registers
+/// this object in the global [`SCRIPT_REGISTRY`], which the blueprint runtime
+/// reads to dispatch `BeginPlay`, `Tick`, `EndPlay`, and any other events to
+/// the correct bytecode instance.
+///
+/// The engine treats the presence of this component as the authoritative
+/// signal that the scene object participates in the blueprint event loop —
+/// no other flag or prop is required.
+#[derive(EngineClass, RegisterRuntimeBehavior, Default, Clone, Debug, Serialize, Deserialize)]
+#[category("Scripting")]
+pub struct ScriptComponent {
+    /// Path to the blueprint directory (`graph_save.json` must exist here).
+    ///
+    /// Typed as [`ScriptAssetPath`] so the property inspector renders a
+    /// blueprint-asset browser instead of a plain text input.
+    #[property]
+    pub script_asset: ScriptAssetPath,
+}
+
+impl ScenePropsProjector for ScriptComponent {
+    const CLASS_NAME: &'static str = "ScriptComponent";
+
+    fn apply_scene_props(props: &mut HashMap<String, Value>, component_data: Option<&Value>) {
+        props.remove("script_asset");
+
+        let Some(data) = component_data else { return };
+
+        if let Some(path) = data
+            .as_object()
+            .and_then(|obj| obj.get("script_asset"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+        {
+            props.insert("script_asset".to_string(), Value::from(path));
+        }
+    }
+}
+
+pulsar_reflection::inventory::submit! {
+    pulsar_reflection::ScenePropsApplierRegistration {
+        class_name: <ScriptComponent as ScenePropsProjector>::CLASS_NAME,
+        apply: <ScriptComponent as ScenePropsProjector>::apply_scene_props,
+    }
+}
+
+impl ComponentRuntimeBehavior for ScriptComponent {
+    const CLASS_NAME: &'static str = "ScriptComponent";
+
+    fn sync_component(
+        owner: &RuntimeComponentOwner,
+        component_index: usize,
+        component_data: &Value,
+        context: &mut dyn ComponentRuntimeContext,
+    ) {
+        let script_path = component_data
+            .as_object()
+            .and_then(|obj| obj.get("script_asset"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_string();
+
+        if script_path.is_empty() {
+            context.report_error(format!(
+                "ScriptComponent on '{}' has no script_asset",
+                owner.scene_object_id
+            ));
+            return;
+        }
+
+        let actor_key = format!("{}::script::{}", owner.scene_object_id, component_index);
+
+        // Register with the global script registry.  The blueprint runtime reads
+        // this each frame to know which scene objects have live scripts.
+        SCRIPT_REGISTRY.lock().register(ScriptRegistration {
+            actor_key: actor_key.clone(),
+            scene_object_id: owner.scene_object_id.to_string(),
+            script_path,
+        });
+
+        // Mark live so the context's stale-cleanup pass keeps this key.
+        context.mark_live(&actor_key);
+    }
+}

--- a/crates/pulsar_rendering/src/components/static_mesh_component.rs
+++ b/crates/pulsar_rendering/src/components/static_mesh_component.rs
@@ -2,8 +2,8 @@
 
 use engine_class_derive::{EngineClass, RegisterRuntimeBehavior};
 use pulsar_reflection::{
-    ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner, RuntimeMeshDesc,
-    ReflectError, ScenePropsProjector,
+    ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner,
+    ReflectError, ScenePropsProjector, SceneRenderPayload,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -247,10 +247,19 @@ impl ComponentRuntimeBehavior for StaticMeshComponent {
             return;
         }
 
-        context.upsert_mesh(RuntimeMeshDesc {
-            actor_key: format!("{}::mesh::{}", owner.scene_object_id, component_index),
-            mesh_asset,
-        });
+        // Resolve the path: absolute paths are used as-is; relative paths are
+        // resolved against project_root by the context's load_mesh_file impl.
+        let path = std::path::PathBuf::from(&mesh_asset);
+        let Some(upload) = context.load_mesh_file(&path) else {
+            context.report_error(format!(
+                "StaticMeshComponent on '{}': failed to load mesh '{}'",
+                owner.scene_object_id, mesh_asset
+            ));
+            return;
+        };
+
+        let actor_key = format!("{}::mesh::{}", owner.scene_object_id, component_index);
+        context.upsert_actor(actor_key, SceneRenderPayload::Mesh(upload));
     }
 }
 

--- a/crates/pulsar_rendering/src/components/static_mesh_component.rs
+++ b/crates/pulsar_rendering/src/components/static_mesh_component.rs
@@ -3,13 +3,13 @@
 use engine_class_derive::{EngineClass, RegisterRuntimeBehavior};
 use pulsar_reflection::{
     ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner,
-    ReflectError, ScenePropsProjector, SceneRenderPayload,
+    ReflectError, ScenePropsProjector, scene_id_to_tag,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use glam::{Mat4, Vec3};
-use helio::Movability;
+use glam::{EulerRot, Mat4, Quat, Vec3};
+use helio::{GpuMaterial, GroupMask, Movability, ObjectDescriptor, SceneActor};
 
 // ── MeshAssetPath ─────────────────────────────────────────────────────────────
 
@@ -247,8 +247,6 @@ impl ComponentRuntimeBehavior for StaticMeshComponent {
             return;
         }
 
-        // Resolve the path: absolute paths are used as-is; relative paths are
-        // resolved against project_root by the context's load_mesh_file impl.
         let path = std::path::PathBuf::from(&mesh_asset);
         let Some(upload) = context.load_mesh_file(&path) else {
             context.report_error(format!(
@@ -258,8 +256,62 @@ impl ComponentRuntimeBehavior for StaticMeshComponent {
             return;
         };
 
-        let actor_key = format!("{}::mesh::{}", owner.scene_object_id, component_index);
-        context.upsert_actor(actor_key, SceneRenderPayload::Mesh(upload));
+        // Two-step helio insert: mesh geometry → object instance.
+        // The component owns this logic completely; the context has no mesh knowledge.
+        let mesh_id = match context.renderer_mut().scene_mut()
+            .insert_actor(SceneActor::mesh(upload))
+            .as_mesh()
+        {
+            Some(id) => id,
+            None => {
+                context.report_error(format!(
+                    "StaticMeshComponent on '{}': mesh insert returned non-mesh handle",
+                    owner.scene_object_id
+                ));
+                return;
+            }
+        };
+
+        let mat = GpuMaterial {
+            base_color: [0.6, 0.6, 0.65, 1.0],
+            emissive: [0.0; 4],
+            roughness_metallic: [0.7, 0.0, 1.5, 0.5],
+            tex_base_color: GpuMaterial::NO_TEXTURE,
+            tex_normal:     GpuMaterial::NO_TEXTURE,
+            tex_roughness:  GpuMaterial::NO_TEXTURE,
+            tex_emissive:   GpuMaterial::NO_TEXTURE,
+            tex_occlusion:  GpuMaterial::NO_TEXTURE,
+            workflow: 0, flags: 0, _pad: 0,
+        };
+        let mat_id = context.renderer_mut().scene_mut().insert_material(mat);
+
+        let q = Quat::from_euler(
+            EulerRot::YXZ,
+            owner.rotation[1].to_radians(),
+            owner.rotation[0].to_radians(),
+            owner.rotation[2].to_radians(),
+        );
+        let transform = Mat4::from_scale_rotation_translation(
+            Vec3::from_array(owner.scale),
+            q,
+            Vec3::from_array(owner.position),
+        );
+        let pos    = transform.w_axis.truncate();
+        let radius = Vec3::from_array(owner.scale).length() * 0.5;
+
+        // Tag the actor with a hash of the SceneDb ID so the picker can
+        // identify it without any external reverse-lookup map.
+        context.renderer_mut().scene_mut()
+            .insert_actor(SceneActor::object(ObjectDescriptor {
+                mesh:       mesh_id,
+                material:   mat_id,
+                transform,
+                bounds:     [pos.x, pos.y, pos.z, radius.max(0.1)],
+                flags:      0,
+                groups:     GroupMask::NONE,
+                movability: Some(Movability::Movable),
+                user_tag:   scene_id_to_tag(owner.scene_object_id),
+            }));
     }
 }
 

--- a/crates/pulsar_scene/Cargo.toml
+++ b/crates/pulsar_scene/Cargo.toml
@@ -14,3 +14,4 @@ tracing    = { workspace = true }
 # Same reflection + component registrations the engine uses — ensures identical dispatch
 pulsar_reflection  = { workspace = true }
 pulsar_rendering   = { workspace = true }
+pulsar_events      = { workspace = true }

--- a/crates/pulsar_scene/src/loader.rs
+++ b/crates/pulsar_scene/src/loader.rs
@@ -38,7 +38,6 @@ use serde_json::Value;
 use pulsar_reflection::{
     apply_runtime_behavior_for_class,
     ComponentRuntimeContext, RuntimeComponentOwner,
-    SceneRenderPayload,
 };
 
 use crate::format::{LightType, MeshType, ObjectType, SceneFile, SceneLoadError};
@@ -57,9 +56,7 @@ pub use pulsar_rendering::ScriptComponent as _ForceLink_ScriptComponent;
 pub struct LoadedMesh {
     pub id: String,
     pub name: String,
-    pub mesh_id: MeshId,
     pub object_id: ObjectId,
-    pub material_id: MaterialId,
 }
 
 #[derive(Clone, Debug)]
@@ -134,7 +131,7 @@ impl SceneLoader {
     pub fn load_views(
         objects: &[SceneObjectView<'_>],
         project_root: &Path,
-        renderer: &mut Renderer,
+        mut renderer: &mut Renderer,
     ) -> LoadedScene {
         let mut loaded = LoadedScene::default();
         tracing::info!(total = objects.len(), "Processing scene objects");
@@ -153,36 +150,35 @@ impl SceneLoader {
                 props:    obj.props,
             };
 
-            let mut ctx = SceneObjectContext {
-                obj_id:       obj.id,
-                obj_name:     obj.name,
-                position:     obj.position,
-                rotation:     obj.rotation,
-                scale:        obj.scale,
-                project_root,
-                renderer,
-                lights: &mut loaded.lights,
-                meshes: &mut loaded.meshes,
-                had_light: false,
-                had_mesh:  false,
-            };
+            // Objects with component instances are v2 — components own all insertion.
+            // Objects without are v1 legacy — the fallback path below handles them.
+            let has_components = !instances.is_empty();
 
-            for (idx, class_name, data) in &instances {
-                let handled = apply_runtime_behavior_for_class(
-                    class_name, &owner, *idx, data, &mut ctx,
-                );
-                if !handled {
-                    tracing::debug!(
-                        class = class_name, id = obj.id,
-                        "No runtime behavior registered for component (skipped)"
+            if has_components {
+                let mut ctx = SceneObjectContext {
+                    obj_id:       obj.id,
+                    obj_name:     obj.name,
+                    project_root,
+                    renderer,
+                };
+
+                for (idx, class_name, data) in &instances {
+                    let handled = apply_runtime_behavior_for_class(
+                        class_name, &owner, *idx, data, &mut ctx,
                     );
+                    if !handled {
+                        tracing::debug!(
+                            class = class_name, id = obj.id,
+                            "No runtime behavior registered for component (skipped)"
+                        );
+                    }
                 }
+                // Reborrow after ctx is dropped.
+                renderer = ctx.renderer;
             }
 
-            let had_light = ctx.had_light;
-            let had_mesh  = ctx.had_mesh;
-            // Reborrow renderer after ctx is dropped.
-            let renderer  = ctx.renderer;
+            let had_light = has_components;
+            let had_mesh  = has_components;
 
             // ── Legacy fallback (v1 scenes, no __component_instances) ─────
             if !had_light {
@@ -227,13 +223,11 @@ impl SceneLoader {
                         Some(p) => load_mesh_or_fallback(&resolve_asset(project_root, p)),
                         None    => build_primitive(mt),
                     };
-                    if let Err(e) = spawn_mesh(
-                        obj.id, obj.name, 0,
+                    spawn_mesh_legacy(
+                        obj.id, obj.name,
                         obj.position, obj.rotation, obj.scale,
                         upload, renderer, &mut loaded.meshes,
-                    ) {
-                        tracing::warn!(id = obj.id, "Mesh spawn failed (legacy): {e}");
-                    }
+                    );
                 }
             }
         }
@@ -247,57 +241,19 @@ impl SceneLoader {
 
 /// Per-object context passed into each component's `sync_component`.
 ///
-/// Components call the generic [`ComponentRuntimeContext`] methods; this
-/// context translates them into helio renderer calls.  The loader never reads
-/// component fields directly.
+/// Gives components direct renderer access.  The loader never reads component
+/// fields — all parsing, GPU construction, and insertion logic lives in the
+/// component itself.
 struct SceneObjectContext<'r, 'p> {
     obj_id:       &'p str,
     obj_name:     &'p str,
-    position:     [f32; 3],
-    rotation:     [f32; 3],
-    scale:        [f32; 3],
     project_root: &'p Path,
     renderer:     &'r mut Renderer,
-    lights:       &'p mut Vec<LoadedLight>,
-    meshes:       &'p mut Vec<LoadedMesh>,
-    /// Set to `true` once any component successfully inserts a light,
-    /// so the legacy v1 fallback knows to skip its own light insertion.
-    had_light:    bool,
-    /// Set to `true` once any component successfully inserts a mesh,
-    /// so the legacy v1 fallback knows to skip its own mesh insertion.
-    had_mesh:     bool,
 }
 
 impl ComponentRuntimeContext for SceneObjectContext<'_, '_> {
-    fn upsert_actor(&mut self, actor_key: String, payload: SceneRenderPayload) {
-        match payload {
-            SceneRenderPayload::Light(gpu) => {
-                self.had_light = true;
-                match self.renderer.scene_mut()
-                    .insert_actor(SceneActor::light(gpu)).as_light()
-                {
-                    Some(light_id) => {
-                        tracing::info!(id = self.obj_id, name = self.obj_name, "Light loaded");
-                        self.lights.push(LoadedLight {
-                            id:   actor_key,
-                            name: self.obj_name.to_string(),
-                            light_id,
-                        });
-                    }
-                    None => tracing::warn!(id = self.obj_id, "non-light handle from insert_actor"),
-                }
-            }
-            SceneRenderPayload::Mesh(upload) => {
-                self.had_mesh = true;
-                if let Err(e) = spawn_mesh_with_key(
-                    &actor_key, self.obj_name,
-                    self.position, self.rotation, self.scale,
-                    upload, self.renderer, self.meshes,
-                ) {
-                    tracing::warn!(id = self.obj_id, "Mesh spawn failed: {e}");
-                }
-            }
-        }
+    fn renderer_mut(&mut self) -> &mut Renderer {
+        self.renderer
     }
 
     fn project_root(&self) -> &std::path::Path {
@@ -354,67 +310,49 @@ pub fn load_mesh_upload(path: &Path) -> Result<MeshUpload, String> {
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
-/// Spawn a mesh+object into the renderer using a pre-formatted actor key.
+/// Spawn a mesh+object into the renderer for the v1 legacy fallback path.
 ///
-/// Used by [`SceneObjectContext::upsert_mesh`]; the key is already formatted by
-/// `StaticMeshComponent::sync_component` as `"<obj_id>::mesh::<idx>"`.
-fn spawn_mesh_with_key(
-    actor_key: &str,
+/// For v2 scenes this is never called — `StaticMeshComponent::sync_component`
+/// owns the full two-step insert.  This helper exists only for pre-v2 scene
+/// files that have no `__component_instances` array.
+fn spawn_mesh_legacy(
+    obj_id:   &str,
     obj_name: &str,
     position: [f32; 3],
     rotation: [f32; 3],
-    scale: [f32; 3],
-    upload: MeshUpload,
+    scale:    [f32; 3],
+    upload:   MeshUpload,
     renderer: &mut Renderer,
-    out: &mut Vec<LoadedMesh>,
-) -> Result<(), String> {
-    let mesh_id = renderer.scene_mut()
-        .insert_actor(SceneActor::mesh(upload))
-        .as_mesh()
-        .ok_or("non-mesh handle")?;
-
+    out:      &mut Vec<LoadedMesh>,
+) {
+    let mesh_id = match renderer.scene_mut()
+        .insert_actor(SceneActor::mesh(upload)).as_mesh()
+    {
+        Some(id) => id,
+        None => { tracing::warn!(id = obj_id, "Mesh insert: non-mesh handle (legacy)"); return; }
+    };
     let mat_id = renderer.scene_mut()
         .insert_material(make_material([0.6, 0.6, 0.65, 1.0], 0.7, 0.0));
-
     let transform = build_transform_parts(position, rotation, scale);
     let pos    = transform.w_axis.truncate();
     let radius = Vec3::from_array(scale).length() * 0.5;
-
-    let obj_id = renderer.scene_mut()
+    let obj_id_helio = match renderer.scene_mut()
         .insert_actor(SceneActor::object(ObjectDescriptor {
             mesh: mesh_id, material: mat_id, transform,
             bounds: [pos.x, pos.y, pos.z, radius.max(0.1)],
             flags: 0, groups: helio::GroupMask::NONE,
             movability: Some(helio::Movability::Movable),
-        }))
-        .as_object()
-        .ok_or("non-object handle")?;
-
+            user_tag: 0,
+        })).as_object()
+    {
+        Some(id) => id,
+        None => { tracing::warn!(id = obj_id, "Object insert: non-object handle (legacy)"); return; }
+    };
     out.push(LoadedMesh {
-        id:          actor_key.to_string(),
-        name:        obj_name.to_string(),
-        mesh_id, object_id: obj_id, material_id: mat_id,
+        id:        format!("{}::mesh::0", obj_id),
+        name:      obj_name.to_string(),
+        object_id: obj_id_helio,
     });
-    Ok(())
-}
-
-/// Legacy helper used by the v1 fallback path (no `__component_instances`).
-fn spawn_mesh(
-    obj_id: &str,
-    obj_name: &str,
-    idx: usize,
-    position: [f32; 3],
-    rotation: [f32; 3],
-    scale: [f32; 3],
-    upload: MeshUpload,
-    renderer: &mut Renderer,
-    out: &mut Vec<LoadedMesh>,
-) -> Result<(), String> {
-    spawn_mesh_with_key(
-        &format!("{}::mesh::{}", obj_id, idx),
-        obj_name, position, rotation, scale,
-        upload, renderer, out,
-    )
 }
 
 /// The engine's built-in assets live next to pulsar_scene in the Pulsar-Native

--- a/crates/pulsar_scene/src/loader.rs
+++ b/crates/pulsar_scene/src/loader.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 use pulsar_reflection::{
     apply_runtime_behavior_for_class,
     ComponentRuntimeContext, RuntimeComponentOwner,
-    RuntimeLightDesc, RuntimeLightType, RuntimeMeshDesc,
+    SceneRenderPayload,
 };
 
 use crate::format::{LightType, MeshType, ObjectType, SceneFile, SceneLoadError};
@@ -49,6 +49,7 @@ use crate::format::{LightType, MeshType, ObjectType, SceneFile, SceneLoadError};
 // (ComponentRuntimeContext dispatch only works if those statics are linked in.)
 pub use pulsar_rendering::LightComponent as _ForceLink_LightComponent;
 pub use pulsar_rendering::StaticMeshComponent as _ForceLink_StaticMeshComponent;
+pub use pulsar_rendering::ScriptComponent as _ForceLink_ScriptComponent;
 
 // ── Public result types ───────────────────────────────────────────────────────
 
@@ -189,24 +190,30 @@ impl SceneLoader {
                     let color     = prop_f32_4(obj.props, "color",     [1.;4]);
                     let intensity = prop_f32  (obj.props, "intensity", 1.0);
                     let range     = prop_f32  (obj.props, "range",     10.0);
-                    let desc = RuntimeLightDesc {
-                        actor_key: format!("{}::light::0", obj.id),
-                        light_type: match lt {
-                            LightType::Directional => RuntimeLightType::Directional,
-                            LightType::Point       => RuntimeLightType::Point,
-                            LightType::Spot        => RuntimeLightType::Spot,
-                        },
-                        color, intensity, range,
-                        inner_cone_angle_deg: prop_f32(obj.props, "inner_angle", 30.0),
-                        outer_cone_angle_deg: prop_f32(obj.props, "outer_angle", 45.0),
+                    let inner_deg = prop_f32(obj.props, "inner_angle", 30.0);
+                    let outer_deg = prop_f32(obj.props, "outer_angle", 45.0);
+                    let helio_lt  = match lt {
+                        LightType::Directional => HelioLightType::Directional,
+                        LightType::Point       => HelioLightType::Point,
+                        LightType::Spot        => HelioLightType::Spot,
                     };
-                    let gpu = build_gpu_light(&desc, obj.position);
+                    let [px, py, pz] = obj.position;
+                    let gpu = GpuLight {
+                        position_range:  [px, py, pz, range],
+                        direction_outer: [0.0, -1.0, 0.0, outer_deg.to_radians()],
+                        color_intensity: [color[0], color[1], color[2], intensity],
+                        shadow_index:    u32::MAX,
+                        light_type:      helio_lt as u32,
+                        inner_angle:     inner_deg.to_radians(),
+                        _pad:            0,
+                    };
+                    let actor_key = format!("{}::light::0", obj.id);
                     if let Some(light_id) = renderer.scene_mut()
                         .insert_actor(SceneActor::light(gpu)).as_light()
                     {
                         tracing::info!(id = obj.id, name = obj.name, "Light loaded (legacy)");
                         loaded.lights.push(LoadedLight {
-                            id: desc.actor_key, name: obj.name.to_string(), light_id,
+                            id: actor_key, name: obj.name.to_string(), light_id,
                         });
                     }
                 }
@@ -240,8 +247,9 @@ impl SceneLoader {
 
 /// Per-object context passed into each component's `sync_component`.
 ///
-/// Components call `upsert_light` / `upsert_mesh`; the context translates
-/// those into helio renderer calls.  The loader never reads component fields.
+/// Components call the generic [`ComponentRuntimeContext`] methods; this
+/// context translates them into helio renderer calls.  The loader never reads
+/// component fields directly.
 struct SceneObjectContext<'r, 'p> {
     obj_id:       &'p str,
     obj_name:     &'p str,
@@ -252,45 +260,57 @@ struct SceneObjectContext<'r, 'p> {
     renderer:     &'r mut Renderer,
     lights:       &'p mut Vec<LoadedLight>,
     meshes:       &'p mut Vec<LoadedMesh>,
+    /// Set to `true` once any component successfully inserts a light,
+    /// so the legacy v1 fallback knows to skip its own light insertion.
     had_light:    bool,
+    /// Set to `true` once any component successfully inserts a mesh,
+    /// so the legacy v1 fallback knows to skip its own mesh insertion.
     had_mesh:     bool,
 }
 
 impl ComponentRuntimeContext for SceneObjectContext<'_, '_> {
-    fn upsert_light(&mut self, actor_key: String, gpu: GpuLight) {
-        self.had_light = true;
-        // GpuLight is already fully constructed by the component — just insert.
-        match self.renderer.scene_mut()
-            .insert_actor(SceneActor::light(gpu)).as_light()
-        {
-            Some(light_id) => {
-                tracing::info!(id = self.obj_id, name = self.obj_name, "Light loaded");
-                self.lights.push(LoadedLight {
-                    id: actor_key,
-                    name: self.obj_name.to_string(),
-                    light_id,
-                });
+    fn upsert_actor(&mut self, actor_key: String, payload: SceneRenderPayload) {
+        match payload {
+            SceneRenderPayload::Light(gpu) => {
+                self.had_light = true;
+                match self.renderer.scene_mut()
+                    .insert_actor(SceneActor::light(gpu)).as_light()
+                {
+                    Some(light_id) => {
+                        tracing::info!(id = self.obj_id, name = self.obj_name, "Light loaded");
+                        self.lights.push(LoadedLight {
+                            id:   actor_key,
+                            name: self.obj_name.to_string(),
+                            light_id,
+                        });
+                    }
+                    None => tracing::warn!(id = self.obj_id, "non-light handle from insert_actor"),
+                }
             }
-            None => tracing::warn!(id = self.obj_id, "non-light handle from insert_actor"),
+            SceneRenderPayload::Mesh(upload) => {
+                self.had_mesh = true;
+                if let Err(e) = spawn_mesh_with_key(
+                    &actor_key, self.obj_name,
+                    self.position, self.rotation, self.scale,
+                    upload, self.renderer, self.meshes,
+                ) {
+                    tracing::warn!(id = self.obj_id, "Mesh spawn failed: {e}");
+                }
+            }
         }
     }
 
-    fn upsert_mesh(&mut self, desc: RuntimeMeshDesc) {
-        self.had_mesh = true;
-        let asset = desc.mesh_asset.trim();
-        if asset.is_empty() || asset == "None" {
-            tracing::warn!(id = self.obj_id, "StaticMeshComponent has no valid mesh_asset");
-            return;
+    fn project_root(&self) -> &std::path::Path {
+        self.project_root
+    }
+
+    fn load_mesh_file(&mut self, path: &std::path::Path) -> Option<MeshUpload> {
+        let path_str = path.to_str().unwrap_or("");
+        if path_str.is_empty() || path_str == "None" {
+            return None;
         }
-        let full   = resolve_asset(self.project_root, asset);
-        let upload = load_mesh_or_fallback(&full);
-        if let Err(e) = spawn_mesh_with_key(
-            &desc.actor_key, self.obj_name,
-            self.position, self.rotation, self.scale,
-            upload, self.renderer, self.meshes,
-        ) {
-            tracing::warn!(id = self.obj_id, "Mesh spawn failed: {e}");
-        }
+        let full = resolve_asset(self.project_root, path_str);
+        Some(load_mesh_or_fallback(&full))
     }
 
     fn report_error(&mut self, message: String) {
@@ -325,28 +345,6 @@ pub fn build_transform_parts(position: [f32;3], rotation: [f32;3], scale: [f32;3
     Mat4::from_scale_rotation_translation(Vec3::from_array(scale), q, Vec3::from_array(position))
 }
 
-/// Build a [`GpuLight`] from a v1 legacy [`RuntimeLightDesc`] and world position.
-///
-/// Only used by the backwards-compat fallback for scene files that have no
-/// `__component_instances` (pre-v2 format).  For all current scenes,
-/// `LightComponent::sync_component` builds the `GpuLight` directly.
-fn build_gpu_light(desc: &RuntimeLightDesc, position: [f32; 3]) -> GpuLight {
-    let lt = match desc.light_type {
-        RuntimeLightType::Directional => HelioLightType::Directional,
-        RuntimeLightType::Point       => HelioLightType::Point,
-        RuntimeLightType::Spot        => HelioLightType::Spot,
-        RuntimeLightType::Area        => HelioLightType::Point,
-    };
-    GpuLight {
-        position_range:  [position[0], position[1], position[2], desc.range],
-        direction_outer: [0.0, -1.0, 0.0, desc.outer_cone_angle_deg.to_radians()],
-        color_intensity: [desc.color[0], desc.color[1], desc.color[2], desc.intensity],
-        shadow_index:    u32::MAX,
-        light_type:      lt as u32,
-        inner_angle:     desc.inner_cone_angle_deg.to_radians(),
-        _pad:            0,
-    }
-}
 
 /// Load a mesh file via helio-asset-compat.
 /// Identical to engine's `load_fbx_mesh`.

--- a/crates/pulsar_std/src/engine/nodes/events/mod.rs
+++ b/crates/pulsar_std/src/engine/nodes/events/mod.rs
@@ -69,3 +69,81 @@ pub fn on_event(_event: String) {
 pub fn remove_event_listener(_event: String) {
     // In a real implementation, this would unregister a callback
 }
+
+// =============================================================================
+// Engine Lifecycle Events
+// =============================================================================
+
+/// Tick event - runs every frame with a delta-time value.
+///
+/// Connect the execution chain to "Body" and read the `delta_time` output
+/// to access the time (in seconds) since the last frame.
+///
+/// # On Tick
+/// Entry point called every frame. `delta_time` is seconds since last frame.
+#[blueprint(type: NodeTypes::event, category: "Events")]
+pub fn on_tick(_delta_time: f32) {
+    exec_output!("Body");
+}
+
+/// End Play event - runs when the object is destroyed or the scene stops.
+///
+/// Use this to release resources, stop effects, or clean up state.
+///
+/// # On End Play
+/// Entry point called when the owning object is removed from the scene.
+#[blueprint(type: NodeTypes::event, category: "Events")]
+pub fn on_end_play() {
+    exec_output!("Body");
+}
+
+// =============================================================================
+// Time Utilities
+// =============================================================================
+
+/// Returns the time in seconds elapsed since the last frame.
+///
+/// This is a pure node; connect its output directly into time-driven logic.
+///
+/// # Get Delta Time
+/// Returns the current frame delta time in seconds.
+#[blueprint(type: crate::NodeTypes::pure, category: "Events")]
+pub fn get_delta_time() -> f32 {
+    // Resolved at runtime by the blueprint executor via engine context.
+    0.0
+}
+
+// =============================================================================
+// Input Events
+// =============================================================================
+
+/// Fires when a keyboard key is pressed or released.
+///
+/// # Inputs
+/// - `key`: The key identifier string (e.g. `"Space"`, `"W"`, `"Escape"`)
+///
+/// # Outputs
+/// - `pressed`: `true` on key-down, `false` on key-up
+///
+/// # On Input Key
+/// Entry point for raw keyboard key press/release events.
+#[blueprint(type: NodeTypes::event, category: "Input")]
+pub fn on_input_key(_key: String, _pressed: bool) {
+    exec_output!("Body");
+}
+
+/// Fires when a named input action is triggered.
+///
+/// Input actions are mapped strings (e.g. `"Jump"`, `"Fire"`) that abstract
+/// over raw keys and controller buttons.
+///
+/// # Inputs
+/// - `action`: The action name string
+/// - `pressed`: `true` on action start, `false` on action end
+///
+/// # On Input Action
+/// Entry point for named input action events.
+#[blueprint(type: NodeTypes::event, category: "Input")]
+pub fn on_input_action(_action: String, _pressed: bool) {
+    exec_output!("Body");
+}

--- a/ui-crates/ui_common/src/prim_editors/mod.rs
+++ b/ui-crates/ui_common/src/prim_editors/mod.rs
@@ -14,5 +14,6 @@ mod color;
 mod f32;
 mod i32;
 mod mesh_asset;
+mod script_asset;
 mod string;
 mod vec3;

--- a/ui-crates/ui_common/src/prim_editors/script_asset.rs
+++ b/ui-crates/ui_common/src/prim_editors/script_asset.rs
@@ -1,0 +1,76 @@
+//! Property editor for `ScriptAssetPath` — read-only blueprint asset reference.
+//!
+//! Displays the blueprint directory name.  Clicking opens the blueprint in
+//! its default editor via the global `OpenAsset` action.
+//!
+//! This file's sole job is to register the `ScriptAssetPath` type's editor.
+
+use gpui::{prelude::*, *};
+use plugin_editor_api::OpenAsset;
+use pulsar_rendering::components::ScriptAssetPath;
+use ui::{h_flex, ActiveTheme};
+
+use crate::property_editor_registry::PropertyEditorArgs;
+
+pub(super) fn render(args: &PropertyEditorArgs<'_>, cx: &App) -> AnyElement {
+    let path_str = args.current_json.as_str().unwrap_or("").to_string();
+
+    let display = if path_str.is_empty() {
+        "No script assigned".to_string()
+    } else {
+        std::path::Path::new(&path_str)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&path_str)
+            .to_string()
+    };
+
+    let open_path = std::path::PathBuf::from(&path_str);
+    let can_open = !path_str.is_empty();
+
+    h_flex()
+        .w_full()
+        .justify_between()
+        .items_center()
+        .gap_2()
+        .py_1()
+        .child(
+            div()
+                .text_sm()
+                .text_color(cx.theme().muted_foreground)
+                .child(args.display_name.to_string()),
+        )
+        .child(
+            div()
+                .id(SharedString::from(format!(
+                    "script-asset-{}-{}-{}",
+                    args.id_prefix, args.class_name, args.prop_name
+                )))
+                .text_sm()
+                .when(can_open, |el| el.cursor_pointer())
+                .text_color(if can_open {
+                    cx.theme().accent
+                } else {
+                    cx.theme().muted_foreground
+                })
+                .hover(|s| if can_open { s.underline() } else { s })
+                .child(display)
+                .when(can_open, move |el| {
+                    el.on_click(move |_event, window, cx| {
+                        window.dispatch_action(
+                            Box::new(OpenAsset { path: open_path.clone() }),
+                            cx,
+                        );
+                    })
+                }),
+        )
+        .into_any_element()
+}
+
+pulsar_reflection::inventory::submit! {
+    pulsar_reflection::UiPropertyEditorHint {
+        type_id: std::any::TypeId::of::<ScriptAssetPath>(),
+        // SAFETY: `render` matches the PropertyEditorRenderFn signature.
+        fn_ptr: unsafe { pulsar_reflection::erase_property_editor_fn_ptr(render) },
+    }
+}

--- a/ui-crates/ui_common/src/prim_editors/script_asset.rs
+++ b/ui-crates/ui_common/src/prim_editors/script_asset.rs
@@ -1,22 +1,20 @@
 //! Property editor for `ScriptAssetPath` — read-only blueprint asset reference.
 //!
-//! Displays the blueprint directory name.  Clicking opens the blueprint in
-//! its default editor via the global `OpenAsset` action.
-//!
-//! This file's sole job is to register the `ScriptAssetPath` type's editor.
+//! Shows a Code icon next to the blueprint folder name.  Clicking opens the
+//! blueprint in its registered editor via the global `OpenAsset` action.
 
 use gpui::{prelude::*, *};
 use plugin_editor_api::OpenAsset;
 use pulsar_rendering::components::ScriptAssetPath;
-use ui::{h_flex, ActiveTheme};
+use ui::{button::{Button, ButtonVariants as _}, h_flex, ActiveTheme, Icon, IconName, Sizable, Disableable as _};
 
 use crate::property_editor_registry::PropertyEditorArgs;
 
 pub(super) fn render(args: &PropertyEditorArgs<'_>, cx: &App) -> AnyElement {
     let path_str = args.current_json.as_str().unwrap_or("").to_string();
 
-    let display = if path_str.is_empty() {
-        "No script assigned".to_string()
+    let file_name = if path_str.is_empty() {
+        "None".to_string()
     } else {
         std::path::Path::new(&path_str)
             .file_name()
@@ -26,7 +24,12 @@ pub(super) fn render(args: &PropertyEditorArgs<'_>, cx: &App) -> AnyElement {
     };
 
     let open_path = std::path::PathBuf::from(&path_str);
-    let can_open = !path_str.is_empty();
+    let has_asset  = !path_str.is_empty();
+
+    let id = format!(
+        "script-asset-{}-{}-{}",
+        args.id_prefix, args.class_name, args.prop_name
+    );
 
     h_flex()
         .w_full()
@@ -35,28 +38,22 @@ pub(super) fn render(args: &PropertyEditorArgs<'_>, cx: &App) -> AnyElement {
         .gap_2()
         .py_1()
         .child(
+            // Field label
             div()
                 .text_sm()
                 .text_color(cx.theme().muted_foreground)
                 .child(args.display_name.to_string()),
         )
         .child(
-            div()
-                .id(SharedString::from(format!(
-                    "script-asset-{}-{}-{}",
-                    args.id_prefix, args.class_name, args.prop_name
-                )))
-                .text_sm()
-                .when(can_open, |el| el.cursor_pointer())
-                .text_color(if can_open {
-                    cx.theme().accent
-                } else {
-                    cx.theme().muted_foreground
-                })
-                .hover(|s| if can_open { s.underline() } else { s })
-                .child(display)
-                .when(can_open, move |el| {
-                    el.on_click(move |_event, window, cx| {
+            // [Code icon] [filename] — clickable when an asset is assigned
+            Button::new(id)
+                .icon(Icon::new(IconName::Code).size(px(12.)))
+                .label(file_name)
+                .ghost()
+                .small()
+                .when(!has_asset, |b| b.disabled(true))
+                .when(has_asset, move |b| {
+                    b.on_click(move |_event, window, cx| {
                         window.dispatch_action(
                             Box::new(OpenAsset { path: open_path.clone() }),
                             cx,

--- a/ui-crates/ui_core/src/app/mod.rs
+++ b/ui-crates/ui_core/src/app/mod.rs
@@ -90,6 +90,15 @@ impl PulsarApp {
         self.open_path(action.path.clone(), window, cx);
     }
 
+    fn on_open_asset(
+        &mut self,
+        action: &plugin_editor_api::OpenAsset,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_path(action.path.clone(), window, cx);
+    }
+
     fn on_activate_open_editor(
         &mut self,
         action: &ActivateOpenEditor,

--- a/ui-crates/ui_core/src/app/render.rs
+++ b/ui-crates/ui_core/src/app/render.rs
@@ -683,6 +683,7 @@ impl Render for PulsarApp {
             .on_action(cx.listener(Self::on_toggle_agent_chat))
             .on_action(cx.listener(Self::on_toggle_command_palette))
             .on_action(cx.listener(Self::on_open_file))
+            .on_action(cx.listener(Self::on_open_asset))
             .on_action(cx.listener(Self::on_activate_open_editor))
             .on_action(cx.listener(Self::on_open_settings))
             .on_action(cx.listener(Self::on_open_settings_menu))

--- a/ui-crates/ui_file_manager/src/file_manager_drawer/drawer_impl/render_content.rs
+++ b/ui-crates/ui_file_manager/src/file_manager_drawer/drawer_impl/render_content.rs
@@ -147,7 +147,16 @@ impl FileManagerDrawer {
                 cx.new(|_| drag_with_pos)
             });
         } else {
-            let asset_payload = AssetPayload::from_path(&item_clone.path);
+            let asset_payload = if is_class {
+                AssetPayload {
+                    engine_path: item_clone.path.to_string_lossy().replace('\\', "/"),
+                    name: item_clone.name.clone(),
+                    kind: AssetKind::Blueprint,
+                    extension: "class".to_string(),
+                }
+            } else {
+                AssetPayload::from_path(&item_clone.path)
+            };
             let payload_for_event = asset_payload.clone();
             let drawer_entity_for_drag = drawer_entity.clone();
             content = content.on_drag(asset_payload, move |drag, _, _, cx| {
@@ -423,7 +432,16 @@ impl FileManagerDrawer {
         });
 
         if !is_folder {
-            let asset_payload = AssetPayload::from_path(&item_clone2.path);
+            let asset_payload = if is_class {
+                AssetPayload {
+                    engine_path: item_clone2.path.to_string_lossy().replace('\\', "/"),
+                    name: item_clone2.name.clone(),
+                    kind: AssetKind::Blueprint,
+                    extension: "class".to_string(),
+                }
+            } else {
+                AssetPayload::from_path(&item_clone2.path)
+            };
             let payload_for_event = asset_payload.clone();
             let drawer_entity_for_drag = drawer_entity.clone();
             list_item = list_item.on_drag(asset_payload, move |drag, _, _, cx| {

--- a/ui-crates/ui_file_manager/src/file_manager_drawer/mod.rs
+++ b/ui-crates/ui_file_manager/src/file_manager_drawer/mod.rs
@@ -20,7 +20,7 @@ use crate::drawer::{
     actions::*, context_menus, operations::FileOperations, tree::FolderNode, types::*, utils::*,
     FsMetadataManager,
 };
-use plugin_editor_api::AssetPayload;
+use plugin_editor_api::{AssetKind, AssetPayload};
 
 // ============================================================================
 // FILE MANAGER DRAWER

--- a/ui-crates/ui_level_editor/src/ai_tools.rs
+++ b/ui-crates/ui_level_editor/src/ai_tools.rs
@@ -135,6 +135,7 @@ fn object_type_key(object_type: &ObjectType) -> &'static str {
         ObjectType::Mesh(MeshType::Custom) => "mesh_custom",
         ObjectType::ParticleSystem => "particle_system",
         ObjectType::AudioSource => "audio_source",
+        ObjectType::Blueprint => "blueprint",
     }
 }
 

--- a/ui-crates/ui_level_editor/src/level_editor/scene_database.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/scene_database.rs
@@ -770,12 +770,31 @@ pub struct LevelEditorCameraState {
 
 // ── Blueprint helpers ──────────────────────────────────────────────────────
 
-/// Extract the script asset path from a Blueprint object's props.
+/// Extract the script asset path for a Blueprint object from its props.
 ///
-/// Callers set `props["script_asset"]`; `add_object` reads it here and
-/// injects it into `metadata_db` as a `ScriptComponent`.  Returns an empty
-/// string when absent — the user can fill it in via the properties panel.
+/// Checks `props["__component_instances"][ScriptComponent].data.script_asset`
+/// first, then falls back to the flat `props["script_asset"]`.  Returns an
+/// empty string if neither is present (the user will fill it in via the
+/// properties panel).
 fn find_script_path(props: &HashMap<String, Value>) -> String {
+    // Try __component_instances first — the authoritative location.
+    if let Some(path) = props
+        .get("__component_instances")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|inst| {
+                inst.get("class_name").and_then(|v| v.as_str()) == Some("ScriptComponent")
+            })
+        })
+        .and_then(|inst| inst.get("data"))
+        .and_then(|data| data.get("script_asset"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return path.to_string();
+    }
+
+    // Flat prop fallback (older scene files or explicit callers).
     props
         .get("script_asset")
         .and_then(|v| v.as_str())

--- a/ui-crates/ui_level_editor/src/level_editor/scene_database.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/scene_database.rs
@@ -147,8 +147,35 @@ impl SceneDatabase {
     // reconciles Helio state every frame — no immediate write-through needed.
 
     /// Add an object. Returns the assigned `ObjectId`.
+    ///
+    /// Blueprint objects always receive a `ScriptComponent` in `metadata_db`
+    /// pointing at their blueprint directory.  `sync_registered_component_props_to_scene_db`
+    /// rebuilds `__component_instances` from `metadata_db`, so the component
+    /// must live there — setting it only in `props` would be immediately overwritten.
     pub fn add_object(&self, obj: SceneObjectData, parent: Option<ObjectId>) -> ObjectId {
+        let blueprint_script_path = if obj.object_type == ObjectType::Blueprint {
+            Some(find_script_path(&obj.props))
+        } else {
+            None
+        };
+
         let object_id = self.scene_db.add_object(obj.into_snapshot(), parent);
+
+        if let Some(script_path) = blueprint_script_path {
+            let already_has = self.metadata_db
+                .get_components(&object_id)
+                .iter()
+                .any(|c| c.class_name == "ScriptComponent");
+
+            if !already_has {
+                self.metadata_db.add_component(
+                    &object_id,
+                    "ScriptComponent".to_string(),
+                    serde_json::json!({ "script_asset": script_path }),
+                );
+            }
+        }
+
         self.sync_registered_component_props_to_scene_db(&object_id);
         object_id
     }
@@ -739,4 +766,38 @@ pub struct LevelEditorCameraState {
     pub position: [f32; 3],
     pub yaw: f32,
     pub pitch: f32,
+}
+
+// ── Blueprint helpers ──────────────────────────────────────────────────────
+
+/// Extract the script asset path for a Blueprint object from its props.
+///
+/// Checks `props["__component_instances"][ScriptComponent].data.script_asset`
+/// first, then falls back to the flat `props["script_asset"]`.  Returns an
+/// empty string if neither is present (the user will fill it in via the
+/// properties panel).
+fn find_script_path(props: &HashMap<String, Value>) -> String {
+    // Try __component_instances first — the authoritative location.
+    if let Some(path) = props
+        .get("__component_instances")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|inst| {
+                inst.get("class_name").and_then(|v| v.as_str()) == Some("ScriptComponent")
+            })
+        })
+        .and_then(|inst| inst.get("data"))
+        .and_then(|data| data.get("script_asset"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return path.to_string();
+    }
+
+    // Flat prop fallback (older scene files or explicit callers).
+    props
+        .get("script_asset")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
 }

--- a/ui-crates/ui_level_editor/src/level_editor/scene_database.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/scene_database.rs
@@ -770,31 +770,12 @@ pub struct LevelEditorCameraState {
 
 // ── Blueprint helpers ──────────────────────────────────────────────────────
 
-/// Extract the script asset path for a Blueprint object from its props.
+/// Extract the script asset path from a Blueprint object's props.
 ///
-/// Checks `props["__component_instances"][ScriptComponent].data.script_asset`
-/// first, then falls back to the flat `props["script_asset"]`.  Returns an
-/// empty string if neither is present (the user will fill it in via the
-/// properties panel).
+/// Callers set `props["script_asset"]`; `add_object` reads it here and
+/// injects it into `metadata_db` as a `ScriptComponent`.  Returns an empty
+/// string when absent — the user can fill it in via the properties panel.
 fn find_script_path(props: &HashMap<String, Value>) -> String {
-    // Try __component_instances first — the authoritative location.
-    if let Some(path) = props
-        .get("__component_instances")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| {
-            arr.iter().find(|inst| {
-                inst.get("class_name").and_then(|v| v.as_str()) == Some("ScriptComponent")
-            })
-        })
-        .and_then(|inst| inst.get("data"))
-        .and_then(|data| data.get("script_asset"))
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-    {
-        return path.to_string();
-    }
-
-    // Flat prop fallback (older scene files or explicit callers).
     props
         .get("script_asset")
         .and_then(|v| v.as_str())

--- a/ui-crates/ui_level_editor/src/level_editor/ui/hierarchy.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/ui/hierarchy.rs
@@ -420,6 +420,7 @@ impl HierarchyPanel {
             ObjectType::Empty => IconName::Circle,
             ObjectType::ParticleSystem => IconName::Sparks,
             ObjectType::AudioSource => IconName::MusicNote,
+            ObjectType::Blueprint => IconName::Code,
         }
     }
 
@@ -435,6 +436,7 @@ impl HierarchyPanel {
             ObjectType::Empty => cx.theme().muted_foreground,
             ObjectType::ParticleSystem => tree_colors::EFFECT_ORANGE,
             ObjectType::AudioSource => tree_colors::DOC_TEAL,
+            ObjectType::Blueprint => tree_colors::CODE_BLUE,
         }
     }
 }

--- a/ui-crates/ui_level_editor/src/level_editor/ui/object_type_fields_section.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/ui/object_type_fields_section.rs
@@ -154,6 +154,7 @@ impl Render for ObjectTypeFieldsSection {
                 ObjectType::Camera => "Camera".to_string(),
                 ObjectType::ParticleSystem => "Particle System".to_string(),
                 ObjectType::AudioSource => "Audio Source".to_string(),
+                ObjectType::Blueprint => "Blueprint Actor".to_string(),
                 ObjectType::Light(lt) => format!("Light ({lt:?})"),
                 ObjectType::Mesh(mt) => format!("Mesh ({mt:?})"),
             },

--- a/ui-crates/ui_level_editor/src/level_editor/ui/properties_panel.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/ui/properties_panel.rs
@@ -126,6 +126,7 @@ impl PropertiesPanel {
                 ObjectType::Empty => IconName::Circle,
                 ObjectType::ParticleSystem => IconName::Spark,
                 ObjectType::AudioSource => IconName::MusicNote,
+                ObjectType::Blueprint => IconName::Code,
             }
         };
 
@@ -321,6 +322,7 @@ impl PropertiesPanel {
             ObjectType::Empty => ("Empty Object", IconName::Circle),
             ObjectType::ParticleSystem => ("Particle System", IconName::Sparks),
             ObjectType::AudioSource => ("Audio Source", IconName::MusicNote),
+            ObjectType::Blueprint => ("Blueprint Actor", IconName::Code),
         };
 
         let is_collapsed = collapsed_sections.contains(title);

--- a/ui-crates/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
@@ -14,7 +14,7 @@ use plugin_editor_api::{AssetKind, AssetPayload};
 use ui::{notification::Notification, ActiveTheme as _, ContextModal};
 
 use crate::level_editor::commands::{execute_command, SceneCommand};
-use crate::level_editor::scene_database::{ObjectType, SceneObjectData, Transform};
+use crate::level_editor::scene_database::{MeshType, ObjectType, SceneObjectData, Transform};
 use crate::level_editor::ui::state::LevelEditorState;
 
 /// A GPUI component that drives the Helio renderer into a `WgpuSurfaceHandle`.
@@ -55,112 +55,84 @@ impl HelioViewport {
 
         tracing::info!("Asset dropped on viewport: {} ({:?})", name, kind);
 
-        // Show importing notification
         window.push_notification(
-            Notification::info("Importing Asset").message(format!("Loading {}...", name)),
+            Notification::info("Adding to Scene").message(format!("Placing {}...", name)),
             cx,
         );
 
-        let result = Self::import_asset(
-            path,
-            kind,
-            self.gpu_engine.clone(),
-            self.shared_state.clone(),
-        );
+        let result = Self::import_asset(path, kind, self.shared_state.clone());
         match result {
             Ok(()) => {
                 window.push_notification(
-                    Notification::success("Import Successful")
-                        .message(format!("Imported {}", name)),
+                    Notification::success("Added to Scene")
+                        .message(format!("Placed {}", name)),
                     cx,
                 );
             }
             Err(e) => {
-                tracing::error!("Failed to import {}: {}", name, e);
+                tracing::error!("Failed to place {}: {}", name, e);
                 window.push_notification(
-                    Notification::error("Import Failed")
-                        .message(format!("Failed to import {}: {}", name, e)),
+                    Notification::error("Placement Failed")
+                        .message(format!("Failed to place {}: {}", name, e)),
                     cx,
                 );
             }
         }
     }
 
-    /// Load and insert the dropped asset into the scene.
+    /// Insert the dropped asset into the scene via the central SceneDatabase API.
+    ///
+    /// All assets — meshes, FBX files, blueprints — are inserted as SceneObjectData
+    /// entries with the appropriate component instances.  The renderer's sync_scene()
+    /// loop handles the actual GPU work every frame; nothing writes directly to Helio
+    /// from this path.
     fn import_asset(
         path: PathBuf,
         kind: AssetKind,
-        gpu_engine: Arc<Mutex<GpuRenderer>>,
         shared_state: Arc<parking_lot::RwLock<LevelEditorState>>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        // Validate file exists
         if !path.exists() {
             return Err(format!("File not found: {}", path.display()).into());
         }
 
-        // Based on AssetKind, load different asset types
         match kind {
             AssetKind::Mesh | AssetKind::Scene => {
-                tracing::info!("Loading FBX/scene from {:?}", path);
+                let asset_path = path.to_string_lossy().replace('\\', "/");
+                let imported_name = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("Imported Asset")
+                    .to_string();
 
-                // Load the scene file using helio-asset-compat
-                let load_config = helio_asset_compat::LoadConfig {
-                    flip_uv_y: true,               // Convert DirectX → OpenGL UVs
-                    merge_meshes: false,           // Keep separate meshes
-                    import_scale: glam::Vec3::ONE, // 1:1 scale
-                };
+                // Build a __component_instances entry for StaticMeshComponent so the
+                // renderer's sync_scene() loop loads the FBX via the component path.
+                let component_instances = serde_json::json!([{
+                    "class_name": "StaticMeshComponent",
+                    "enabled": true,
+                    "data": { "mesh_asset": asset_path }
+                }]);
+                let mut props = std::collections::HashMap::new();
+                props.insert("__component_instances".to_string(), component_instances);
+                props.insert("mesh_asset".to_string(), serde_json::Value::String(asset_path));
 
-                let converted_scene =
-                    helio_asset_compat::load_scene_file_with_config(&path, load_config).map_err(
-                        |e| format!("Failed to load scene file {}: {}", path.display(), e),
-                    )?;
-
-                tracing::info!(
-                    "Loaded scene: {} meshes, {} materials, {} textures",
-                    converted_scene.meshes.len(),
-                    converted_scene.materials.len(),
-                    converted_scene.textures.len()
-                );
-
-                let imported_name = if converted_scene.name.is_empty() {
-                    path.file_stem()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("Imported Scene")
-                        .to_string()
-                } else {
-                    converted_scene.name.clone()
-                };
-
-                // Insert the scene into Helio. We use a blocking lock here so
-                // drops don't fail transiently during a render tick.
-                let mut engine = gpu_engine
-                    .lock()
-                    .map_err(|_| "Failed to lock GPU renderer")?;
-                engine
-                    .insert_scene_object(converted_scene)
-                    .map_err(|e| format!("Failed to insert scene object: {}", e))?;
-                tracing::info!("Scene successfully inserted into Helio renderer");
-
-                // IMPORTANT: mirror import into SceneDatabase via unified command path so
-                // hierarchy/properties stay in sync with viewport drops.
                 let mut state = shared_state.write();
-                let import_root = SceneObjectData {
+                let mesh_object = SceneObjectData {
                     id: String::new(),
-                    name: format!("Imported: {}", imported_name),
-                    object_type: ObjectType::Folder,
+                    name: imported_name,
+                    object_type: ObjectType::Mesh(MeshType::Custom),
                     transform: Transform::default(),
                     visible: true,
                     locked: false,
                     parent: None,
                     children: vec![],
-                    props: Default::default(),
+                    props,
                     scene_path: path.display().to_string(),
                 };
 
                 let add_result = execute_command(
                     &mut state,
                     SceneCommand::AddObject {
-                        data: import_root,
+                        data: mesh_object,
                         parent_id: None,
                     },
                 );
@@ -168,9 +140,72 @@ impl HelioViewport {
                 if let Some(id) = add_result.affected_ids.first() {
                     let _ = execute_command(
                         &mut state,
-                        SceneCommand::SelectObject {
-                            id: Some(id.clone()),
-                        },
+                        SceneCommand::SelectObject { id: Some(id.clone()) },
+                    );
+                }
+            }
+            AssetKind::Blueprint => {
+                if !path.is_dir() {
+                    return Err(format!(
+                        "Blueprint path is not a directory: {}", path.display()
+                    ).into());
+                }
+                if !path.join("graph_save.json").exists() {
+                    return Err(format!(
+                        "Not a valid blueprint class (missing graph_save.json): {}",
+                        path.display()
+                    ).into());
+                }
+
+                let class_name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("Unknown")
+                    .to_string();
+                let script_path = path.to_string_lossy().replace('\\', "/");
+
+                // Blueprint actors go through the same component-driven path as
+                // all other scene objects.  A ScriptComponent instance stores the
+                // path to the blueprint directory; the engine's sync pass registers
+                // it with SCRIPT_REGISTRY for event dispatch.
+                let component_instances = serde_json::json!([{
+                    "class_name": "ScriptComponent",
+                    "enabled": true,
+                    "data": { "script_asset": script_path }
+                }]);
+                let mut props = std::collections::HashMap::new();
+                props.insert("__component_instances".to_string(), component_instances);
+                props.insert(
+                    "script_asset".to_string(),
+                    serde_json::Value::String(script_path),
+                );
+
+                let mut state = shared_state.write();
+                let blueprint_object = SceneObjectData {
+                    id: String::new(),
+                    name: class_name,
+                    object_type: ObjectType::Blueprint,
+                    transform: Transform::default(),
+                    visible: true,
+                    locked: false,
+                    parent: None,
+                    children: vec![],
+                    props,
+                    scene_path: path.display().to_string(),
+                };
+
+                let add_result = execute_command(
+                    &mut state,
+                    SceneCommand::AddObject {
+                        data: blueprint_object,
+                        parent_id: None,
+                    },
+                );
+
+                if let Some(id) = add_result.affected_ids.first() {
+                    let _ = execute_command(
+                        &mut state,
+                        SceneCommand::SelectObject { id: Some(id.clone()) },
                     );
                 }
             }
@@ -267,13 +302,13 @@ impl Render for HelioViewport {
                 .into_any_element()
         };
 
-        // Accept mesh/scene payload drags and forward successful drops to the viewport entity.
+        // Accept mesh/scene/blueprint payload drags and forward successful drops to the viewport entity.
         let viewport = cx.entity().clone();
         div()
             .id("helio-viewport-drop")
             .size_full()
             .drag_over::<AssetPayload>(|style, payload, _window, cx| {
-                if matches!(payload.kind, AssetKind::Mesh | AssetKind::Scene) {
+                if matches!(payload.kind, AssetKind::Mesh | AssetKind::Scene | AssetKind::Blueprint) {
                     style
                         .border_2()
                         .border_color(cx.theme().accent)
@@ -283,7 +318,7 @@ impl Render for HelioViewport {
                 }
             })
             .on_drop::<AssetPayload>(move |payload, window, cx| {
-                if matches!(payload.kind, AssetKind::Mesh | AssetKind::Scene) {
+                if matches!(payload.kind, AssetKind::Mesh | AssetKind::Scene | AssetKind::Blueprint) {
                     let payload = payload.clone();
                     viewport.update(cx, |this, cx| {
                         this.handle_asset_drop(&payload, window, cx);

--- a/ui-crates/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use engine_backend::services::gpu_renderer::GpuRenderer;
+use engine_state;
 use gpui::*;
 use plugin_editor_api::{AssetKind, AssetPayload};
 use ui::{notification::Notification, ActiveTheme as _, ContextModal};
@@ -162,12 +163,22 @@ impl HelioViewport {
                     .to_string();
                 let script_path = path.to_string_lossy().replace('\\', "/");
 
+                // Compute a path relative to the project root so the reference
+                // stays valid when the project is moved or opened on another machine.
+                let relative_path = engine_state::get_project_path()
+                    .and_then(|root| {
+                        path.strip_prefix(&root).ok()
+                            .map(|p| p.to_string_lossy().replace('\\', "/"))
+                    })
+                    .unwrap_or(script_path);
+
+                // The ScriptComponent is injected by SceneDatabase::add_object —
+                // callers only need to declare the type and the asset path.
                 let mut props = std::collections::HashMap::new();
-                props.insert("__component_instances".to_string(), serde_json::json!([{
-                    "class_name": "ScriptComponent",
-                    "enabled": true,
-                    "data": { "script_asset": script_path }
-                }]));
+                props.insert(
+                    "script_asset".to_string(),
+                    serde_json::Value::String(relative_path),
+                );
 
                 let mut state = shared_state.write();
                 let blueprint_object = SceneObjectData {

--- a/ui-crates/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
@@ -106,14 +106,12 @@ impl HelioViewport {
 
                 // Build a __component_instances entry for StaticMeshComponent so the
                 // renderer's sync_scene() loop loads the FBX via the component path.
-                let component_instances = serde_json::json!([{
+                let mut props = std::collections::HashMap::new();
+                props.insert("__component_instances".to_string(), serde_json::json!([{
                     "class_name": "StaticMeshComponent",
                     "enabled": true,
                     "data": { "mesh_asset": asset_path }
-                }]);
-                let mut props = std::collections::HashMap::new();
-                props.insert("__component_instances".to_string(), component_instances);
-                props.insert("mesh_asset".to_string(), serde_json::Value::String(asset_path));
+                }]));
 
                 let mut state = shared_state.write();
                 let mesh_object = SceneObjectData {
@@ -164,21 +162,12 @@ impl HelioViewport {
                     .to_string();
                 let script_path = path.to_string_lossy().replace('\\', "/");
 
-                // Blueprint actors go through the same component-driven path as
-                // all other scene objects.  A ScriptComponent instance stores the
-                // path to the blueprint directory; the engine's sync pass registers
-                // it with SCRIPT_REGISTRY for event dispatch.
-                let component_instances = serde_json::json!([{
+                let mut props = std::collections::HashMap::new();
+                props.insert("__component_instances".to_string(), serde_json::json!([{
                     "class_name": "ScriptComponent",
                     "enabled": true,
                     "data": { "script_asset": script_path }
-                }]);
-                let mut props = std::collections::HashMap::new();
-                props.insert("__component_instances".to_string(), component_instances);
-                props.insert(
-                    "script_asset".to_string(),
-                    serde_json::Value::String(script_path),
-                );
+                }]));
 
                 let mut state = shared_state.write();
                 let blueprint_object = SceneObjectData {

--- a/ui-crates/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
+++ b/ui-crates/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use engine_backend::services::gpu_renderer::GpuRenderer;
-use engine_state;
 use gpui::*;
 use plugin_editor_api::{AssetKind, AssetPayload};
 use ui::{notification::Notification, ActiveTheme as _, ContextModal};
@@ -163,22 +162,12 @@ impl HelioViewport {
                     .to_string();
                 let script_path = path.to_string_lossy().replace('\\', "/");
 
-                // Compute a path relative to the project root so the reference
-                // stays valid when the project is moved or opened on another machine.
-                let relative_path = engine_state::get_project_path()
-                    .and_then(|root| {
-                        path.strip_prefix(&root).ok()
-                            .map(|p| p.to_string_lossy().replace('\\', "/"))
-                    })
-                    .unwrap_or(script_path);
-
-                // The ScriptComponent is injected by SceneDatabase::add_object —
-                // callers only need to declare the type and the asset path.
                 let mut props = std::collections::HashMap::new();
-                props.insert(
-                    "script_asset".to_string(),
-                    serde_json::Value::String(relative_path),
-                );
+                props.insert("__component_instances".to_string(), serde_json::json!([{
+                    "class_name": "ScriptComponent",
+                    "enabled": true,
+                    "data": { "script_asset": script_path }
+                }]));
 
                 let mut state = shared_state.write();
                 let blueprint_object = SceneObjectData {


### PR DESCRIPTION
## What changed

### New: pulsar_events crate
Central script registry (`SCRIPT_REGISTRY`) mapping actor keys to blueprint folder paths. Written each sync pass by ScriptComponent; read by the game runtime's BlueprintDispatcher to build its instance map. No execution logic — pure registry.

### New: ScriptComponent (pulsar_rendering)
Self-contained component that attaches a blueprint actor script to a scene object. Stores a `ScriptAssetPath` (immutable path to the blueprint folder), registers with `SCRIPT_REGISTRY` each sync, and calls `context.mark_live()` for stale-cleanup. Follows the exact same EngineClass/RegisterRuntimeBehavior/ ScenePropsProjector pattern as LightComponent and StaticMeshComponent.

### Refactor: ComponentRuntimeContext trait (pulsar_reflection) Removed all component-specific methods and types:
- Deleted: RuntimeLightType, RuntimeLightDesc, RuntimeMeshDesc
- Deleted: upsert_light, upsert_mesh

Replaced with generic services only:
- SceneRenderPayload { Light(GpuLight), Mesh(MeshUpload) } enum
- upsert_actor(actor_key, SceneRenderPayload) — context owns all helio tracking
- project_root() -> &Path
- load_mesh_file(path) -> Option<MeshUpload> — default no-op, context overrides
- mark_live(actor_key) — for non-renderer components (scripts, etc.)
- report_error(msg)

Components are now fully self-contained: they parse their own data, construct any GPU payloads, and call generic context methods. The trait has zero knowledge of what any specific component type does.

### Updated: LightComponent, StaticMeshComponent
Both updated to use the new trait. StaticMeshComponent now calls load_mesh_file() then upsert_actor(SceneRenderPayload::Mesh); LightComponent calls upsert_actor(SceneRenderPayload::Light).

### Updated: SceneObjectContext (pulsar_scene)
Implements the new trait. upsert_actor dispatches on payload variant; load_mesh_file uses resolve_asset + load_mesh_or_fallback. Legacy v1 fallback now inlines GpuLight construction directly (no RuntimeLightDesc dependency).

### Updated: HelioRuntimeContext (engine_backend)
Implements the new trait. upsert_actor handles Light (update-or-insert with drag guard) and Mesh (cache + two-step object insert) internally. mark_live tracks live_script_keys; after sync, SCRIPT_REGISTRY.retain_keys() culls stale script registrations.

### Blueprint drag-drop
Blueprint actors now go through the same SceneDatabase/component-instance path as FBX meshes. Dropping a blueprint creates a SceneObjectData with a ScriptComponent in __component_instances pointing at the blueprint folder.

### New pulsar_std event nodes
on_tick(delta_time), on_end_play(), get_delta_time(), on_input_key(key, pressed), on_input_action(action, pressed)