### PR TITLE
ci: fix broken check action, add cargo check + cargo audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,11 @@ jobs:
           sudo apt-get install -y \
             pkg-config libssl-dev libglib2.0-dev libgtk-3-dev \
             libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
-            libxkbcommon-x11-0 libxkbcommon-x11-dev libasound2-dev
+            libxkbcommon-x11-0 libxkbcommon-x11-dev libasound2-dev \
+            clang libclang-dev
+
+      - name: Install bindgen (required by aws-lc-sys)
+        run: cargo install bindgen-cli --locked
 
       - name: cargo check
         run: cargo check --workspace --exclude pulsar_docs --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   pull_request:
   push:
@@ -7,9 +8,12 @@ on:
     tags:
       - "*"
 
+env:
+  RUSTFLAGS: ""
+
 jobs:
-  test:
-    name: Test
+  check:
+    name: cargo check
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
@@ -24,38 +28,52 @@ jobs:
     runs-on: ${{ matrix.run_on }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           components: clippy
-      - name: Install system dependencies
-        if: ${{ matrix.run_on != 'windows-latest' }}
-        run: script/bootstrap
-      - name: Machete
-        if: ${{ matrix.run_on == 'macos-latest' }}
-        uses: bnjbvr/cargo-machete@ac30a525c0a8d163a92d727b3ff079ee3f6ecb08 # v0.9.2
 
-      - name: Typo check
-        if: ${{ matrix.run_on == 'macos-latest' }}
-        run: |
-          cargo install typos-cli || echo "typos-cli already installed"
-          typos
-      - name: Lint
-        if: ${{ matrix.run_on == 'macos-latest' }}
-        env:
-          RUSTFLAGS: ""
-        run: |
-          cargo clippy --workspace --exclude pulsar_docs --all-targets -- -A dead_code -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::match_like_matches_macro -A clippy::only_used_in_recursion -A improper_ctypes_definitions -A clippy::field_reassign_with_default -A clippy::result_large_err -A clippy::doc_overindented_list_items
-      - name: Install nextest
-        run: cargo nextest --version || cargo install cargo-nextest --locked
-      - name: Test Linux
+      - name: Install Linux system dependencies
         if: ${{ matrix.run_on == 'ubuntu-latest' }}
         run: |
-          cargo nextest run --all
-      - name: Test Windows
-        if: ${{ matrix.run_on == 'windows-latest' }}
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config libssl-dev libglib2.0-dev libgtk-3-dev \
+            libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
+            libxkbcommon-x11-0 libxkbcommon-x11-dev libasound2-dev
+
+      - name: cargo check
+        run: cargo check --workspace --exclude pulsar_docs --all-targets
+
+      - name: cargo clippy
         run: |
-          cargo nextest run --all
-      - name: Test MacOS
-        if: ${{ matrix.run_on == 'macos-latest' }}
+          cargo clippy --workspace --exclude pulsar_docs --all-targets -- \
+            -A dead_code \
+            -A clippy::too_many_arguments \
+            -A clippy::type_complexity \
+            -A clippy::match_like_matches_macro \
+            -A clippy::only_used_in_recursion \
+            -A improper_ctypes_definitions \
+            -A clippy::field_reassign_with_default \
+            -A clippy::result_large_err \
+            -A clippy::doc_overindented_list_items
+
+      - name: Install nextest
+        run: cargo nextest --version || cargo install cargo-nextest --locked
+
+      - name: Run tests
+        run: cargo nextest run --all
+
+  cargo-audit:
+    name: Security audit
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+
+      - name: cargo audit
         run: |
-          cargo nextest run --all
+          cargo install cargo-audit --locked
+          cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "pulsar_engine"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## Summary

The CI check action (`ci.yml`) has been broken due to `script/bootstrap` calling a non-existent `setup-dev-environment.sh`, resulting in **exit code 127**. This PR rewrites the check workflow to be simpler, faster, and cover all platforms.

## Changes

| Before | After |
|---|---|
| `script/bootstrap` → missing script → error 127 | System deps installed via inline `apt-get` (matching release.yml) |
| `cargo clippy` only on macOS | `cargo check` + `cargo clippy` on **all 3 platforms** |
| No `cargo check` step (only implied by clippy) | Explicit `cargo check --workspace --exclude pulsar_docs --all-targets` |
| No security audit in CI | New **`cargo-audit`** job scanning for dependency vulnerabilities |
| `cargo-machete` + `typos-cli` only on macOS | Removed (unnecessary for check CI) |

## Why

Per discussion with @Trident_For_U, the setup scripts are no longer needed — the check action should simply run `cargo check` and `cargo clippy`. The release workflow is left untouched.