### PR TITLE
Adapt Pulsar to the current Helio v4 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,12 +2887,13 @@ dependencies = [
  "git2 0.21.0",
  "glam 0.33.2",
  "gpui-ce",
- "helio 0.17.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio 0.18.0",
  "helio-asset-compat",
  "lsp-types",
  "parking_lot",
  "profiling 0.1.0",
  "pulsar_events",
+ "pulsar_helio",
  "pulsar_lsp",
  "pulsar_reflection",
  "pulsar_rendering",
@@ -4102,7 +4103,7 @@ dependencies = [
  "gpui_sum_tree",
  "gpui_util",
  "gpui_util_macros",
- "helio 0.17.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio 0.17.0",
  "image",
  "inventory",
  "itertools 0.14.0",
@@ -4453,63 +4454,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.17.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
-dependencies = [
- "arrayvec",
- "bytemuck",
- "glam 0.33.2",
- "helio-pass-billboard 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-corona",
- "helio-pass-debug 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-debug-overlay",
- "helio-pass-deferred-light 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-depth-prepass 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-fxaa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-gbuffer 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-hiz 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-hlfs 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-indirect-dispatch 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-light-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-occlusion-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-perf-overlay 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-shadow 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-shadow-cull",
- "helio-pass-shadow-dirty 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-shadow-matrix 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-simple-cube 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-sky 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-sky-lut 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-smaa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-ssao 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-taa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-transparent 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-virtual-geometry 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-pass-water-sim 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "image",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "log",
- "meshopt",
- "pollster 0.4.0",
- "quark",
- "thiserror 2.0.18",
- "web-time",
- "wgpu",
- "windows 0.62.2",
-]
-
-[[package]]
-name = "helio"
-version = "0.17.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "arrayvec",
  "bytemuck",
  "glam 0.29.3",
  "helio-pass-billboard 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
- "helio-pass-debug 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-pass-debug",
  "helio-pass-deferred-light 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
- "helio-pass-depth-prepass 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-pass-depth-prepass",
  "helio-pass-fxaa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "helio-pass-gbuffer 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "helio-pass-hiz 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
@@ -4524,13 +4477,13 @@ dependencies = [
  "helio-pass-simple-cube 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "helio-pass-sky 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "helio-pass-sky-lut 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
- "helio-pass-smaa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
- "helio-pass-ssao 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-pass-smaa",
+ "helio-pass-ssao",
  "helio-pass-taa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "helio-pass-transparent 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "helio-pass-virtual-geometry 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "helio-pass-water-sim 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "image",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "log",
@@ -4543,15 +4496,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "helio"
+version = "0.18.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
+dependencies = [
+ "arrayvec",
+ "bytemuck",
+ "glam 0.33.2",
+ "helio-core",
+ "helio-pass-postprocess",
+ "helio-voxel-core",
+ "image",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "log",
+ "meshopt",
+ "pollster 0.4.0",
+ "quark",
+ "thiserror 2.0.18",
+ "web-time",
+ "wgpu",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
- "helio 0.17.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio 0.18.0",
  "image",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "log",
  "solid-fbx",
  "solid-gltf",
@@ -4563,13 +4539,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "helio-pass-billboard"
+name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "glam 0.33.2",
+ "helio-voxel-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "thiserror 2.0.18",
+ "wgpu",
+]
+
+[[package]]
+name = "helio-default-graphs"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
+dependencies = [
+ "helio 0.18.0",
+ "helio-core",
+ "helio-pass-billboard 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-corona",
+ "helio-pass-debug-overlay",
+ "helio-pass-deferred-light 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-fxaa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-gbuffer 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-hiz 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-hlfs 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-indirect-dispatch 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-light-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-occlusion-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-perf-overlay 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-postprocess",
+ "helio-pass-shadow 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-shadow-cull",
+ "helio-pass-shadow-dirty 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-shadow-matrix 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-simple-cube 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-sky 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-sky-lut 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-taa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-transparent 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-virtual-geometry 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "helio-pass-water-sim 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
+ "image",
+ "wgpu",
+]
+
+[[package]]
+name = "helio-pass-billboard"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
+dependencies = [
+ "bytemuck",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4579,7 +4603,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -4587,22 +4611,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "wgpu",
-]
-
-[[package]]
-name = "helio-pass-debug"
-version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
-dependencies = [
- "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4612,7 +4625,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -4620,22 +4633,22 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4645,7 +4658,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -4653,22 +4666,10 @@ dependencies = [
 [[package]]
 name = "helio-pass-depth-prepass"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
-dependencies = [
- "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "log",
- "wgpu",
-]
-
-[[package]]
-name = "helio-pass-depth-prepass"
-version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "log",
  "wgpu",
@@ -4677,11 +4678,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4691,7 +4692,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -4699,11 +4700,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "log",
  "wgpu",
 ]
@@ -4714,7 +4715,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "log",
  "wgpu",
@@ -4723,10 +4724,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "log",
  "wgpu",
 ]
@@ -4737,7 +4739,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "log",
  "wgpu",
 ]
@@ -4745,12 +4747,12 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4761,7 +4763,7 @@ source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c1
 dependencies = [
  "bytemuck",
  "glam 0.29.3",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -4769,10 +4771,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4782,18 +4785,18 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4803,7 +4806,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -4811,10 +4814,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4824,18 +4828,18 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4845,19 +4849,30 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "wgpu",
+]
+
+[[package]]
+name = "helio-pass-postprocess"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
+dependencies = [
+ "bytemuck",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "log",
  "wgpu",
 ]
@@ -4868,7 +4883,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "log",
  "wgpu",
@@ -4877,20 +4892,22 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4900,17 +4917,18 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4920,17 +4938,18 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "log",
  "wgpu",
 ]
@@ -4941,7 +4960,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "log",
  "wgpu",
 ]
@@ -4949,11 +4968,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4963,7 +4982,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -4971,11 +4990,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -4985,19 +5004,8 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
- "wgpu",
-]
-
-[[package]]
-name = "helio-pass-smaa"
-version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
-dependencies = [
- "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
  "wgpu",
 ]
 
@@ -5007,19 +5015,8 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
- "wgpu",
-]
-
-[[package]]
-name = "helio-pass-ssao"
-version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
-dependencies = [
- "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
  "wgpu",
 ]
 
@@ -5029,7 +5026,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -5037,11 +5034,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-taa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -5051,7 +5048,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -5059,11 +5056,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -5073,7 +5070,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -5081,11 +5078,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "log",
  "wgpu",
 ]
@@ -5096,7 +5093,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "log",
  "wgpu",
@@ -5105,11 +5102,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio-core",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db)",
  "wgpu",
 ]
 
@@ -5119,7 +5116,7 @@ version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
- "helio-v3 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
+ "helio-v3",
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "wgpu",
 ]
@@ -5127,13 +5124,14 @@ dependencies = [
 [[package]]
 name = "helio-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
  "futures-channel",
  "glam 0.33.2",
- "helio 0.17.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio 0.18.0",
  "helio-asset-compat",
+ "helio-default-graphs",
  "image",
  "log",
  "pollster 0.4.0",
@@ -5144,18 +5142,6 @@ dependencies = [
 [[package]]
 name = "helio-v3"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
-dependencies = [
- "bytemuck",
- "glam 0.33.2",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
- "thiserror 2.0.18",
- "wgpu",
-]
-
-[[package]]
-name = "helio-v3"
-version = "0.1.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
 dependencies = [
  "bytemuck",
@@ -5163,6 +5149,15 @@ dependencies = [
  "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9)",
  "thiserror 2.0.18",
  "wgpu",
+]
+
+[[package]]
+name = "helio-voxel-core"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
+dependencies = [
+ "bytemuck",
+ "glam 0.33.2",
 ]
 
 [[package]]
@@ -6110,7 +6105,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747#b88e366d6a6792e34d5b9c7afd1a197a78c54747"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=3210590541e28a3c37ec6fe5c2bc0b80214a70db#3210590541e28a3c37ec6fe5c2bc0b80214a70db"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -8970,13 +8965,14 @@ version = "0.1.0"
 dependencies = [
  "engine_state",
  "glam 0.33.2",
- "helio 0.17.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio 0.18.0",
  "pbgc",
  "pollster 1.0.1",
  "profiling 0.1.0",
  "pulsar_bp_executor",
  "pulsar_core",
  "pulsar_ecs",
+ "pulsar_helio",
  "pulsar_reflection",
  "pulsar_scene",
  "pulsar_settings",
@@ -8988,6 +8984,15 @@ dependencies = [
  "uuid",
  "wgpu",
  "winit",
+]
+
+[[package]]
+name = "pulsar_helio"
+version = "0.1.0"
+dependencies = [
+ "helio 0.18.0",
+ "helio-default-graphs",
+ "wgpu",
 ]
 
 [[package]]
@@ -9045,7 +9050,7 @@ dependencies = [
  "dashmap",
  "glam 0.33.2",
  "gpui-ce",
- "helio 0.17.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio 0.18.0",
  "inventory",
  "once_cell",
  "pulsar_reflection_derive",
@@ -9073,7 +9078,7 @@ dependencies = [
  "engine_class_derive",
  "glam 0.33.2",
  "gpui-ce",
- "helio 0.17.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio 0.18.0",
  "helio-asset-compat",
  "plugin_editor_api",
  "pulsar_events",
@@ -9091,7 +9096,7 @@ version = "0.1.0"
 dependencies = [
  "engine_fs",
  "glam 0.33.2",
- "helio 0.17.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b88e366d6a6792e34d5b9c7afd1a197a78c54747)",
+ "helio 0.18.0",
  "helio-asset-compat",
  "pulsar_events",
  "pulsar_reflection",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8992,6 +8992,7 @@ version = "0.1.0"
 dependencies = [
  "helio 0.18.0",
  "helio-default-graphs",
+ "toml 1.1.2+spec-1.1.0",
  "wgpu",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ agent_provider_cohere              = { path = "crates/agent-providers/agent_prov
 
 # ---------- Subsystem Crates ----------
 pulsar_physics        = { path = "crates/subsystems/pulsar_physics" }
+pulsar_helio          = { path = "crates/subsystems/pulsar_helio" }
 pulsar_rendering      = { path = "crates/subsystems/pulsar_rendering" }
 
 
@@ -125,9 +126,10 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                 = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b88e366d6a6792e34d5b9c7afd1a197a78c54747" }
-helio-snapshot        = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b88e366d6a6792e34d5b9c7afd1a197a78c54747" }
-helio-asset-compat    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b88e366d6a6792e34d5b9c7afd1a197a78c54747" }
+helio                 = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "3210590541e28a3c37ec6fe5c2bc0b80214a70db" }
+helio-snapshot        = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "3210590541e28a3c37ec6fe5c2bc0b80214a70db" }
+helio-asset-compat    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "3210590541e28a3c37ec6fe5c2bc0b80214a70db" }
+helio-default-graphs  = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "3210590541e28a3c37ec6fe5c2bc0b80214a70db" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/crates/core/engine_backend/Cargo.toml
+++ b/crates/core/engine_backend/Cargo.toml
@@ -50,6 +50,7 @@ flume = { workspace = true }
 # Helio rendering (wgpu-based)
 helio.workspace = true
 helio-asset-compat = { workspace = true }
+pulsar_helio.workspace = true
 glam.workspace = true
 bytemuck = "1.14"
 

--- a/crates/core/engine_backend/src/services/core_project_builder.rs
+++ b/crates/core/engine_backend/src/services/core_project_builder.rs
@@ -132,14 +132,15 @@ serde = {{ version = \"1.0\", features = [\"derive\"] }}\n\
 serde_json = \"1.0\"\n\
 tracing = \"0.1\"\n\
 tracing-subscriber = {{ version = \"0.3\", features = [\"fmt\", \"env-filter\"] }}\n\
-helio = {{ git = \"https://github.com/Far-Beyond-Pulsar/Helio\" }}\n\
+helio = {{ git = \"https://github.com/Far-Beyond-Pulsar/Helio\", rev = \"{helio_rev}\" }}\n\
 winit = \"0.30\"\n\n\
 [profile.dev]\n\
 opt-level = {}\n\
 debug = {}\n",
         package_lines.join("\n"),
         profile_opt,
-        profile_debug
+        profile_debug,
+        helio_rev = pulsar_helio::HELIO_GIT_REVISION,
     );
 
     virtual_fs::write_file(&cargo_toml_path, cargo_content.as_bytes())

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
@@ -13,6 +13,7 @@ use helio::{
     SceneActorId, ScenePicker, SkyActor,
 };
 use pulsar_events::script_registry;
+use pulsar_helio::new_external_renderer;
 use pulsar_reflection::{
     apply_runtime_behavior_for_class, scene_id_to_tag, ComponentRuntimeContext, LiveKeySet,
     RuntimeComponentOwner, Subsystems,
@@ -166,7 +167,7 @@ impl HelioRenderer {
             // Clone device/queue from GPUI's WgpuSurface
             let device_arc = Arc::new(_device.clone());
             let queue_arc = Arc::new(_queue.clone());
-            let mut r = Renderer::new_with_external_device(
+            let mut r = new_external_renderer(
                 device_arc.clone(),
                 queue_arc.clone(),
                 RendererConfig::new(width, height, format),

--- a/crates/core/pulsar_game/Cargo.toml
+++ b/crates/core/pulsar_game/Cargo.toml
@@ -27,6 +27,7 @@ pulsar_reflection = { workspace = true }
 
 # Windowed rendering (Helio + winit + wgpu)
 helio   = { workspace = true }
+pulsar_helio = { workspace = true }
 winit   = { workspace = true }
 wgpu    = { workspace = true }
 glam    = { workspace = true }

--- a/crates/core/pulsar_game/src/windowed_app.rs
+++ b/crates/core/pulsar_game/src/windowed_app.rs
@@ -19,6 +19,7 @@ use winit::{
 };
 
 use helio::{required_wgpu_features, required_wgpu_limits, Camera, Renderer, RendererConfig};
+use pulsar_helio::new_external_renderer;
 
 use crate::freecam::FreeCam;
 use crate::window::{RenderCamera, WindowBridge, WindowCommand, WindowDescriptor, WindowHandle};
@@ -72,7 +73,7 @@ impl GameWindow {
         };
         surface.configure(&device, &surface_config);
 
-        let mut renderer = Renderer::new(
+        let mut renderer = new_external_renderer(
             device.clone(),
             queue.clone(),
             RendererConfig::new(surface_config.width, surface_config.height, surface_format),

--- a/crates/subsystems/pulsar_helio/Cargo.toml
+++ b/crates/subsystems/pulsar_helio/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pulsar_helio"
+version = "0.1.0"
+edition = "2021"
+description = "Pulsar-owned bootstrap and integration boundary for Helio"
+
+[dependencies]
+helio = { workspace = true }
+helio-default-graphs = { workspace = true }
+wgpu = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/subsystems/pulsar_helio/Cargo.toml
+++ b/crates/subsystems/pulsar_helio/Cargo.toml
@@ -9,5 +9,8 @@ helio = { workspace = true }
 helio-default-graphs = { workspace = true }
 wgpu = { workspace = true }
 
+[build-dependencies]
+toml = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/subsystems/pulsar_helio/build.rs
+++ b/crates/subsystems/pulsar_helio/build.rs
@@ -1,0 +1,49 @@
+use std::{env, fs, path::PathBuf};
+
+const HELIO_DEPENDENCIES: [&str; 4] = [
+    "helio",
+    "helio-snapshot",
+    "helio-asset-compat",
+    "helio-default-graphs",
+];
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let workspace_manifest = manifest_dir.join("../../../Cargo.toml");
+    println!("cargo:rerun-if-changed={}", workspace_manifest.display());
+
+    let source = fs::read_to_string(&workspace_manifest).unwrap_or_else(|error| {
+        panic!(
+            "failed to read Pulsar workspace manifest {}: {error}",
+            workspace_manifest.display()
+        )
+    });
+    let manifest: toml::Value = toml::from_str(&source)
+        .unwrap_or_else(|error| panic!("failed to parse Pulsar workspace manifest: {error}"));
+    let dependencies = manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("dependencies"))
+        .and_then(toml::Value::as_table)
+        .expect("Pulsar workspace manifest is missing [workspace.dependencies]");
+
+    let revision = dependency_revision(dependencies, HELIO_DEPENDENCIES[0]);
+    for dependency in HELIO_DEPENDENCIES.into_iter().skip(1) {
+        let candidate = dependency_revision(dependencies, dependency);
+        assert_eq!(
+            candidate, revision,
+            "workspace dependency `{dependency}` uses Helio revision {candidate}, expected {revision}"
+        );
+    }
+
+    println!("cargo:rustc-env=PULSAR_HELIO_GIT_REVISION={revision}");
+}
+
+fn dependency_revision<'a>(dependencies: &'a toml::Table, dependency: &str) -> &'a str {
+    dependencies
+        .get(dependency)
+        .and_then(|value| value.get("rev"))
+        .and_then(toml::Value::as_str)
+        .unwrap_or_else(|| {
+            panic!("workspace dependency `{dependency}` must pin Helio with an explicit `rev`")
+        })
+}

--- a/crates/subsystems/pulsar_helio/src/lib.rs
+++ b/crates/subsystems/pulsar_helio/src/lib.rs
@@ -1,0 +1,99 @@
+//! Pulsar's runtime integration boundary for the Helio graphics engine.
+//!
+//! Helio intentionally exposes its scene, graph, and renderer construction
+//! separately. Pulsar owns the policy that joins those pieces because its GPU
+//! device is shared by GPUI and, in games, potentially by multiple windows.
+
+use std::sync::{Arc, Mutex};
+
+use helio::{DebugCameraUniform, DebugDrawState, Renderer, RendererConfig, Scene};
+use helio_default_graphs::build_default_graph_external;
+
+/// Helio revision audited against this Pulsar integration layer.
+///
+/// Generated game projects must use this exact revision as well. Otherwise
+/// Cargo can resolve two different `helio` package identities and values from
+/// a game's direct Helio dependency will not be compatible with Pulsar's API.
+pub const HELIO_GIT_REVISION: &str = "3210590541e28a3c37ec6fe5c2bc0b80214a70db";
+
+/// Creates an empty Helio renderer that borrows a device managed by Pulsar.
+///
+/// This is the only supported bootstrap for Pulsar runtime and editor callers.
+/// It deliberately uses Helio's external-device graph and renderer paths so
+/// Helio never blocks on or independently polls a device shared with GPUI or
+/// another game window.
+pub fn new_external_renderer(
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    config: RendererConfig,
+) -> Renderer {
+    let scene = Scene::new(Arc::clone(&device), Arc::clone(&queue));
+    let debug_state = Arc::new(Mutex::new(DebugDrawState::default()));
+
+    let debug_camera_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Pulsar Helio Debug Camera"),
+        size: std::mem::size_of::<DebugCameraUniform>() as u64,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let cull_stats_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Pulsar Helio Cull Stats"),
+        size: 32,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let graph = build_default_graph_external(
+        &device,
+        &queue,
+        &scene,
+        config,
+        Arc::clone(&debug_state),
+        &debug_camera_buffer,
+        &cull_stats_buffer,
+        None,
+    );
+
+    Renderer::new_with_external_device(
+        device,
+        queue,
+        config.surface_format,
+        config.width,
+        config.height,
+        config.render_scale,
+        config,
+        scene,
+        graph,
+        debug_state,
+        debug_camera_buffer,
+        cull_stats_buffer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HELIO_GIT_REVISION;
+
+    #[test]
+    fn workspace_helio_dependencies_match_the_audited_revision() {
+        let workspace_manifest = include_str!("../../../../Cargo.toml");
+
+        for dependency in [
+            "helio",
+            "helio-snapshot",
+            "helio-asset-compat",
+            "helio-default-graphs",
+        ] {
+            let line = workspace_manifest
+                .lines()
+                .find(|line| line.trim_start().starts_with(dependency))
+                .unwrap_or_else(|| panic!("missing workspace dependency `{dependency}`"));
+            assert!(
+                line.contains(HELIO_GIT_REVISION),
+                "workspace dependency `{dependency}` drifted from audited Helio revision {HELIO_GIT_REVISION}: {line}"
+            );
+        }
+    }
+}

--- a/crates/subsystems/pulsar_helio/src/lib.rs
+++ b/crates/subsystems/pulsar_helio/src/lib.rs
@@ -9,12 +9,15 @@ use std::sync::{Arc, Mutex};
 use helio::{DebugCameraUniform, DebugDrawState, Renderer, RendererConfig, Scene};
 use helio_default_graphs::build_default_graph_external;
 
-/// Helio revision audited against this Pulsar integration layer.
+/// Helio revision selected by the Pulsar workspace and audited against this
+/// integration layer.
 ///
 /// Generated game projects must use this exact revision as well. Otherwise
 /// Cargo can resolve two different `helio` package identities and values from
 /// a game's direct Helio dependency will not be compatible with Pulsar's API.
-pub const HELIO_GIT_REVISION: &str = "3210590541e28a3c37ec6fe5c2bc0b80214a70db";
+/// The build script reads this value from the root `[workspace.dependencies]`
+/// table and rejects mismatched Helio package revisions.
+pub const HELIO_GIT_REVISION: &str = env!("PULSAR_HELIO_GIT_REVISION");
 
 /// Creates an empty Helio renderer that borrows a device managed by Pulsar.
 ///
@@ -70,30 +73,4 @@ pub fn new_external_renderer(
         debug_camera_buffer,
         cull_stats_buffer,
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::HELIO_GIT_REVISION;
-
-    #[test]
-    fn workspace_helio_dependencies_match_the_audited_revision() {
-        let workspace_manifest = include_str!("../../../../Cargo.toml");
-
-        for dependency in [
-            "helio",
-            "helio-snapshot",
-            "helio-asset-compat",
-            "helio-default-graphs",
-        ] {
-            let line = workspace_manifest
-                .lines()
-                .find(|line| line.trim_start().starts_with(dependency))
-                .unwrap_or_else(|| panic!("missing workspace dependency `{dependency}`"));
-            assert!(
-                line.contains(HELIO_GIT_REVISION),
-                "workspace dependency `{dependency}` drifted from audited Helio revision {HELIO_GIT_REVISION}: {line}"
-            );
-        }
-    }
 }


### PR DESCRIPTION
## Summary

- advance Pulsar's Helio, snapshot, and asset dependencies from `b88e366` to audited v4 revision `3210590`
- add a Pulsar-owned `pulsar_helio` bootstrap boundary using Helio's external-device graph and renderer paths
- migrate the GPUI editor and standalone/multi-window game callers to the shared-device-safe bootstrap
- derive the generated-project Helio revision from the root workspace manifest and reject cross-package revision drift at build time
- update the lockfile for the current Helio graph

## Caller audit

Checked runtime/editor construction plus direct consumers in `pulsar_scene`, `pulsar_rendering`, `engine_fs`/`helio-snapshot`, `pulsar_reflection`, and `ui_level_editor`. WGPUI's separate stale development example is tracked in Far-Beyond-Pulsar/WGPUI#45 and is intentionally not changed through the Pulsar submodule in this PR.

## Verification

- `cargo check -p engine_backend -p pulsar_game --message-format short`
- `cargo test -p pulsar_helio --lib --message-format short` (build-script revision validation completed)
- `cargo check -p pulsar_helio -p pulsar_scene -p pulsar_rendering -p engine_fs -p pulsar_reflection -p ui_level_editor --message-format short`
- `git diff --check`

Existing workspace warnings remain. This PR establishes the audited compatibility boundary; it does not claim Helio or Pulsar is production ready.

Closes #302
