### PR TITLE
Add production sparse planetary terrain core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9144,6 +9144,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulsar_terrain"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "engine_fs",
+ "serde",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ pulsar_reflection                  = { path = "crates/core/pulsar_reflection" }
 pulsar_events                      = { path = "crates/core/pulsar_events" }
 engine_class_derive                = { path = "crates/core/engine_class_derive" }
 pulsar_scene                       = { path = "crates/subsystems/pulsar_scene" }
+pulsar_terrain                     = { path = "crates/subsystems/pulsar_terrain" }
 
 # ---------- Agent Providers ----------
 agent_chat_core                    = { path = "crates/agent-providers/agent_chat_core" }

--- a/crates/subsystems/pulsar_terrain/Cargo.toml
+++ b/crates/subsystems/pulsar_terrain/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pulsar_terrain"
+version = "0.1.0"
+edition = "2021"
+description = "Authoritative sparse planetary voxel terrain core for Pulsar"
+
+[dependencies]
+anyhow = { workspace = true }
+engine_fs = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[[bench]]
+name = "terrain_core"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
+++ b/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
@@ -1,0 +1,81 @@
+use pulsar_terrain::{
+    CellWord, ContentHash, EditMode, EditOp, EditShape, FixedSphereGenerator, NodeState,
+    PageKey, PlanetId, SparseBrickTree, TerrainCore,
+};
+use std::time::Instant;
+
+fn main() {
+    const TOUCHES: i64 = 10_000;
+    let started = Instant::now();
+    let mut sparse = SparseBrickTree::centered(24, NodeState::Air).unwrap();
+    for index in 0..TOUCHES {
+        sparse
+            .set(
+                PageKey::new(0, [index - TOUCHES / 2, index % 97, -(index % 193)]),
+                NodeState::Page(ContentHash::of(&index.to_le_bytes())),
+            )
+            .unwrap();
+    }
+    let sparse_time = started.elapsed();
+
+    const DENSE_EDGE: usize = 128;
+    let dense_started = Instant::now();
+    let dense = vec![CellWord::AIR; DENSE_EDGE * DENSE_EDGE * DENSE_EDGE];
+    std::hint::black_box(&dense);
+    let dense_time = dense_started.elapsed();
+
+    let mut core = TerrainCore::new(
+        PlanetId([1; 16]),
+        24,
+        FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 63_710_000,
+            material: 1,
+        },
+    )
+    .unwrap();
+    core.append_edit(EditOp {
+        sequence: 1,
+        stable_id: [1; 16],
+        shape: EditShape::Sphere {
+            center_cell: [0; 3],
+            radius_cells: 10,
+        },
+        mode: EditMode::Subtract,
+        material: 0,
+    })
+    .unwrap();
+    let edit_started = Instant::now();
+    let compacted = core.compact_page(PageKey::new(0, [0; 3])).unwrap();
+    let edit_time = edit_started.elapsed();
+
+    let delete_started = Instant::now();
+    core.set_root(NodeState::Air).unwrap();
+    let delete_time = delete_started.elapsed();
+
+    let edit_amplification = [1_u32, 10, 100, 1_000].map(|radius_cells| {
+        EditShape::Sphere {
+            center_cell: [0; 3],
+            radius_cells,
+        }
+        .affected_lod0_page_count()
+    });
+    let memory = core.memory_counters();
+    let work = core.work_counters();
+
+    // A billion logical cells are represented by the root without allocation.
+    let logical_dense_bytes = 1_000_000_000_u64 * 4;
+    println!(
+        "terrain_core sparse_touches={TOUCHES} nodes={} sparse_ms={:.3} dense_sample_cells={} dense_sample_bytes={} dense_fill_ms={:.3} billion_dense_equivalent_bytes={logical_dense_bytes} edited_page_bytes={} resident_dense_bytes={} generated_cells={} edit_compact_ms={:.3} edit_radius_cells=[1,10,100,1000] edit_aabb_pages={edit_amplification:?} root_delete_us={:.3}",
+        sparse.node_count(),
+        sparse_time.as_secs_f64() * 1_000.0,
+        dense.len(),
+        dense.len() * std::mem::size_of::<CellWord>(),
+        dense_time.as_secs_f64() * 1_000.0,
+        core.page(compacted.key).unwrap().encode().len(),
+        memory.resident_dense_bytes,
+        work.cells_generated,
+        edit_time.as_secs_f64() * 1_000.0,
+        delete_time.as_secs_f64() * 1_000_000.0,
+    );
+}

--- a/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
+++ b/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
@@ -1,6 +1,6 @@
 use pulsar_terrain::{
-    CellWord, ContentHash, EditMode, EditOp, EditShape, FixedSphereGenerator, NodeState,
-    PageKey, PlanetId, SparseBrickTree, TerrainCore,
+    CellWord, ContentHash, EditMode, EditOp, EditShape, FixedSphereGenerator, NodeState, PageKey,
+    PlanetId, SparseBrickTree, TerrainCore,
 };
 use std::time::Instant;
 
@@ -66,7 +66,7 @@ fn main() {
     // A billion logical cells are represented by the root without allocation.
     let logical_dense_bytes = 1_000_000_000_u64 * 4;
     println!(
-        "terrain_core sparse_touches={TOUCHES} nodes={} sparse_ms={:.3} dense_sample_cells={} dense_sample_bytes={} dense_fill_ms={:.3} billion_dense_equivalent_bytes={logical_dense_bytes} edited_page_bytes={} resident_dense_bytes={} generated_cells={} edit_compact_ms={:.3} edit_radius_cells=[1,10,100,1000] edit_aabb_pages={edit_amplification:?} root_delete_us={:.3}",
+        "terrain_core sparse_touches={TOUCHES} nodes={} sparse_ms={:.3} dense_sample_cells={} dense_sample_bytes={} dense_fill_ms={:.3} billion_dense_equivalent_bytes={logical_dense_bytes} edited_page_bytes={} resident_dense_bytes={} generated_cells={} edit_attachment_regions={} edit_attachment_refs={} edit_candidates_replayed={} edit_compact_ms={:.3} edit_radius_cells=[1,10,100,1000] edit_aabb_pages={edit_amplification:?} root_delete_us={:.3}",
         sparse.node_count(),
         sparse_time.as_secs_f64() * 1_000.0,
         dense.len(),
@@ -75,6 +75,9 @@ fn main() {
         core.page(compacted.key).unwrap().encode().len(),
         memory.resident_dense_bytes,
         work.cells_generated,
+        memory.edit_attachment_regions,
+        memory.edit_attachment_references,
+        work.edit_candidates_replayed,
         edit_time.as_secs_f64() * 1_000.0,
         delete_time.as_secs_f64() * 1_000_000.0,
     );

--- a/crates/subsystems/pulsar_terrain/src/core.rs
+++ b/crates/subsystems/pulsar_terrain/src/core.rs
@@ -1,3 +1,4 @@
+use crate::edit::EditIndex;
 use crate::{
     CompactedPageRecord, DeterministicGenerator, EditError, EditLog, EditOp, HierarchyError,
     NodeState, PageCodecError, PageKey, PlanetId, SparseBrickTree, TerrainSnapshot, VoxelPage,
@@ -14,6 +15,7 @@ pub struct TerrainCore<G> {
     generator: G,
     hierarchy: SparseBrickTree,
     edits: EditLog,
+    edit_index: EditIndex,
     pages: BTreeMap<PageKey, VoxelPage>,
     compacted: BTreeMap<PageKey, CompactedPageRecord>,
     work: TerrainWorkCounters,
@@ -26,6 +28,7 @@ pub struct TerrainWorkCounters {
     pub pages_compacted: u64,
     pub cells_generated: u64,
     pub cells_replayed: u64,
+    pub edit_candidates_replayed: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -33,6 +36,8 @@ pub struct TerrainMemoryCounters {
     pub hierarchy_nodes: usize,
     pub hierarchy_encoded_bytes: usize,
     pub edit_operations: usize,
+    pub edit_attachment_regions: usize,
+    pub edit_attachment_references: usize,
     pub resident_pages: usize,
     pub resident_dense_bytes: usize,
     pub compacted_page_records: usize,
@@ -47,6 +52,7 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             generator,
             hierarchy,
             edits: EditLog::default(),
+            edit_index: EditIndex::new(root_lod),
             pages: BTreeMap::new(),
             compacted: BTreeMap::new(),
             work: TerrainWorkCounters::default(),
@@ -65,6 +71,7 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
         let previous_len = self.edits.operations().len();
         self.edits.push(operation)?;
         if self.edits.operations().len() != previous_len {
+            self.edit_index.insert(previous_len, operation);
             self.work.edits_appended = self.work.edits_appended.saturating_add(1);
         }
         Ok(())
@@ -84,25 +91,25 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             }
         }
 
+        let relevant = self
+            .edit_index
+            .operations_for_page(&self.edits, key, previous_sequence);
+        self.work.edit_candidates_replayed = self
+            .work
+            .edit_candidates_replayed
+            .saturating_add(relevant.len() as u64);
         let page = if let Some(previous) = self.pages.get(&key) {
-            let tail = self
-                .edits
-                .operations()
-                .iter()
-                .copied()
-                .filter(|operation| operation.sequence > previous_sequence)
-                .collect::<Vec<_>>();
             self.work.cells_replayed = self
                 .work
                 .cells_replayed
                 .saturating_add(crate::CELL_COUNT as u64);
-            previous.apply_edit_tail(key, &tail)?
+            previous.apply_edit_tail(key, &relevant)?
         } else {
             self.work.cells_generated = self
                 .work
                 .cells_generated
                 .saturating_add(crate::CELL_COUNT as u64);
-            VoxelPage::generate(key, &self.generator, &self.edits)?
+            VoxelPage::generate_with_operations(key, &self.generator, &relevant)?
         };
         let page_id = page.page_id();
         let record = CompactedPageRecord {
@@ -110,13 +117,15 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             page_id,
             compacted_through_sequence: latest_sequence,
         };
-        let state = page.constant_cell().map_or(NodeState::Page(page_id), |cell| {
-            if cell.is_solid() {
-                NodeState::Solid(cell.material())
-            } else {
-                NodeState::Air
-            }
-        });
+        let state = page
+            .constant_cell()
+            .map_or(NodeState::Page(page_id), |cell| {
+                if cell.is_solid() {
+                    NodeState::Solid(cell.material())
+                } else {
+                    NodeState::Air
+                }
+            });
         self.hierarchy.set(key, state)?;
         self.pages.insert(key, page);
         self.compacted.insert(key, record);
@@ -167,6 +176,8 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             hierarchy_nodes: self.hierarchy.node_count(),
             hierarchy_encoded_bytes: self.hierarchy.encode().len(),
             edit_operations: self.edits.operations().len(),
+            edit_attachment_regions: self.edit_index.region_count(),
+            edit_attachment_references: self.edit_index.reference_count(),
             resident_pages: self.pages.len(),
             resident_dense_bytes: self
                 .pages
@@ -226,7 +237,10 @@ mod tests {
         assert_eq!(core.resident_page_count(), 1);
         assert_eq!(core.work_counters().edits_appended, 1);
         assert_eq!(core.work_counters().pages_compacted, 1);
-        assert_eq!(core.work_counters().cells_generated, crate::CELL_COUNT as u64);
+        assert_eq!(
+            core.work_counters().cells_generated,
+            crate::CELL_COUNT as u64
+        );
         assert_eq!(core.memory_counters().resident_pages, 1);
 
         core.append_edit(EditOp {
@@ -242,8 +256,14 @@ mod tests {
         .unwrap();
         let updated = core.compact_page(key).unwrap();
         assert_eq!(updated.compacted_through_sequence, 2);
-        assert_eq!(core.work_counters().cells_generated, crate::CELL_COUNT as u64);
-        assert_eq!(core.work_counters().cells_replayed, crate::CELL_COUNT as u64);
+        assert_eq!(
+            core.work_counters().cells_generated,
+            crate::CELL_COUNT as u64
+        );
+        assert_eq!(
+            core.work_counters().cells_replayed,
+            crate::CELL_COUNT as u64
+        );
         assert_eq!(core.work_counters().pages_compacted, 2);
     }
 
@@ -265,5 +285,45 @@ mod tests {
         assert_eq!(core.hierarchy().resolve(continent).unwrap(), NodeState::Air);
         assert!(core.hierarchy().node_count() <= 1 + 8 * 24 + 8 * 8);
         assert_eq!(core.work_counters().hierarchy_overrides, 1);
+    }
+
+    #[test]
+    fn page_compaction_replays_only_spatially_attached_edit_candidates() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([3; 16]), 24, generator).unwrap();
+        for sequence in 1..=64_u64 {
+            let page = 1_000 + sequence as i64;
+            core.append_edit(EditOp {
+                sequence,
+                stable_id: [sequence as u8; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [page * crate::PAGE_EDGE_CELLS + 8; 3],
+                    radius_cells: 1,
+                },
+                mode: EditMode::Subtract,
+                material: 0,
+            })
+            .unwrap();
+        }
+        core.append_edit(EditOp {
+            sequence: 65,
+            stable_id: [65; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8; 3],
+                radius_cells: 2,
+            },
+            mode: EditMode::Paint,
+            material: 9,
+        })
+        .unwrap();
+
+        core.compact_page(PageKey::new(0, [0; 3])).unwrap();
+        assert_eq!(core.work_counters().edit_candidates_replayed, 1);
+        assert_eq!(core.memory_counters().edit_attachment_references, 65);
+        assert_eq!(core.memory_counters().edit_attachment_regions, 65);
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/core.rs
+++ b/crates/subsystems/pulsar_terrain/src/core.rs
@@ -1,0 +1,269 @@
+use crate::{
+    CompactedPageRecord, DeterministicGenerator, EditError, EditLog, EditOp, HierarchyError,
+    NodeState, PageCodecError, PageKey, PlanetId, SparseBrickTree, TerrainSnapshot, VoxelPage,
+};
+use std::collections::BTreeMap;
+use thiserror::Error;
+
+/// Owning authoritative state for one planet's sparse terrain.
+///
+/// GPU pages, extracted meshes, and collision data are deliberately absent;
+/// those are generation-tagged consumers of this state in later milestones.
+pub struct TerrainCore<G> {
+    planet_id: PlanetId,
+    generator: G,
+    hierarchy: SparseBrickTree,
+    edits: EditLog,
+    pages: BTreeMap<PageKey, VoxelPage>,
+    compacted: BTreeMap<PageKey, CompactedPageRecord>,
+    work: TerrainWorkCounters,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerrainWorkCounters {
+    pub edits_appended: u64,
+    pub hierarchy_overrides: u64,
+    pub pages_compacted: u64,
+    pub cells_generated: u64,
+    pub cells_replayed: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerrainMemoryCounters {
+    pub hierarchy_nodes: usize,
+    pub hierarchy_encoded_bytes: usize,
+    pub edit_operations: usize,
+    pub resident_pages: usize,
+    pub resident_dense_bytes: usize,
+    pub compacted_page_records: usize,
+}
+
+impl<G: DeterministicGenerator> TerrainCore<G> {
+    pub fn new(planet_id: PlanetId, root_lod: u8, generator: G) -> Result<Self, TerrainCoreError> {
+        let hierarchy =
+            SparseBrickTree::centered(root_lod, NodeState::Procedural(generator.hash()))?;
+        Ok(Self {
+            planet_id,
+            generator,
+            hierarchy,
+            edits: EditLog::default(),
+            pages: BTreeMap::new(),
+            compacted: BTreeMap::new(),
+            work: TerrainWorkCounters::default(),
+        })
+    }
+
+    pub fn hierarchy(&self) -> &SparseBrickTree {
+        &self.hierarchy
+    }
+
+    pub fn edit_log(&self) -> &EditLog {
+        &self.edits
+    }
+
+    pub fn append_edit(&mut self, operation: EditOp) -> Result<(), TerrainCoreError> {
+        let previous_len = self.edits.operations().len();
+        self.edits.push(operation)?;
+        if self.edits.operations().len() != previous_len {
+            self.work.edits_appended = self.work.edits_appended.saturating_add(1);
+        }
+        Ok(())
+    }
+
+    /// Fold the current ordered edit prefix into one content-addressed LOD0
+    /// page and publish that page into the canonical hierarchy.
+    pub fn compact_page(&mut self, key: PageKey) -> Result<CompactedPageRecord, TerrainCoreError> {
+        let previous_sequence = self
+            .compacted
+            .get(&key)
+            .map_or(0, |record| record.compacted_through_sequence);
+        let latest_sequence = self.edits.latest_sequence();
+        if previous_sequence == latest_sequence {
+            if let Some(record) = self.compacted.get(&key) {
+                return Ok(*record);
+            }
+        }
+
+        let page = if let Some(previous) = self.pages.get(&key) {
+            let tail = self
+                .edits
+                .operations()
+                .iter()
+                .copied()
+                .filter(|operation| operation.sequence > previous_sequence)
+                .collect::<Vec<_>>();
+            self.work.cells_replayed = self
+                .work
+                .cells_replayed
+                .saturating_add(crate::CELL_COUNT as u64);
+            previous.apply_edit_tail(key, &tail)?
+        } else {
+            self.work.cells_generated = self
+                .work
+                .cells_generated
+                .saturating_add(crate::CELL_COUNT as u64);
+            VoxelPage::generate(key, &self.generator, &self.edits)?
+        };
+        let page_id = page.page_id();
+        let record = CompactedPageRecord {
+            key,
+            page_id,
+            compacted_through_sequence: latest_sequence,
+        };
+        let state = page.constant_cell().map_or(NodeState::Page(page_id), |cell| {
+            if cell.is_solid() {
+                NodeState::Solid(cell.material())
+            } else {
+                NodeState::Air
+            }
+        });
+        self.hierarchy.set(key, state)?;
+        self.pages.insert(key, page);
+        self.compacted.insert(key, record);
+        self.work.pages_compacted = self.work.pages_compacted.saturating_add(1);
+        Ok(record)
+    }
+
+    pub fn page(&self, key: PageKey) -> Option<&VoxelPage> {
+        self.pages.get(&key)
+    }
+
+    /// Exact whole-root replacement. Resident pages remain disposable caches;
+    /// the root state is immediately authoritative without iterating over them.
+    pub fn set_root(&mut self, state: NodeState) -> Result<(), TerrainCoreError> {
+        self.hierarchy.set_root(state)?;
+        self.work.hierarchy_overrides = self.work.hierarchy_overrides.saturating_add(1);
+        Ok(())
+    }
+
+    /// Attach an exact uniform or content-addressed override at any hierarchy
+    /// level. Descendants are resolved lazily and never expanded here.
+    pub fn set_region(&mut self, key: PageKey, state: NodeState) -> Result<(), TerrainCoreError> {
+        self.hierarchy.set(key, state)?;
+        self.work.hierarchy_overrides = self.work.hierarchy_overrides.saturating_add(1);
+        Ok(())
+    }
+
+    pub fn snapshot(&self) -> TerrainSnapshot {
+        TerrainSnapshot {
+            planet_id: self.planet_id,
+            generator_hash: self.generator.hash(),
+            hierarchy: self.hierarchy.clone(),
+            edit_tail: self.edits.clone(),
+            compacted_pages: self.compacted.values().copied().collect(),
+        }
+    }
+
+    pub fn resident_page_count(&self) -> usize {
+        self.pages.len()
+    }
+
+    pub fn work_counters(&self) -> TerrainWorkCounters {
+        self.work
+    }
+
+    pub fn memory_counters(&self) -> TerrainMemoryCounters {
+        TerrainMemoryCounters {
+            hierarchy_nodes: self.hierarchy.node_count(),
+            hierarchy_encoded_bytes: self.hierarchy.encode().len(),
+            edit_operations: self.edits.operations().len(),
+            resident_pages: self.pages.len(),
+            resident_dense_bytes: self
+                .pages
+                .values()
+                .map(VoxelPage::dense_allocation_bytes)
+                .sum(),
+            compacted_page_records: self.compacted.len(),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum TerrainCoreError {
+    #[error(transparent)]
+    Hierarchy(#[from] HierarchyError),
+    #[error(transparent)]
+    Edit(#[from] EditError),
+    #[error(transparent)]
+    Page(#[from] PageCodecError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EditMode, EditShape, FixedSphereGenerator};
+
+    #[test]
+    fn compaction_publishes_a_hashed_page_and_snapshot() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([1; 16]), 12, generator).unwrap();
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [8; 16],
+            shape: EditShape::Sphere {
+                center_cell: [4, 4, 4],
+                radius_cells: 3,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        })
+        .unwrap();
+        let key = PageKey::new(0, [0, 0, 0]);
+        let record = core.compact_page(key).unwrap();
+        assert_eq!(record.page_id, core.page(key).unwrap().page_id());
+        assert_eq!(
+            core.hierarchy().resolve(key).unwrap(),
+            NodeState::Page(record.page_id)
+        );
+        assert_eq!(core.snapshot().compacted_pages, vec![record]);
+
+        core.set_root(NodeState::Air).unwrap();
+        assert_eq!(core.hierarchy().node_count(), 1);
+        assert_eq!(core.resident_page_count(), 1);
+        assert_eq!(core.work_counters().edits_appended, 1);
+        assert_eq!(core.work_counters().pages_compacted, 1);
+        assert_eq!(core.work_counters().cells_generated, crate::CELL_COUNT as u64);
+        assert_eq!(core.memory_counters().resident_pages, 1);
+
+        core.append_edit(EditOp {
+            sequence: 2,
+            stable_id: [9; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8, 8, 8],
+                radius_cells: 2,
+            },
+            mode: EditMode::Paint,
+            material: 11,
+        })
+        .unwrap();
+        let updated = core.compact_page(key).unwrap();
+        assert_eq!(updated.compacted_through_sequence, 2);
+        assert_eq!(core.work_counters().cells_generated, crate::CELL_COUNT as u64);
+        assert_eq!(core.work_counters().cells_replayed, crate::CELL_COUNT as u64);
+        assert_eq!(core.work_counters().pages_compacted, 2);
+    }
+
+    #[test]
+    fn uniform_compaction_and_high_level_override_remain_sparse() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([2; 16]), 24, generator).unwrap();
+        let far_page = PageKey::new(0, [1_000_000, 0, 0]);
+        core.compact_page(far_page).unwrap();
+        assert_eq!(core.hierarchy().resolve(far_page).unwrap(), NodeState::Air);
+        assert_eq!(core.page(far_page).unwrap().dense_allocation_bytes(), 0);
+
+        let continent = PageKey::new(16, [-2, 1, 0]);
+        core.set_region(continent, NodeState::Air).unwrap();
+        assert_eq!(core.hierarchy().resolve(continent).unwrap(), NodeState::Air);
+        assert!(core.hierarchy().node_count() <= 1 + 8 * 24 + 8 * 8);
+        assert_eq!(core.work_counters().hierarchy_overrides, 1);
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/edit.rs
+++ b/crates/subsystems/pulsar_terrain/src/edit.rs
@@ -1,4 +1,5 @@
-use crate::{CellWord, ContentHash, MaterialId};
+use crate::{CellWord, ContentHash, MaterialId, PageKey};
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 const EDIT_LOG_MAGIC: &[u8; 8] = b"PTEDIT01";
@@ -44,7 +45,10 @@ impl EditOp {
         .clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
 
         let affects_material = shape_distance <= 0
-            && matches!(self.mode, EditMode::Union | EditMode::Replace | EditMode::Paint);
+            && matches!(
+                self.mode,
+                EditMode::Union | EditMode::Replace | EditMode::Paint
+            );
         let material = if affects_material && density <= 0 {
             self.material
         } else if density > 0 {
@@ -88,6 +92,44 @@ impl EditShape {
             .fold(1_u128, u128::saturating_mul)
     }
 
+    /// Smallest canonical hierarchy region that contains the edit AABB.
+    ///
+    /// Edits that cross the centered root split (or extend beyond the root)
+    /// attach to the root. This keeps insertion bounded without enumerating
+    /// intersected pages; exact shape bounds are still checked during replay.
+    fn covering_attachment(self, root_lod: u8) -> EditAttachment {
+        let (min_cell, max_cell) = self.bounds();
+        let min_page = min_cell.map(|axis| axis.div_euclid(crate::PAGE_EDGE_CELLS));
+        let max_page =
+            max_cell.map(|axis| axis.saturating_sub(1).div_euclid(crate::PAGE_EDGE_CELLS));
+        let half = 1_i64 << (root_lod - 1);
+        let root_min = -half;
+        let root_max = half - 1;
+        if (0..3).any(|axis| min_page[axis] < root_min || max_page[axis] > root_max) {
+            return EditAttachment::Root;
+        }
+
+        let relative_min = min_page.map(|axis| (axis - root_min) as u64);
+        let relative_max = max_page.map(|axis| (axis - root_min) as u64);
+        let differing = (relative_min[0] ^ relative_max[0])
+            | (relative_min[1] ^ relative_max[1])
+            | (relative_min[2] ^ relative_max[2]);
+        if differing == 0 {
+            return EditAttachment::Region(PageKey::new(0, min_page));
+        }
+
+        let lod = (u64::BITS - differing.leading_zeros()) as u8;
+        if lod >= root_lod {
+            EditAttachment::Root
+        } else {
+            let scale = 1_i64 << lod;
+            EditAttachment::Region(PageKey::new(
+                lod,
+                min_page.map(|axis| axis.div_euclid(scale)),
+            ))
+        }
+    }
+
     fn signed_distance(self, cell_xyz: [i64; 3]) -> i32 {
         match self {
             Self::Sphere {
@@ -107,6 +149,74 @@ impl EditShape {
                 distance.saturating_sub(radius_cells.min(i32::MAX as u32) as i32)
             }
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EditAttachment {
+    Root,
+    Region(PageKey),
+}
+
+/// Derived sparse spatial index for the canonical edit log.
+///
+/// Every edit contributes exactly one reference, either at the root or at its
+/// smallest covering hierarchy region. Page replay walks only the page's
+/// ancestor chain, so work is proportional to relevant candidates rather than
+/// the total logical volume or the total global edit count.
+#[derive(Clone, Debug)]
+pub(crate) struct EditIndex {
+    root_lod: u8,
+    root: Vec<usize>,
+    regions: BTreeMap<PageKey, Vec<usize>>,
+}
+
+impl EditIndex {
+    pub(crate) fn new(root_lod: u8) -> Self {
+        Self {
+            root_lod,
+            root: Vec::new(),
+            regions: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, operation_index: usize, operation: EditOp) {
+        match operation.shape.covering_attachment(self.root_lod) {
+            EditAttachment::Root => self.root.push(operation_index),
+            EditAttachment::Region(key) => {
+                self.regions.entry(key).or_default().push(operation_index);
+            }
+        }
+    }
+
+    pub(crate) fn operations_for_page(
+        &self,
+        log: &EditLog,
+        key: PageKey,
+        after_sequence: u64,
+    ) -> Vec<EditOp> {
+        let mut indices = self.root.clone();
+        let mut ancestor = Some(key);
+        while let Some(key) = ancestor.filter(|key| key.lod < self.root_lod) {
+            if let Some(attached) = self.regions.get(&key) {
+                indices.extend_from_slice(attached);
+            }
+            ancestor = key.parent();
+        }
+        indices.sort_unstable();
+        indices
+            .into_iter()
+            .filter_map(|index| log.operations().get(index).copied())
+            .filter(|operation| operation.sequence > after_sequence)
+            .collect()
+    }
+
+    pub(crate) fn region_count(&self) -> usize {
+        self.regions.len() + usize::from(!self.root.is_empty())
+    }
+
+    pub(crate) fn reference_count(&self) -> usize {
+        self.root.len() + self.regions.values().map(Vec::len).sum::<usize>()
     }
 }
 
@@ -184,7 +294,9 @@ impl EditLog {
     }
 
     pub fn latest_sequence(&self) -> u64 {
-        self.operations.last().map_or(0, |operation| operation.sequence)
+        self.operations
+            .last()
+            .map_or(0, |operation| operation.sequence)
     }
 
     pub fn apply(&self, cell_xyz: [i64; 3], mut cell: CellWord) -> CellWord {
@@ -347,8 +459,15 @@ mod tests {
         assert_eq!(decoded.operations(), log.operations());
         assert_eq!(decoded.content_hash(), log.content_hash());
         assert_eq!(
-            log.push(EditOp { sequence: 2, stable_id: [2; 16], ..first }),
-            Err(EditError::OutOfOrder { latest: 9, received: 2 })
+            log.push(EditOp {
+                sequence: 2,
+                stable_id: [2; 16],
+                ..first
+            }),
+            Err(EditError::OutOfOrder {
+                latest: 9,
+                received: 2
+            })
         );
     }
 
@@ -395,5 +514,66 @@ mod tests {
             radius_cells: 1,
         };
         assert_eq!(across_negative_boundary.affected_lod0_page_count(), 8);
+    }
+
+    #[test]
+    fn edits_attach_once_and_page_queries_visit_only_ancestors() {
+        let operations = [
+            EditOp {
+                sequence: 1,
+                stable_id: [1; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [3_208, 3_208, 3_208],
+                    radius_cells: 1,
+                },
+                mode: EditMode::Subtract,
+                material: 0,
+            },
+            EditOp {
+                sequence: 2,
+                stable_id: [2; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [8, 8, 8],
+                    radius_cells: 1,
+                },
+                mode: EditMode::Paint,
+                material: 4,
+            },
+            EditOp {
+                sequence: 3,
+                stable_id: [3; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [0; 3],
+                    radius_cells: 1,
+                },
+                mode: EditMode::Union,
+                material: 7,
+            },
+        ];
+        let mut log = EditLog::default();
+        let mut index = EditIndex::new(12);
+        for operation in operations {
+            let operation_index = log.operations().len();
+            log.push(operation).unwrap();
+            index.insert(operation_index, operation);
+        }
+
+        let local = index.operations_for_page(&log, PageKey::new(0, [0; 3]), 0);
+        assert_eq!(
+            local
+                .iter()
+                .map(|operation| operation.sequence)
+                .collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+        let far = index.operations_for_page(&log, PageKey::new(0, [100; 3]), 1);
+        assert_eq!(
+            far.iter()
+                .map(|operation| operation.sequence)
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+        assert_eq!(index.region_count(), 3);
+        assert_eq!(index.reference_count(), operations.len());
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/edit.rs
+++ b/crates/subsystems/pulsar_terrain/src/edit.rs
@@ -1,0 +1,399 @@
+use crate::{CellWord, ContentHash, MaterialId};
+use thiserror::Error;
+
+const EDIT_LOG_MAGIC: &[u8; 8] = b"PTEDIT01";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditMode {
+    Union,
+    Subtract,
+    Replace,
+    Paint,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditShape {
+    Sphere {
+        center_cell: [i64; 3],
+        radius_cells: u32,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EditOp {
+    pub sequence: u64,
+    pub stable_id: [u8; 16],
+    pub shape: EditShape,
+    pub mode: EditMode,
+    pub material: MaterialId,
+}
+
+impl EditOp {
+    pub fn apply(self, cell_xyz: [i64; 3], cell: CellWord) -> CellWord {
+        let shape_distance = self.shape.signed_distance(cell_xyz);
+        if shape_distance > 0 && matches!(self.mode, EditMode::Replace | EditMode::Paint) {
+            return cell;
+        }
+        let old_distance = i32::from(cell.density());
+        let density = match self.mode {
+            EditMode::Union => old_distance.min(shape_distance),
+            EditMode::Subtract => old_distance.max(-shape_distance),
+            EditMode::Replace => shape_distance,
+            EditMode::Paint => old_distance,
+        }
+        .clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
+
+        let affects_material = shape_distance <= 0
+            && matches!(self.mode, EditMode::Union | EditMode::Replace | EditMode::Paint);
+        let material = if affects_material && density <= 0 {
+            self.material
+        } else if density > 0 {
+            0
+        } else {
+            cell.material()
+        };
+        CellWord::new(density, material, cell.flags())
+    }
+}
+
+impl EditShape {
+    pub fn bounds(self) -> ([i64; 3], [i64; 3]) {
+        match self {
+            Self::Sphere {
+                center_cell,
+                radius_cells,
+            } => {
+                let radius = i64::from(radius_cells);
+                (
+                    center_cell.map(|axis| axis.saturating_sub(radius)),
+                    center_cell.map(|axis| axis.saturating_add(radius).saturating_add(1)),
+                )
+            }
+        }
+    }
+
+    /// Conservative count of LOD0 pages intersected by the shape's integer
+    /// cell AABB. This is used for scheduling and edit-amplification budgets;
+    /// it does not materialize or visit any page.
+    pub fn affected_lod0_page_count(self) -> u128 {
+        let (min, max) = self.bounds();
+        (0..3)
+            .map(|axis| {
+                let first = min[axis].div_euclid(crate::PAGE_EDGE_CELLS);
+                let last = max[axis]
+                    .saturating_sub(1)
+                    .div_euclid(crate::PAGE_EDGE_CELLS);
+                u128::try_from(last.saturating_sub(first).saturating_add(1)).unwrap_or(u128::MAX)
+            })
+            .fold(1_u128, u128::saturating_mul)
+    }
+
+    fn signed_distance(self, cell_xyz: [i64; 3]) -> i32 {
+        match self {
+            Self::Sphere {
+                center_cell,
+                radius_cells,
+            } => {
+                let delta = [
+                    i128::from(cell_xyz[0]) - i128::from(center_cell[0]),
+                    i128::from(cell_xyz[1]) - i128::from(center_cell[1]),
+                    i128::from(cell_xyz[2]) - i128::from(center_cell[2]),
+                ];
+                let squared = delta
+                    .iter()
+                    .map(|axis| axis.saturating_mul(*axis) as u128)
+                    .sum::<u128>();
+                let distance = integer_sqrt(squared).min(i32::MAX as u128) as i32;
+                distance.saturating_sub(radius_cells.min(i32::MAX as u32) as i32)
+            }
+        }
+    }
+}
+
+fn integer_sqrt(value: u128) -> u128 {
+    if value < 2 {
+        return value;
+    }
+    let mut low = 1_u128;
+    let mut high = 1_u128 << (128 - value.leading_zeros()).div_ceil(2);
+    while low + 1 < high {
+        let middle = low + (high - low) / 2;
+        if middle <= value / middle {
+            low = middle;
+        } else {
+            high = middle;
+        }
+    }
+    low
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum EditError {
+    #[error("edit sequence {received} must be greater than {latest}")]
+    OutOfOrder { latest: u64, received: u64 },
+    #[error("edit id was already applied at a different sequence")]
+    DuplicateId,
+    #[error("invalid canonical edit-log encoding")]
+    Codec,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EditLog {
+    operations: Vec<EditOp>,
+}
+
+impl EditLog {
+    /// Canonicalize operations delivered by independent workers or network
+    /// scheduling. Authoritative sequence numbers, not arrival order, define
+    /// replay order.
+    pub fn from_scheduled(mut operations: Vec<EditOp>) -> Result<Self, EditError> {
+        operations.sort_unstable_by_key(|operation| (operation.sequence, operation.stable_id));
+        let mut log = Self::default();
+        for operation in operations {
+            log.push(operation)?;
+        }
+        Ok(log)
+    }
+
+    pub fn push(&mut self, operation: EditOp) -> Result<(), EditError> {
+        if let Some(existing) = self
+            .operations
+            .iter()
+            .find(|existing| existing.stable_id == operation.stable_id)
+        {
+            return if *existing == operation {
+                Ok(())
+            } else {
+                Err(EditError::DuplicateId)
+            };
+        }
+        if let Some(latest) = self.operations.last().map(|op| op.sequence) {
+            if operation.sequence <= latest {
+                return Err(EditError::OutOfOrder {
+                    latest,
+                    received: operation.sequence,
+                });
+            }
+        }
+        self.operations.push(operation);
+        Ok(())
+    }
+
+    pub fn operations(&self) -> &[EditOp] {
+        &self.operations
+    }
+
+    pub fn latest_sequence(&self) -> u64 {
+        self.operations.last().map_or(0, |operation| operation.sequence)
+    }
+
+    pub fn apply(&self, cell_xyz: [i64; 3], mut cell: CellWord) -> CellWord {
+        for operation in &self.operations {
+            let (min, max) = operation.shape.bounds();
+            if (0..3).all(|axis| cell_xyz[axis] >= min[axis] && cell_xyz[axis] < max[axis]) {
+                cell = operation.apply(cell_xyz, cell);
+            }
+        }
+        cell
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut output = Vec::with_capacity(12 + self.operations.len() * 56);
+        output.extend_from_slice(EDIT_LOG_MAGIC);
+        output.extend_from_slice(&(self.operations.len() as u32).to_le_bytes());
+        for operation in &self.operations {
+            output.extend_from_slice(&operation.sequence.to_le_bytes());
+            output.extend_from_slice(&operation.stable_id);
+            output.push(match operation.mode {
+                EditMode::Union => 0,
+                EditMode::Subtract => 1,
+                EditMode::Replace => 2,
+                EditMode::Paint => 3,
+            });
+            output.push(operation.material);
+            match operation.shape {
+                EditShape::Sphere {
+                    center_cell,
+                    radius_cells,
+                } => {
+                    output.push(0);
+                    output.push(0);
+                    for axis in center_cell {
+                        output.extend_from_slice(&axis.to_le_bytes());
+                    }
+                    output.extend_from_slice(&radius_cells.to_le_bytes());
+                }
+            }
+        }
+        output
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, EditError> {
+        if bytes.get(..8) != Some(EDIT_LOG_MAGIC) || bytes.len() < 12 {
+            return Err(EditError::Codec);
+        }
+        let count = read_u32(bytes, 8)? as usize;
+        let expected = 12_usize
+            .checked_add(count.checked_mul(56).ok_or(EditError::Codec)?)
+            .ok_or(EditError::Codec)?;
+        if bytes.len() != expected {
+            return Err(EditError::Codec);
+        }
+        let mut log = Self::default();
+        let mut cursor = 12;
+        for _ in 0..count {
+            let sequence = read_u64(bytes, cursor)?;
+            let stable_id = bytes
+                .get(cursor + 8..cursor + 24)
+                .ok_or(EditError::Codec)?
+                .try_into()
+                .map_err(|_| EditError::Codec)?;
+            let mode = match *bytes.get(cursor + 24).ok_or(EditError::Codec)? {
+                0 => EditMode::Union,
+                1 => EditMode::Subtract,
+                2 => EditMode::Replace,
+                3 => EditMode::Paint,
+                _ => return Err(EditError::Codec),
+            };
+            let material = *bytes.get(cursor + 25).ok_or(EditError::Codec)?;
+            if bytes.get(cursor + 26..cursor + 28) != Some(&[0, 0]) {
+                return Err(EditError::Codec);
+            }
+            let mut center_cell = [0_i64; 3];
+            for (axis, value) in center_cell.iter_mut().enumerate() {
+                *value = read_i64(bytes, cursor + 28 + axis * 8)?;
+            }
+            let radius_cells = read_u32(bytes, cursor + 52)?;
+            log.push(EditOp {
+                sequence,
+                stable_id,
+                shape: EditShape::Sphere {
+                    center_cell,
+                    radius_cells,
+                },
+                mode,
+                material,
+            })?;
+            cursor += 56;
+        }
+        Ok(log)
+    }
+
+    pub fn content_hash(&self) -> ContentHash {
+        ContentHash::of(&self.encode())
+    }
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, EditError> {
+    Ok(u32::from_le_bytes(
+        bytes
+            .get(offset..offset + 4)
+            .ok_or(EditError::Codec)?
+            .try_into()
+            .map_err(|_| EditError::Codec)?,
+    ))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, EditError> {
+    Ok(u64::from_le_bytes(
+        bytes
+            .get(offset..offset + 8)
+            .ok_or(EditError::Codec)?
+            .try_into()
+            .map_err(|_| EditError::Codec)?,
+    ))
+}
+
+fn read_i64(bytes: &[u8], offset: usize) -> Result<i64, EditError> {
+    Ok(i64::from_le_bytes(
+        bytes
+            .get(offset..offset + 8)
+            .ok_or(EditError::Codec)?
+            .try_into()
+            .map_err(|_| EditError::Codec)?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_edit_log_round_trips_and_rejects_reordering() {
+        let first = EditOp {
+            sequence: 4,
+            stable_id: [4; 16],
+            shape: EditShape::Sphere {
+                center_cell: [-9, 2, 17],
+                radius_cells: 6,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        };
+        let second = EditOp {
+            sequence: 9,
+            stable_id: [9; 16],
+            shape: EditShape::Sphere {
+                center_cell: [3, -7, 1],
+                radius_cells: 2,
+            },
+            mode: EditMode::Paint,
+            material: 8,
+        };
+        let mut log = EditLog::default();
+        log.push(first).unwrap();
+        log.push(second).unwrap();
+        let decoded = EditLog::decode(&log.encode()).unwrap();
+        assert_eq!(decoded.operations(), log.operations());
+        assert_eq!(decoded.content_hash(), log.content_hash());
+        assert_eq!(
+            log.push(EditOp { sequence: 2, stable_id: [2; 16], ..first }),
+            Err(EditError::OutOfOrder { latest: 9, received: 2 })
+        );
+    }
+
+    #[test]
+    fn worker_arrival_order_does_not_change_canonical_replay() {
+        let operations = (1..=32)
+            .map(|sequence| EditOp {
+                sequence,
+                stable_id: [sequence as u8; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [sequence as i64 - 16, -(sequence as i64), 3],
+                    radius_cells: (sequence % 7 + 1) as u32,
+                },
+                mode: if sequence % 2 == 0 {
+                    EditMode::Union
+                } else {
+                    EditMode::Subtract
+                },
+                material: sequence as u8,
+            })
+            .collect::<Vec<_>>();
+        let forward = EditLog::from_scheduled(operations.clone()).unwrap();
+        let reverse = EditLog::from_scheduled(operations.into_iter().rev().collect()).unwrap();
+        assert_eq!(forward, reverse);
+        assert_eq!(forward.content_hash(), reverse.content_hash());
+        for coordinate in [[-20, 0, 3], [0, -10, 3], [20, -30, 3]] {
+            assert_eq!(
+                forward.apply(coordinate, CellWord::AIR),
+                reverse.apply(coordinate, CellWord::AIR)
+            );
+        }
+    }
+
+    #[test]
+    fn edit_page_amplification_is_bounded_without_visiting_pages() {
+        let one_cell = EditShape::Sphere {
+            center_cell: [0; 3],
+            radius_cells: 0,
+        };
+        assert_eq!(one_cell.affected_lod0_page_count(), 1);
+
+        let across_negative_boundary = EditShape::Sphere {
+            center_cell: [0; 3],
+            radius_cells: 1,
+        };
+        assert_eq!(across_negative_boundary.affected_lod0_page_count(), 8);
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/generator.rs
+++ b/crates/subsystems/pulsar_terrain/src/generator.rs
@@ -1,0 +1,80 @@
+use crate::{CellWord, ContentHash, MaterialId};
+
+/// Deterministic canonical terrain source. Implementations must use integer or
+/// fixed-point math and include every behavior-changing parameter in `hash`.
+pub trait DeterministicGenerator: Send + Sync {
+    fn hash(&self) -> ContentHash;
+    fn sample_cell(&self, cell_xyz: [i64; 3]) -> CellWord;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FixedSphereGenerator {
+    pub center_cell: [i64; 3],
+    pub radius_cells: u64,
+    pub material: MaterialId,
+}
+
+impl DeterministicGenerator for FixedSphereGenerator {
+    fn hash(&self) -> ContentHash {
+        let mut bytes = Vec::with_capacity(34);
+        bytes.extend_from_slice(b"pulsar.fixed-sphere.v1");
+        for axis in self.center_cell {
+            bytes.extend_from_slice(&axis.to_le_bytes());
+        }
+        bytes.extend_from_slice(&self.radius_cells.to_le_bytes());
+        bytes.push(self.material);
+        ContentHash::of(&bytes)
+    }
+
+    fn sample_cell(&self, cell_xyz: [i64; 3]) -> CellWord {
+        let delta = [
+            i128::from(cell_xyz[0]) - i128::from(self.center_cell[0]),
+            i128::from(cell_xyz[1]) - i128::from(self.center_cell[1]),
+            i128::from(cell_xyz[2]) - i128::from(self.center_cell[2]),
+        ];
+        let distance_squared = delta
+            .iter()
+            .map(|axis| axis.saturating_mul(*axis) as u128)
+            .sum::<u128>();
+        let distance = integer_sqrt(distance_squared);
+        let signed_distance = (distance as i128 - i128::from(self.radius_cells))
+            .clamp(i128::from(i16::MIN), i128::from(i16::MAX)) as i16;
+        let material = if signed_distance <= 0 { self.material } else { 0 };
+        CellWord::new(signed_distance, material, 0)
+    }
+}
+
+fn integer_sqrt(value: u128) -> u128 {
+    if value < 2 {
+        return value;
+    }
+    let mut low = 1_u128;
+    let mut high = 1_u128 << (128 - value.leading_zeros()).div_ceil(2);
+    while low + 1 < high {
+        let middle = low + (high - low) / 2;
+        if middle <= value / middle {
+            low = middle;
+        } else {
+            high = middle;
+        }
+    }
+    low
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_sphere_is_stable_and_signed() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 10,
+            material: 7,
+        };
+        assert!(generator.sample_cell([0; 3]).is_solid());
+        assert_eq!(generator.sample_cell([0; 3]).material(), 7);
+        assert!(!generator.sample_cell([20, 0, 0]).is_solid());
+        assert_eq!(generator.hash(), generator.hash());
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/generator.rs
+++ b/crates/subsystems/pulsar_terrain/src/generator.rs
@@ -39,7 +39,11 @@ impl DeterministicGenerator for FixedSphereGenerator {
         let distance = integer_sqrt(distance_squared);
         let signed_distance = (distance as i128 - i128::from(self.radius_cells))
             .clamp(i128::from(i16::MIN), i128::from(i16::MAX)) as i16;
-        let material = if signed_distance <= 0 { self.material } else { 0 };
+        let material = if signed_distance <= 0 {
+            self.material
+        } else {
+            0
+        };
         CellWord::new(signed_distance, material, 0)
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/hierarchy.rs
+++ b/crates/subsystems/pulsar_terrain/src/hierarchy.rs
@@ -1,0 +1,329 @@
+use crate::{ContentHash, NodeState, PageKey};
+use thiserror::Error;
+
+const HIERARCHY_MAGIC: &[u8; 8] = b"PTHIER01";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum TreeNode {
+    Leaf(NodeState),
+    Branch(Box<[TreeNode; 8]>),
+}
+
+/// A mutable sparse brick hierarchy covering a centered cube of LOD0 pages.
+/// Splitting one address allocates only eight siblings per traversed level.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SparseBrickTree {
+    root_lod: u8,
+    root_min_page: [i64; 3],
+    root: TreeNode,
+}
+
+impl SparseBrickTree {
+    pub fn centered(root_lod: u8, state: NodeState) -> Result<Self, HierarchyError> {
+        if root_lod == 0 || root_lod > 62 || state == NodeState::Branch {
+            return Err(HierarchyError::InvalidRoot);
+        }
+        let half = 1_i64 << (root_lod - 1);
+        Ok(Self {
+            root_lod,
+            root_min_page: [-half; 3],
+            root: TreeNode::Leaf(state),
+        })
+    }
+
+    pub fn root_state(&self) -> NodeState {
+        match &self.root {
+            TreeNode::Leaf(state) => state.clone(),
+            TreeNode::Branch(_) => NodeState::Branch,
+        }
+    }
+
+    /// Exact O(1) root replacement, including whole-planet deletion.
+    pub fn set_root(&mut self, state: NodeState) -> Result<(), HierarchyError> {
+        if state == NodeState::Branch {
+            return Err(HierarchyError::BranchIsInternal);
+        }
+        self.root = TreeNode::Leaf(state);
+        Ok(())
+    }
+
+    pub fn set(&mut self, key: PageKey, state: NodeState) -> Result<(), HierarchyError> {
+        if state == NodeState::Branch {
+            return Err(HierarchyError::BranchIsInternal);
+        }
+        let path = self.path_for(key)?;
+        set_recursive(&mut self.root, &path, state);
+        Ok(())
+    }
+
+    pub fn resolve(&self, key: PageKey) -> Result<NodeState, HierarchyError> {
+        let path = self.path_for(key)?;
+        let mut node = &self.root;
+        for child in path {
+            match node {
+                TreeNode::Leaf(state) => return Ok(state.clone()),
+                TreeNode::Branch(children) => node = &children[child],
+            }
+        }
+        Ok(match node {
+            TreeNode::Leaf(state) => state.clone(),
+            TreeNode::Branch(_) => NodeState::Branch,
+        })
+    }
+
+    pub fn node_count(&self) -> usize {
+        count_nodes(&self.root)
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut output = Vec::with_capacity(40 + self.node_count() * 2);
+        output.extend_from_slice(HIERARCHY_MAGIC);
+        output.push(self.root_lod);
+        output.extend_from_slice(&[0; 7]);
+        for axis in self.root_min_page {
+            output.extend_from_slice(&axis.to_le_bytes());
+        }
+        encode_node(&self.root, &mut output);
+        output
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, HierarchyError> {
+        if bytes.len() < 41
+            || bytes.get(..8) != Some(HIERARCHY_MAGIC)
+            || bytes.get(9..16) != Some(&[0; 7])
+        {
+            return Err(HierarchyError::Codec);
+        }
+        let root_lod = bytes[8];
+        if root_lod == 0 || root_lod > 62 {
+            return Err(HierarchyError::Codec);
+        }
+        let mut root_min_page = [0_i64; 3];
+        for (axis, value) in root_min_page.iter_mut().enumerate() {
+            let offset = 16 + axis * 8;
+            *value = i64::from_le_bytes(
+                bytes
+                    .get(offset..offset + 8)
+                    .ok_or(HierarchyError::Codec)?
+                    .try_into()
+                    .map_err(|_| HierarchyError::Codec)?,
+            );
+        }
+        let expected_min = -(1_i64 << (root_lod - 1));
+        if root_min_page != [expected_min; 3] {
+            return Err(HierarchyError::Codec);
+        }
+        let mut cursor = 40;
+        let root = decode_node(bytes, &mut cursor, 0, root_lod)?;
+        if cursor != bytes.len() {
+            return Err(HierarchyError::Codec);
+        }
+        Ok(Self {
+            root_lod,
+            root_min_page,
+            root,
+        })
+    }
+
+    pub fn content_hash(&self) -> ContentHash {
+        ContentHash::of(&self.encode())
+    }
+
+    fn path_for(&self, key: PageKey) -> Result<Vec<usize>, HierarchyError> {
+        if key.lod >= self.root_lod {
+            return Err(HierarchyError::LodOutsideRoot(key.lod));
+        }
+        let target_min = key.lod0_min().ok_or(HierarchyError::CoordinateOverflow)?;
+        let target_size = 1_i64 << key.lod;
+        let root_size = 1_i64 << self.root_lod;
+        for axis in 0..3 {
+            let relative = target_min[axis]
+                .checked_sub(self.root_min_page[axis])
+                .ok_or(HierarchyError::CoordinateOverflow)?;
+            if relative < 0 || relative.saturating_add(target_size) > root_size {
+                return Err(HierarchyError::OutsideRoot(key));
+            }
+        }
+
+        let depth = usize::from(self.root_lod - key.lod);
+        let relative = [
+            target_min[0] - self.root_min_page[0],
+            target_min[1] - self.root_min_page[1],
+            target_min[2] - self.root_min_page[2],
+        ];
+        let mut path = Vec::with_capacity(depth);
+        for step in 0..depth {
+            let bit = u32::from(self.root_lod - 1 - step as u8);
+            let x = ((relative[0] >> bit) & 1) as usize;
+            let y = ((relative[1] >> bit) & 1) as usize;
+            let z = ((relative[2] >> bit) & 1) as usize;
+            path.push(x | (y << 1) | (z << 2));
+        }
+        Ok(path)
+    }
+}
+
+fn set_recursive(node: &mut TreeNode, path: &[usize], state: NodeState) {
+    if path.is_empty() {
+        *node = TreeNode::Leaf(state);
+        return;
+    }
+    if let TreeNode::Leaf(previous) = node {
+        let child = TreeNode::Leaf(previous.clone());
+        *node = TreeNode::Branch(Box::new(std::array::from_fn(|_| child.clone())));
+    }
+    let TreeNode::Branch(children) = node else {
+        unreachable!();
+    };
+    set_recursive(&mut children[path[0]], &path[1..], state);
+
+    let first = match &children[0] {
+        TreeNode::Leaf(first) => first.clone(),
+        TreeNode::Branch(_) => return,
+    };
+    if children
+        .iter()
+        .all(|child| matches!(child, TreeNode::Leaf(value) if *value == first))
+    {
+        *node = TreeNode::Leaf(first);
+    }
+}
+
+fn count_nodes(node: &TreeNode) -> usize {
+    match node {
+        TreeNode::Leaf(_) => 1,
+        TreeNode::Branch(children) => 1 + children.iter().map(count_nodes).sum::<usize>(),
+    }
+}
+
+fn encode_node(node: &TreeNode, output: &mut Vec<u8>) {
+    match node {
+        TreeNode::Leaf(NodeState::Air) => output.push(0),
+        TreeNode::Leaf(NodeState::Solid(material)) => {
+            output.push(1);
+            output.push(*material);
+        }
+        TreeNode::Leaf(NodeState::Procedural(hash)) => {
+            output.push(2);
+            output.extend_from_slice(&hash.0);
+        }
+        TreeNode::Branch(children) => {
+            output.push(3);
+            for child in children.iter() {
+                encode_node(child, output);
+            }
+        }
+        TreeNode::Leaf(NodeState::Page(hash)) => {
+            output.push(4);
+            output.extend_from_slice(&hash.0);
+        }
+        TreeNode::Leaf(NodeState::Branch) => unreachable!("Branch is stored structurally"),
+    }
+}
+
+fn decode_node(
+    bytes: &[u8],
+    cursor: &mut usize,
+    depth: u8,
+    root_lod: u8,
+) -> Result<TreeNode, HierarchyError> {
+    let tag = *bytes.get(*cursor).ok_or(HierarchyError::Codec)?;
+    *cursor += 1;
+    match tag {
+        0 => Ok(TreeNode::Leaf(NodeState::Air)),
+        1 => {
+            let material = *bytes.get(*cursor).ok_or(HierarchyError::Codec)?;
+            *cursor += 1;
+            Ok(TreeNode::Leaf(NodeState::Solid(material)))
+        }
+        2 | 4 => {
+            let hash = ContentHash(
+                bytes
+                    .get(*cursor..*cursor + 32)
+                    .ok_or(HierarchyError::Codec)?
+                    .try_into()
+                    .map_err(|_| HierarchyError::Codec)?,
+            );
+            *cursor += 32;
+            Ok(TreeNode::Leaf(if tag == 2 {
+                NodeState::Procedural(hash)
+            } else {
+                NodeState::Page(hash)
+            }))
+        }
+        3 if depth < root_lod => {
+            let mut children = Vec::with_capacity(8);
+            for _ in 0..8 {
+                children.push(decode_node(bytes, cursor, depth + 1, root_lod)?);
+            }
+            Ok(TreeNode::Branch(Box::new(
+                children.try_into().map_err(|_| HierarchyError::Codec)?,
+            )))
+        }
+        _ => Err(HierarchyError::Codec),
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum HierarchyError {
+    #[error("root LOD must be 1..=62 and root state must be uniform")]
+    InvalidRoot,
+    #[error("Branch is an internal state and cannot be assigned directly")]
+    BranchIsInternal,
+    #[error("LOD{0} is not a descendant of the root")]
+    LodOutsideRoot(u8),
+    #[error("page {0:?} is outside the centered root cube")]
+    OutsideRoot(PageKey),
+    #[error("page coordinate overflow")]
+    CoordinateOverflow,
+    #[error("invalid canonical sparse-hierarchy encoding")]
+    Codec,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn negative_coordinates_resolve_and_uniform_siblings_collapse() {
+        let mut tree = SparseBrickTree::centered(4, NodeState::Air).unwrap();
+        let parent = PageKey::new(1, [-1, 0, 0]);
+        for z in 0..2 {
+            for y in 0..2 {
+                for x in 0..2 {
+                    tree.set(
+                        PageKey::new(0, [-2 + x, y, z]),
+                        NodeState::Solid(4),
+                    )
+                    .unwrap();
+                }
+            }
+        }
+        assert_eq!(tree.resolve(parent).unwrap(), NodeState::Solid(4));
+        assert!(tree.node_count() < 1 + 8 * 4);
+    }
+
+    #[test]
+    fn root_delete_drops_all_materialized_nodes() {
+        let mut tree = SparseBrickTree::centered(24, NodeState::Air).unwrap();
+        tree.set(PageKey::new(0, [12, -9, 3]), NodeState::Solid(1)).unwrap();
+        assert!(tree.node_count() <= 1 + 8 * 24);
+        tree.set_root(NodeState::Air).unwrap();
+        assert_eq!(tree.node_count(), 1);
+    }
+
+    #[test]
+    fn canonical_hierarchy_round_trips_with_stable_hash() {
+        let generator = ContentHash::of(b"generator-v1");
+        let mut tree = SparseBrickTree::centered(12, NodeState::Procedural(generator)).unwrap();
+        tree.set(PageKey::new(0, [-3, 7, 2]), NodeState::Solid(6)).unwrap();
+        tree.set(
+            PageKey::new(2, [4, -2, 1]),
+            NodeState::Page(ContentHash::of(b"page")),
+        )
+        .unwrap();
+        let decoded = SparseBrickTree::decode(&tree.encode()).unwrap();
+        assert_eq!(decoded, tree);
+        assert_eq!(decoded.content_hash(), tree.content_hash());
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/hierarchy.rs
+++ b/crates/subsystems/pulsar_terrain/src/hierarchy.rs
@@ -38,6 +38,10 @@ impl SparseBrickTree {
         }
     }
 
+    pub fn root_lod(&self) -> u8 {
+        self.root_lod
+    }
+
     /// Exact O(1) root replacement, including whole-planet deletion.
     pub fn set_root(&mut self, state: NodeState) -> Result<(), HierarchyError> {
         if state == NodeState::Branch {
@@ -291,11 +295,8 @@ mod tests {
         for z in 0..2 {
             for y in 0..2 {
                 for x in 0..2 {
-                    tree.set(
-                        PageKey::new(0, [-2 + x, y, z]),
-                        NodeState::Solid(4),
-                    )
-                    .unwrap();
+                    tree.set(PageKey::new(0, [-2 + x, y, z]), NodeState::Solid(4))
+                        .unwrap();
                 }
             }
         }
@@ -306,7 +307,8 @@ mod tests {
     #[test]
     fn root_delete_drops_all_materialized_nodes() {
         let mut tree = SparseBrickTree::centered(24, NodeState::Air).unwrap();
-        tree.set(PageKey::new(0, [12, -9, 3]), NodeState::Solid(1)).unwrap();
+        tree.set(PageKey::new(0, [12, -9, 3]), NodeState::Solid(1))
+            .unwrap();
         assert!(tree.node_count() <= 1 + 8 * 24);
         tree.set_root(NodeState::Air).unwrap();
         assert_eq!(tree.node_count(), 1);
@@ -316,7 +318,8 @@ mod tests {
     fn canonical_hierarchy_round_trips_with_stable_hash() {
         let generator = ContentHash::of(b"generator-v1");
         let mut tree = SparseBrickTree::centered(12, NodeState::Procedural(generator)).unwrap();
-        tree.set(PageKey::new(0, [-3, 7, 2]), NodeState::Solid(6)).unwrap();
+        tree.set(PageKey::new(0, [-3, 7, 2]), NodeState::Solid(6))
+            .unwrap();
         tree.set(
             PageKey::new(2, [4, -2, 1]),
             NodeState::Page(ContentHash::of(b"page")),

--- a/crates/subsystems/pulsar_terrain/src/lib.rs
+++ b/crates/subsystems/pulsar_terrain/src/lib.rs
@@ -1,0 +1,32 @@
+//! Authoritative sparse planetary voxel terrain state.
+//!
+//! This crate owns canonical planet-space addressing, deterministic generation
+//! and edits, the mutable sparse hierarchy, stable page encoding, and durable
+//! snapshots. Rendering and physics consume derived data and never become the
+//! source of truth.
+
+mod core;
+mod edit;
+mod generator;
+mod hierarchy;
+mod page;
+mod snapshot;
+mod store;
+mod types;
+
+pub use core::{
+    TerrainCore, TerrainCoreError, TerrainMemoryCounters, TerrainWorkCounters,
+};
+pub use edit::{EditError, EditLog, EditMode, EditOp, EditShape};
+pub use generator::{DeterministicGenerator, FixedSphereGenerator};
+pub use hierarchy::{HierarchyError, SparseBrickTree};
+pub use page::{
+    PageCodecError, VoxelPage, CELL_COUNT, MICROBRICK_COUNT, MICROBRICK_EDGE,
+    MICROBRICKS_PER_AXIS, PAGE_EDGE,
+};
+pub use snapshot::{CompactedPageRecord, SnapshotCodecError, TerrainSnapshot};
+pub use store::{SnapshotRecord, TerrainStore, TerrainStoreError};
+pub use types::{
+    CellWord, ContentHash, MaterialId, NodeState, PageId, PageKey, PlanetId,
+    PlanetPosition, LOD0_CELL_SIZE_METERS, PAGE_EDGE_CELLS,
+};

--- a/crates/subsystems/pulsar_terrain/src/lib.rs
+++ b/crates/subsystems/pulsar_terrain/src/lib.rs
@@ -14,19 +14,17 @@ mod snapshot;
 mod store;
 mod types;
 
-pub use core::{
-    TerrainCore, TerrainCoreError, TerrainMemoryCounters, TerrainWorkCounters,
-};
+pub use core::{TerrainCore, TerrainCoreError, TerrainMemoryCounters, TerrainWorkCounters};
 pub use edit::{EditError, EditLog, EditMode, EditOp, EditShape};
 pub use generator::{DeterministicGenerator, FixedSphereGenerator};
 pub use hierarchy::{HierarchyError, SparseBrickTree};
 pub use page::{
-    PageCodecError, VoxelPage, CELL_COUNT, MICROBRICK_COUNT, MICROBRICK_EDGE,
-    MICROBRICKS_PER_AXIS, PAGE_EDGE,
+    PageCodecError, VoxelPage, CELL_COUNT, MICROBRICKS_PER_AXIS, MICROBRICK_COUNT, MICROBRICK_EDGE,
+    PAGE_EDGE,
 };
 pub use snapshot::{CompactedPageRecord, SnapshotCodecError, TerrainSnapshot};
 pub use store::{SnapshotRecord, TerrainStore, TerrainStoreError};
 pub use types::{
-    CellWord, ContentHash, MaterialId, NodeState, PageId, PageKey, PlanetId,
-    PlanetPosition, LOD0_CELL_SIZE_METERS, PAGE_EDGE_CELLS,
+    CellWord, ContentHash, MaterialId, NodeState, PageId, PageKey, PlanetId, PlanetPosition,
+    LOD0_CELL_SIZE_METERS, PAGE_EDGE_CELLS,
 };

--- a/crates/subsystems/pulsar_terrain/src/page.rs
+++ b/crates/subsystems/pulsar_terrain/src/page.rs
@@ -27,8 +27,7 @@ impl VoxelPage {
         }
         let brick = local_cell.map(|axis| axis / MICROBRICK_EDGE);
         let within = local_cell.map(|axis| axis % MICROBRICK_EDGE);
-        let index = brick[0]
-            + MICROBRICKS_PER_AXIS * (brick[1] + MICROBRICKS_PER_AXIS * brick[2]);
+        let index = brick[0] + MICROBRICKS_PER_AXIS * (brick[1] + MICROBRICKS_PER_AXIS * brick[2]);
         Some((index, within))
     }
 
@@ -57,6 +56,14 @@ impl VoxelPage {
         generator: &dyn DeterministicGenerator,
         edits: &EditLog,
     ) -> Result<Self, PageCodecError> {
+        Self::generate_with_operations(key, generator, edits.operations())
+    }
+
+    pub(crate) fn generate_with_operations(
+        key: PageKey,
+        generator: &dyn DeterministicGenerator,
+        operations: &[EditOp],
+    ) -> Result<Self, PageCodecError> {
         if key.lod != 0 {
             return Err(PageCodecError::UnsupportedLod(key.lod));
         }
@@ -68,7 +75,16 @@ impl VoxelPage {
             for y in 0..PAGE_EDGE as i64 {
                 for x in 0..PAGE_EDGE as i64 {
                     let coordinate = [origin[0] + x, origin[1] + y, origin[2] + z];
-                    cells.push(edits.apply(coordinate, generator.sample_cell(coordinate)));
+                    let mut cell = generator.sample_cell(coordinate);
+                    for operation in operations {
+                        let (min, max) = operation.shape.bounds();
+                        if (0..3).all(|axis| {
+                            coordinate[axis] >= min[axis] && coordinate[axis] < max[axis]
+                        }) {
+                            cell = operation.apply(coordinate, cell);
+                        }
+                    }
+                    cells.push(cell);
                 }
             }
         }
@@ -96,9 +112,9 @@ impl VoxelPage {
                     let mut cell = self.get([x as usize, y as usize, z as usize]).unwrap();
                     for operation in operations {
                         let (min, max) = operation.shape.bounds();
-                        if (0..3)
-                            .all(|axis| coordinate[axis] >= min[axis] && coordinate[axis] < max[axis])
-                        {
+                        if (0..3).all(|axis| {
+                            coordinate[axis] >= min[axis] && coordinate[axis] < max[axis]
+                        }) {
                             cell = operation.apply(coordinate, cell);
                         }
                     }
@@ -125,7 +141,8 @@ impl VoxelPage {
                                 let fine = [x * 2 + dx, y * 2 + dy, z * 2 + dz];
                                 let child_xyz = fine.map(|axis| axis / PAGE_EDGE);
                                 let local = fine.map(|axis| axis % PAGE_EDGE);
-                                let child_index = child_xyz[0] | (child_xyz[1] << 1) | (child_xyz[2] << 2);
+                                let child_index =
+                                    child_xyz[0] | (child_xyz[1] << 1) | (child_xyz[2] << 2);
                                 samples[sample_index] = children[child_index].get(local).unwrap();
                                 sample_index += 1;
                             }
@@ -138,8 +155,14 @@ impl VoxelPage {
                         .or_else(|| samples.iter().min_by_key(|sample| sample.density()))
                         .copied()
                         .unwrap();
-                    let flags = samples.iter().fold(0, |flags, sample| flags | sample.flags());
-                    cells.push(CellWord::new(selected.density(), selected.material(), flags));
+                    let flags = samples
+                        .iter()
+                        .fold(0, |flags, sample| flags | sample.flags());
+                    cells.push(CellWord::new(
+                        selected.density(),
+                        selected.material(),
+                        flags,
+                    ));
                 }
             }
         }
@@ -170,9 +193,7 @@ impl VoxelPage {
         if xyz.iter().any(|axis| *axis >= PAGE_EDGE) {
             return None;
         }
-        Some(self.cell_at_index(
-            xyz[0] + PAGE_EDGE * (xyz[1] + PAGE_EDGE * xyz[2]),
-        ))
+        Some(self.cell_at_index(xyz[0] + PAGE_EDGE * (xyz[1] + PAGE_EDGE * xyz[2])))
     }
 
     /// Stable little-endian RLE format. Halos are deliberately excluded.
@@ -293,7 +314,10 @@ mod tests {
         let page = VoxelPage::constant(CellWord::AIR);
         let mut wrong_version = page.encode();
         wrong_version[7] = b'2';
-        assert_eq!(VoxelPage::decode(&wrong_version), Err(PageCodecError::Magic));
+        assert_eq!(
+            VoxelPage::decode(&wrong_version),
+            Err(PageCodecError::Magic)
+        );
 
         let mut adjacent_runs = Vec::new();
         adjacent_runs.extend_from_slice(MAGIC);
@@ -318,9 +342,8 @@ mod tests {
         let mut cells = vec![CellWord::AIR; CELL_COUNT];
         cells[0] = CellWord::new(-1, 12, 4);
         let feature = VoxelPage::from_cells(cells).unwrap();
-        let reduced = VoxelPage::reduce_children([
-            &feature, &air, &air, &air, &air, &air, &air, &air,
-        ]);
+        let reduced =
+            VoxelPage::reduce_children([&feature, &air, &air, &air, &air, &air, &air, &air]);
         let first = reduced.get([0, 0, 0]).unwrap();
         assert!(first.is_solid());
         assert_eq!(first.material(), 12);

--- a/crates/subsystems/pulsar_terrain/src/page.rs
+++ b/crates/subsystems/pulsar_terrain/src/page.rs
@@ -1,0 +1,395 @@
+use crate::{CellWord, ContentHash, DeterministicGenerator, EditLog, EditOp, PageId, PageKey};
+use thiserror::Error;
+
+pub const PAGE_EDGE: usize = 32;
+pub const MICROBRICK_EDGE: usize = 8;
+pub const MICROBRICKS_PER_AXIS: usize = PAGE_EDGE / MICROBRICK_EDGE;
+pub const MICROBRICK_COUNT: usize =
+    MICROBRICKS_PER_AXIS * MICROBRICKS_PER_AXIS * MICROBRICKS_PER_AXIS;
+pub const CELL_COUNT: usize = PAGE_EDGE * PAGE_EDGE * PAGE_EDGE;
+const MAGIC: &[u8; 8] = b"PTRNPG01";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VoxelPage {
+    storage: PageStorage,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PageStorage {
+    Constant(CellWord),
+    Dense(Box<[CellWord]>),
+}
+
+impl VoxelPage {
+    pub fn microbrick_address(local_cell: [usize; 3]) -> Option<(usize, [usize; 3])> {
+        if local_cell.iter().any(|axis| *axis >= PAGE_EDGE) {
+            return None;
+        }
+        let brick = local_cell.map(|axis| axis / MICROBRICK_EDGE);
+        let within = local_cell.map(|axis| axis % MICROBRICK_EDGE);
+        let index = brick[0]
+            + MICROBRICKS_PER_AXIS * (brick[1] + MICROBRICKS_PER_AXIS * brick[2]);
+        Some((index, within))
+    }
+
+    pub fn constant(cell: CellWord) -> Self {
+        Self {
+            storage: PageStorage::Constant(cell),
+        }
+    }
+
+    pub fn from_cells(cells: Vec<CellWord>) -> Result<Self, PageCodecError> {
+        if cells.len() != CELL_COUNT {
+            return Err(PageCodecError::CellCount(cells.len()));
+        }
+        let first = cells[0];
+        if cells.iter().all(|cell| *cell == first) {
+            Ok(Self::constant(first))
+        } else {
+            Ok(Self {
+                storage: PageStorage::Dense(cells.into_boxed_slice()),
+            })
+        }
+    }
+
+    pub fn generate(
+        key: PageKey,
+        generator: &dyn DeterministicGenerator,
+        edits: &EditLog,
+    ) -> Result<Self, PageCodecError> {
+        if key.lod != 0 {
+            return Err(PageCodecError::UnsupportedLod(key.lod));
+        }
+        let origin = key
+            .lod0_cell_min()
+            .ok_or(PageCodecError::CoordinateOverflow)?;
+        let mut cells = Vec::with_capacity(CELL_COUNT);
+        for z in 0..PAGE_EDGE as i64 {
+            for y in 0..PAGE_EDGE as i64 {
+                for x in 0..PAGE_EDGE as i64 {
+                    let coordinate = [origin[0] + x, origin[1] + y, origin[2] + z];
+                    cells.push(edits.apply(coordinate, generator.sample_cell(coordinate)));
+                }
+            }
+        }
+        Self::from_cells(cells)
+    }
+
+    /// Fold only the supplied ordered edit tail into an already materialized
+    /// LOD0 page. The procedural source and older edit prefix are not replayed.
+    pub fn apply_edit_tail(
+        &self,
+        key: PageKey,
+        operations: &[EditOp],
+    ) -> Result<Self, PageCodecError> {
+        if key.lod != 0 {
+            return Err(PageCodecError::UnsupportedLod(key.lod));
+        }
+        let origin = key
+            .lod0_cell_min()
+            .ok_or(PageCodecError::CoordinateOverflow)?;
+        let mut cells = Vec::with_capacity(CELL_COUNT);
+        for z in 0..PAGE_EDGE as i64 {
+            for y in 0..PAGE_EDGE as i64 {
+                for x in 0..PAGE_EDGE as i64 {
+                    let coordinate = [origin[0] + x, origin[1] + y, origin[2] + z];
+                    let mut cell = self.get([x as usize, y as usize, z as usize]).unwrap();
+                    for operation in operations {
+                        let (min, max) = operation.shape.bounds();
+                        if (0..3)
+                            .all(|axis| coordinate[axis] >= min[axis] && coordinate[axis] < max[axis])
+                        {
+                            cell = operation.apply(coordinate, cell);
+                        }
+                    }
+                    cells.push(cell);
+                }
+            }
+        }
+        Self::from_cells(cells)
+    }
+
+    /// Conservatively reduce eight LOD N children into one LOD N+1 page.
+    /// Any solid fine sample keeps the coarse cell solid, preventing thin
+    /// features from disappearing solely because of reduction.
+    pub fn reduce_children(children: [&Self; 8]) -> Self {
+        let mut cells = Vec::with_capacity(CELL_COUNT);
+        for z in 0..PAGE_EDGE {
+            for y in 0..PAGE_EDGE {
+                for x in 0..PAGE_EDGE {
+                    let mut samples = [CellWord::AIR; 8];
+                    let mut sample_index = 0;
+                    for dz in 0..2 {
+                        for dy in 0..2 {
+                            for dx in 0..2 {
+                                let fine = [x * 2 + dx, y * 2 + dy, z * 2 + dz];
+                                let child_xyz = fine.map(|axis| axis / PAGE_EDGE);
+                                let local = fine.map(|axis| axis % PAGE_EDGE);
+                                let child_index = child_xyz[0] | (child_xyz[1] << 1) | (child_xyz[2] << 2);
+                                samples[sample_index] = children[child_index].get(local).unwrap();
+                                sample_index += 1;
+                            }
+                        }
+                    }
+                    let selected = samples
+                        .iter()
+                        .filter(|sample| sample.is_solid())
+                        .min_by_key(|sample| sample.density())
+                        .or_else(|| samples.iter().min_by_key(|sample| sample.density()))
+                        .copied()
+                        .unwrap();
+                    let flags = samples.iter().fold(0, |flags, sample| flags | sample.flags());
+                    cells.push(CellWord::new(selected.density(), selected.material(), flags));
+                }
+            }
+        }
+        Self::from_cells(cells).expect("LOD reduction always produces exactly one page")
+    }
+
+    pub fn cells(&self) -> impl ExactSizeIterator<Item = CellWord> + '_ {
+        (0..CELL_COUNT).map(|index| self.cell_at_index(index))
+    }
+
+    pub fn constant_cell(&self) -> Option<CellWord> {
+        match self.storage {
+            PageStorage::Constant(cell) => Some(cell),
+            PageStorage::Dense(_) => None,
+        }
+    }
+
+    /// Heap bytes used by canonical cell storage, excluding the small page
+    /// object itself. Uniform pages deliberately report zero.
+    pub fn dense_allocation_bytes(&self) -> usize {
+        match &self.storage {
+            PageStorage::Constant(_) => 0,
+            PageStorage::Dense(cells) => cells.len() * std::mem::size_of::<CellWord>(),
+        }
+    }
+
+    pub fn get(&self, xyz: [usize; 3]) -> Option<CellWord> {
+        if xyz.iter().any(|axis| *axis >= PAGE_EDGE) {
+            return None;
+        }
+        Some(self.cell_at_index(
+            xyz[0] + PAGE_EDGE * (xyz[1] + PAGE_EDGE * xyz[2]),
+        ))
+    }
+
+    /// Stable little-endian RLE format. Halos are deliberately excluded.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut output = Vec::with_capacity(16 + CELL_COUNT * 8);
+        output.extend_from_slice(MAGIC);
+        output.extend_from_slice(&(CELL_COUNT as u32).to_le_bytes());
+        let mut index = 0;
+        while index < CELL_COUNT {
+            let value = self.cell_at_index(index);
+            let mut run = 1_usize;
+            while index + run < CELL_COUNT
+                && self.cell_at_index(index + run) == value
+                && run < u32::MAX as usize
+            {
+                run += 1;
+            }
+            output.extend_from_slice(&(run as u32).to_le_bytes());
+            output.extend_from_slice(&value.0.to_le_bytes());
+            index += run;
+        }
+        output
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, PageCodecError> {
+        if bytes.get(..8) != Some(MAGIC) {
+            return Err(PageCodecError::Magic);
+        }
+        let count = read_u32(bytes, 8)? as usize;
+        if count != CELL_COUNT {
+            return Err(PageCodecError::CellCount(count));
+        }
+        let mut cells = Vec::with_capacity(CELL_COUNT);
+        let mut cursor = 12;
+        let mut previous = None;
+        while cursor < bytes.len() && cells.len() < CELL_COUNT {
+            let run = read_u32(bytes, cursor)? as usize;
+            let value = CellWord(read_u32(bytes, cursor + 4)?);
+            cursor += 8;
+            if run == 0 || cells.len().saturating_add(run) > CELL_COUNT {
+                return Err(PageCodecError::RunLength);
+            }
+            if previous == Some(value) {
+                return Err(PageCodecError::NonCanonical);
+            }
+            cells.resize(cells.len() + run, value);
+            previous = Some(value);
+        }
+        if cells.len() != CELL_COUNT || cursor != bytes.len() {
+            return Err(PageCodecError::TruncatedOrTrailing);
+        }
+        Self::from_cells(cells)
+    }
+
+    pub fn page_id(&self) -> PageId {
+        ContentHash::of(&self.encode())
+    }
+
+    fn cell_at_index(&self, index: usize) -> CellWord {
+        match &self.storage {
+            PageStorage::Constant(cell) => *cell,
+            PageStorage::Dense(cells) => cells[index],
+        }
+    }
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, PageCodecError> {
+    let value = bytes
+        .get(offset..offset + 4)
+        .ok_or(PageCodecError::TruncatedOrTrailing)?;
+    Ok(u32::from_le_bytes(value.try_into().unwrap()))
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PageCodecError {
+    #[error("invalid terrain page magic/version")]
+    Magic,
+    #[error("terrain page has {0} cells instead of 32768")]
+    CellCount(usize),
+    #[error("invalid terrain page run length")]
+    RunLength,
+    #[error("terrain page is truncated or contains trailing bytes")]
+    TruncatedOrTrailing,
+    #[error("terrain page uses a non-canonical run encoding")]
+    NonCanonical,
+    #[error("materialized pages currently require LOD0, received LOD{0}")]
+    UnsupportedLod(u8),
+    #[error("terrain page coordinate overflow")]
+    CoordinateOverflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EditMode, EditShape, FixedSphereGenerator};
+
+    #[test]
+    fn constant_and_dense_pages_round_trip_with_stable_hashes() {
+        let constant = VoxelPage::constant(CellWord::new(-4, 3, 1));
+        assert_eq!(VoxelPage::decode(&constant.encode()).unwrap(), constant);
+        assert_eq!(constant.encode().len(), 20);
+        assert_eq!(constant.dense_allocation_bytes(), 0);
+
+        let cells = (0..CELL_COUNT)
+            .map(|index| CellWord::new(index as i16, (index % 251) as u8, 0))
+            .collect();
+        let dense = VoxelPage::from_cells(cells).unwrap();
+        assert_eq!(VoxelPage::decode(&dense.encode()).unwrap(), dense);
+        assert_eq!(dense.page_id(), ContentHash::of(&dense.encode()));
+        assert_eq!(
+            dense.dense_allocation_bytes(),
+            CELL_COUNT * std::mem::size_of::<CellWord>()
+        );
+    }
+
+    #[test]
+    fn codec_rejects_corruption_versions_and_noncanonical_runs() {
+        let page = VoxelPage::constant(CellWord::AIR);
+        let mut wrong_version = page.encode();
+        wrong_version[7] = b'2';
+        assert_eq!(VoxelPage::decode(&wrong_version), Err(PageCodecError::Magic));
+
+        let mut adjacent_runs = Vec::new();
+        adjacent_runs.extend_from_slice(MAGIC);
+        adjacent_runs.extend_from_slice(&(CELL_COUNT as u32).to_le_bytes());
+        adjacent_runs.extend_from_slice(&1_u32.to_le_bytes());
+        adjacent_runs.extend_from_slice(&CellWord::AIR.0.to_le_bytes());
+        adjacent_runs.extend_from_slice(&((CELL_COUNT - 1) as u32).to_le_bytes());
+        adjacent_runs.extend_from_slice(&CellWord::AIR.0.to_le_bytes());
+        assert_eq!(
+            VoxelPage::decode(&adjacent_runs),
+            Err(PageCodecError::NonCanonical)
+        );
+
+        let mut corrupt = page.encode();
+        corrupt.truncate(corrupt.len() - 1);
+        assert!(VoxelPage::decode(&corrupt).is_err());
+    }
+
+    #[test]
+    fn lod_reduction_preserves_a_single_thin_solid_sample() {
+        let air = VoxelPage::constant(CellWord::AIR);
+        let mut cells = vec![CellWord::AIR; CELL_COUNT];
+        cells[0] = CellWord::new(-1, 12, 4);
+        let feature = VoxelPage::from_cells(cells).unwrap();
+        let reduced = VoxelPage::reduce_children([
+            &feature, &air, &air, &air, &air, &air, &air, &air,
+        ]);
+        let first = reduced.get([0, 0, 0]).unwrap();
+        assert!(first.is_solid());
+        assert_eq!(first.material(), 12);
+        assert_eq!(first.flags(), 4);
+    }
+
+    #[test]
+    fn microbrick_addressing_covers_every_page_cell_exactly() {
+        let mut hits = vec![0_u8; CELL_COUNT];
+        for z in 0..PAGE_EDGE {
+            for y in 0..PAGE_EDGE {
+                for x in 0..PAGE_EDGE {
+                    let (brick, local) = VoxelPage::microbrick_address([x, y, z]).unwrap();
+                    assert!(brick < MICROBRICK_COUNT);
+                    assert!(local.iter().all(|axis| *axis < MICROBRICK_EDGE));
+                    let reconstructed_brick = [
+                        brick % MICROBRICKS_PER_AXIS,
+                        (brick / MICROBRICKS_PER_AXIS) % MICROBRICKS_PER_AXIS,
+                        brick / (MICROBRICKS_PER_AXIS * MICROBRICKS_PER_AXIS),
+                    ];
+                    let reconstructed = [
+                        reconstructed_brick[0] * MICROBRICK_EDGE + local[0],
+                        reconstructed_brick[1] * MICROBRICK_EDGE + local[1],
+                        reconstructed_brick[2] * MICROBRICK_EDGE + local[2],
+                    ];
+                    assert_eq!(reconstructed, [x, y, z]);
+                    let linear = x + PAGE_EDGE * (y + PAGE_EDGE * z);
+                    hits[linear] += 1;
+                }
+            }
+        }
+        assert!(hits.into_iter().all(|count| count == 1));
+        assert_eq!(VoxelPage::microbrick_address([PAGE_EDGE, 0, 0]), None);
+    }
+
+    #[test]
+    fn incremental_edit_tail_matches_full_deterministic_replay() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 24,
+            material: 2,
+        };
+        let first = EditOp {
+            sequence: 1,
+            stable_id: [1; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8, 8, 8],
+                radius_cells: 5,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        };
+        let second = EditOp {
+            sequence: 2,
+            stable_id: [2; 16],
+            shape: EditShape::Sphere {
+                center_cell: [12, 8, 8],
+                radius_cells: 3,
+            },
+            mode: EditMode::Union,
+            material: 9,
+        };
+        let key = PageKey::new(0, [0; 3]);
+        let prefix = EditLog::from_scheduled(vec![first]).unwrap();
+        let complete = EditLog::from_scheduled(vec![second, first]).unwrap();
+        let prefix_page = VoxelPage::generate(key, &generator, &prefix).unwrap();
+        let incremental = prefix_page.apply_edit_tail(key, &[second]).unwrap();
+        let replayed = VoxelPage::generate(key, &generator, &complete).unwrap();
+        assert_eq!(incremental, replayed);
+        assert_eq!(incremental.page_id(), replayed.page_id());
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/snapshot.rs
+++ b/crates/subsystems/pulsar_terrain/src/snapshot.rs
@@ -1,0 +1,203 @@
+use crate::{ContentHash, EditLog, PageId, PageKey, PlanetId, SparseBrickTree};
+use thiserror::Error;
+
+const SNAPSHOT_MAGIC: &[u8; 8] = b"PTSNAP01";
+const PAGE_RECORD_BYTES: usize = 72;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompactedPageRecord {
+    pub key: PageKey,
+    pub page_id: PageId,
+    pub compacted_through_sequence: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerrainSnapshot {
+    pub planet_id: PlanetId,
+    pub generator_hash: ContentHash,
+    pub hierarchy: SparseBrickTree,
+    pub edit_tail: EditLog,
+    pub compacted_pages: Vec<CompactedPageRecord>,
+}
+
+impl TerrainSnapshot {
+    pub fn encode(&self) -> Result<Vec<u8>, SnapshotCodecError> {
+        let mut compacted_pages = self.compacted_pages.clone();
+        compacted_pages.sort_unstable_by_key(|record| record.key);
+        if compacted_pages
+            .windows(2)
+            .any(|pair| pair[0].key == pair[1].key)
+        {
+            return Err(SnapshotCodecError::DuplicatePageKey);
+        }
+        let hierarchy = self.hierarchy.encode();
+        let edits = self.edit_tail.encode();
+        let mut output = Vec::with_capacity(
+            80 + hierarchy.len() + edits.len() + compacted_pages.len() * PAGE_RECORD_BYTES,
+        );
+        output.extend_from_slice(SNAPSHOT_MAGIC);
+        output.extend_from_slice(&self.planet_id.0);
+        output.extend_from_slice(&self.generator_hash.0);
+        output.extend_from_slice(&(hierarchy.len() as u64).to_le_bytes());
+        output.extend_from_slice(&(edits.len() as u64).to_le_bytes());
+        output.extend_from_slice(&(compacted_pages.len() as u32).to_le_bytes());
+        output.extend_from_slice(&[0; 4]);
+        output.extend_from_slice(&hierarchy);
+        output.extend_from_slice(&edits);
+        for record in compacted_pages {
+            output.push(record.key.lod);
+            output.extend_from_slice(&[0; 7]);
+            for axis in record.key.page_xyz {
+                output.extend_from_slice(&axis.to_le_bytes());
+            }
+            output.extend_from_slice(&record.page_id.0);
+            output.extend_from_slice(&record.compacted_through_sequence.to_le_bytes());
+        }
+        Ok(output)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, SnapshotCodecError> {
+        if bytes.len() < 80
+            || bytes.get(..8) != Some(SNAPSHOT_MAGIC)
+            || bytes.get(76..80) != Some(&[0; 4])
+        {
+            return Err(SnapshotCodecError::Codec);
+        }
+        let planet_id = PlanetId(read_array(bytes, 8)?);
+        let generator_hash = ContentHash(read_array(bytes, 24)?);
+        let hierarchy_len = read_u64(bytes, 56)? as usize;
+        let edits_len = read_u64(bytes, 64)? as usize;
+        let page_count = read_u32(bytes, 72)? as usize;
+        let hierarchy_end = 80_usize
+            .checked_add(hierarchy_len)
+            .ok_or(SnapshotCodecError::Codec)?;
+        let edits_end = hierarchy_end
+            .checked_add(edits_len)
+            .ok_or(SnapshotCodecError::Codec)?;
+        let expected_end = edits_end
+            .checked_add(
+                page_count
+                    .checked_mul(PAGE_RECORD_BYTES)
+                    .ok_or(SnapshotCodecError::Codec)?,
+            )
+            .ok_or(SnapshotCodecError::Codec)?;
+        if expected_end != bytes.len() {
+            return Err(SnapshotCodecError::Codec);
+        }
+        let hierarchy = SparseBrickTree::decode(&bytes[80..hierarchy_end])
+            .map_err(|_| SnapshotCodecError::Codec)?;
+        let edit_tail = EditLog::decode(&bytes[hierarchy_end..edits_end])
+            .map_err(|_| SnapshotCodecError::Codec)?;
+        let mut compacted_pages = Vec::with_capacity(page_count);
+        let mut cursor = edits_end;
+        for _ in 0..page_count {
+            let lod = bytes[cursor];
+            if bytes.get(cursor + 1..cursor + 8) != Some(&[0; 7]) {
+                return Err(SnapshotCodecError::Codec);
+            }
+            let page_xyz = [
+                read_i64(bytes, cursor + 8)?,
+                read_i64(bytes, cursor + 16)?,
+                read_i64(bytes, cursor + 24)?,
+            ];
+            compacted_pages.push(CompactedPageRecord {
+                key: PageKey::new(lod, page_xyz),
+                page_id: ContentHash(read_array(bytes, cursor + 32)?),
+                compacted_through_sequence: read_u64(bytes, cursor + 64)?,
+            });
+            cursor += PAGE_RECORD_BYTES;
+        }
+        if compacted_pages
+            .windows(2)
+            .any(|pair| pair[0].key >= pair[1].key)
+        {
+            return Err(SnapshotCodecError::DuplicatePageKey);
+        }
+        Ok(Self {
+            planet_id,
+            generator_hash,
+            hierarchy,
+            edit_tail,
+            compacted_pages,
+        })
+    }
+
+    pub fn content_hash(&self) -> Result<ContentHash, SnapshotCodecError> {
+        Ok(ContentHash::of(&self.encode()?))
+    }
+}
+
+fn read_array<const N: usize>(bytes: &[u8], offset: usize) -> Result<[u8; N], SnapshotCodecError> {
+    bytes
+        .get(offset..offset + N)
+        .ok_or(SnapshotCodecError::Codec)?
+        .try_into()
+        .map_err(|_| SnapshotCodecError::Codec)
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, SnapshotCodecError> {
+    Ok(u32::from_le_bytes(read_array(bytes, offset)?))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, SnapshotCodecError> {
+    Ok(u64::from_le_bytes(read_array(bytes, offset)?))
+}
+
+fn read_i64(bytes: &[u8], offset: usize) -> Result<i64, SnapshotCodecError> {
+    Ok(i64::from_le_bytes(read_array(bytes, offset)?))
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SnapshotCodecError {
+    #[error("invalid canonical terrain snapshot encoding")]
+    Codec,
+    #[error("terrain snapshot contains duplicate or unsorted page keys")]
+    DuplicatePageKey,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EditMode, EditOp, EditShape, NodeState};
+
+    #[test]
+    fn snapshot_round_trip_is_canonical_across_page_insertion_order() {
+        let generator_hash = ContentHash::of(b"generator");
+        let hierarchy = SparseBrickTree::centered(16, NodeState::Procedural(generator_hash)).unwrap();
+        let mut edits = EditLog::default();
+        edits
+            .push(EditOp {
+                sequence: 3,
+                stable_id: [3; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [1, 2, 3],
+                    radius_cells: 5,
+                },
+                mode: EditMode::Subtract,
+                material: 0,
+            })
+            .unwrap();
+        let pages = vec![
+            CompactedPageRecord {
+                key: PageKey::new(0, [4, -1, 2]),
+                page_id: ContentHash::of(b"b"),
+                compacted_through_sequence: 3,
+            },
+            CompactedPageRecord {
+                key: PageKey::new(0, [-2, 7, 1]),
+                page_id: ContentHash::of(b"a"),
+                compacted_through_sequence: 3,
+            },
+        ];
+        let snapshot = TerrainSnapshot {
+            planet_id: PlanetId([7; 16]),
+            generator_hash,
+            hierarchy,
+            edit_tail: edits,
+            compacted_pages: pages,
+        };
+        let decoded = TerrainSnapshot::decode(&snapshot.encode().unwrap()).unwrap();
+        assert_eq!(decoded.content_hash().unwrap(), snapshot.content_hash().unwrap());
+        assert_eq!(decoded.compacted_pages[0].key.page_xyz, [-2, 7, 1]);
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/snapshot.rs
+++ b/crates/subsystems/pulsar_terrain/src/snapshot.rs
@@ -163,7 +163,8 @@ mod tests {
     #[test]
     fn snapshot_round_trip_is_canonical_across_page_insertion_order() {
         let generator_hash = ContentHash::of(b"generator");
-        let hierarchy = SparseBrickTree::centered(16, NodeState::Procedural(generator_hash)).unwrap();
+        let hierarchy =
+            SparseBrickTree::centered(16, NodeState::Procedural(generator_hash)).unwrap();
         let mut edits = EditLog::default();
         edits
             .push(EditOp {
@@ -197,7 +198,10 @@ mod tests {
             compacted_pages: pages,
         };
         let decoded = TerrainSnapshot::decode(&snapshot.encode().unwrap()).unwrap();
-        assert_eq!(decoded.content_hash().unwrap(), snapshot.content_hash().unwrap());
+        assert_eq!(
+            decoded.content_hash().unwrap(),
+            snapshot.content_hash().unwrap()
+        );
         assert_eq!(decoded.compacted_pages[0].key.page_xyz, [-2, 7, 1]);
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/store.rs
+++ b/crates/subsystems/pulsar_terrain/src/store.rs
@@ -66,7 +66,9 @@ impl TerrainStore {
             .map_err(TerrainStoreError::Io)?
             .into_iter()
             .filter(|entry| !entry.is_dir && entry.name.ends_with(".root"))
-            .filter_map(|entry| parse_generation(&entry.name).map(|generation| (generation, entry.name)))
+            .filter_map(|entry| {
+                parse_generation(&entry.name).map(|generation| (generation, entry.name))
+            })
             .collect::<Vec<_>>();
         candidates.sort_unstable_by_key(|candidate| std::cmp::Reverse(candidate.0));
 
@@ -105,7 +107,9 @@ impl TerrainStore {
         virtual_fs::create_dir_all(&self.objects_dir()).map_err(TerrainStoreError::Io)?;
         let object_path = self.objects_dir().join(hash.to_hex());
         if !virtual_fs::exists(&object_path).map_err(TerrainStoreError::Io)? {
-            let pending = self.objects_dir().join(format!("{}.pending", hash.to_hex()));
+            let pending = self
+                .objects_dir()
+                .join(format!("{}.pending", hash.to_hex()));
             virtual_fs::write_file(&pending, bytes).map_err(TerrainStoreError::Io)?;
             virtual_fs::rename(&pending, &object_path).map_err(TerrainStoreError::Io)?;
         }
@@ -175,9 +179,11 @@ mod tests {
         assert_eq!(recovered, first);
 
         virtual_fs::write_file(
-            &store
-                .roots_dir()
-                .join(format!("{:020}-{}.root", 2, ContentHash::default().to_hex())),
+            &store.roots_dir().join(format!(
+                "{:020}-{}.root",
+                2,
+                ContentHash::default().to_hex()
+            )),
             b"published but incomplete manifest",
         )
         .unwrap();

--- a/crates/subsystems/pulsar_terrain/src/store.rs
+++ b/crates/subsystems/pulsar_terrain/src/store.rs
@@ -1,0 +1,207 @@
+use crate::{ContentHash, PageCodecError, PageId, VoxelPage};
+use engine_fs::virtual_fs;
+use std::path::PathBuf;
+use thiserror::Error;
+
+const MANIFEST_MAGIC: &[u8; 8] = b"PTRNRT01";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnapshotRecord {
+    pub generation: u64,
+    pub hash: ContentHash,
+    pub bytes: Vec<u8>,
+}
+
+/// Content-addressed terrain snapshots with atomic unique-name publication.
+/// A pending file is never considered a root; the preceding generation remains
+/// loadable until the provider's final rename succeeds.
+#[derive(Clone, Debug)]
+pub struct TerrainStore {
+    root: PathBuf,
+}
+
+impl TerrainStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn save(&self, snapshot: &[u8]) -> Result<SnapshotRecord, TerrainStoreError> {
+        let generation = self.latest_generation()?.unwrap_or(0).saturating_add(1);
+        let hash = self.store_object(snapshot)?;
+        virtual_fs::create_dir_all(&self.roots_dir()).map_err(TerrainStoreError::Io)?;
+
+        let manifest = encode_manifest(generation, hash);
+        let pending = self.roots_dir().join(format!("{generation:020}.pending"));
+        let published = self
+            .roots_dir()
+            .join(format!("{generation:020}-{}.root", hash.to_hex()));
+        virtual_fs::write_file(&pending, &manifest).map_err(TerrainStoreError::Io)?;
+        virtual_fs::rename(&pending, &published).map_err(TerrainStoreError::Io)?;
+
+        Ok(SnapshotRecord {
+            generation,
+            hash,
+            bytes: snapshot.to_vec(),
+        })
+    }
+
+    pub fn store_page(&self, page: &VoxelPage) -> Result<PageId, TerrainStoreError> {
+        self.store_object(&page.encode())
+    }
+
+    pub fn load_page(&self, page_id: PageId) -> Result<VoxelPage, TerrainStoreError> {
+        let bytes = virtual_fs::read_file(&self.objects_dir().join(page_id.to_hex()))
+            .map_err(TerrainStoreError::Io)?;
+        if ContentHash::of(&bytes) != page_id {
+            return Err(TerrainStoreError::ObjectHash);
+        }
+        VoxelPage::decode(&bytes).map_err(TerrainStoreError::Page)
+    }
+
+    pub fn load_latest(&self) -> Result<Option<SnapshotRecord>, TerrainStoreError> {
+        if !virtual_fs::exists(&self.roots_dir()).map_err(TerrainStoreError::Io)? {
+            return Ok(None);
+        }
+        let mut candidates = virtual_fs::list_dir(&self.roots_dir())
+            .map_err(TerrainStoreError::Io)?
+            .into_iter()
+            .filter(|entry| !entry.is_dir && entry.name.ends_with(".root"))
+            .filter_map(|entry| parse_generation(&entry.name).map(|generation| (generation, entry.name)))
+            .collect::<Vec<_>>();
+        candidates.sort_unstable_by_key(|candidate| std::cmp::Reverse(candidate.0));
+
+        for (filename_generation, filename) in candidates {
+            let manifest = match virtual_fs::read_file(&self.roots_dir().join(filename)) {
+                Ok(bytes) => bytes,
+                Err(_) => continue,
+            };
+            let Ok((generation, hash)) = decode_manifest(&manifest) else {
+                continue;
+            };
+            if generation != filename_generation {
+                continue;
+            }
+            let Ok(bytes) = virtual_fs::read_file(&self.objects_dir().join(hash.to_hex())) else {
+                continue;
+            };
+            if ContentHash::of(&bytes) != hash {
+                continue;
+            }
+            return Ok(Some(SnapshotRecord {
+                generation,
+                hash,
+                bytes,
+            }));
+        }
+        Ok(None)
+    }
+
+    fn latest_generation(&self) -> Result<Option<u64>, TerrainStoreError> {
+        Ok(self.load_latest()?.map(|record| record.generation))
+    }
+
+    fn store_object(&self, bytes: &[u8]) -> Result<ContentHash, TerrainStoreError> {
+        let hash = ContentHash::of(bytes);
+        virtual_fs::create_dir_all(&self.objects_dir()).map_err(TerrainStoreError::Io)?;
+        let object_path = self.objects_dir().join(hash.to_hex());
+        if !virtual_fs::exists(&object_path).map_err(TerrainStoreError::Io)? {
+            let pending = self.objects_dir().join(format!("{}.pending", hash.to_hex()));
+            virtual_fs::write_file(&pending, bytes).map_err(TerrainStoreError::Io)?;
+            virtual_fs::rename(&pending, &object_path).map_err(TerrainStoreError::Io)?;
+        }
+        Ok(hash)
+    }
+
+    fn objects_dir(&self) -> PathBuf {
+        self.root.join("objects")
+    }
+
+    fn roots_dir(&self) -> PathBuf {
+        self.root.join("roots")
+    }
+
+    #[cfg(test)]
+    fn pending_root_path(&self, generation: u64) -> PathBuf {
+        self.roots_dir().join(format!("{generation:020}.pending"))
+    }
+}
+
+fn encode_manifest(generation: u64, hash: ContentHash) -> Vec<u8> {
+    let mut output = Vec::with_capacity(48);
+    output.extend_from_slice(MANIFEST_MAGIC);
+    output.extend_from_slice(&generation.to_le_bytes());
+    output.extend_from_slice(&hash.0);
+    output
+}
+
+fn decode_manifest(bytes: &[u8]) -> Result<(u64, ContentHash), TerrainStoreError> {
+    if bytes.len() != 48 || bytes.get(..8) != Some(MANIFEST_MAGIC) {
+        return Err(TerrainStoreError::Manifest);
+    }
+    let generation = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+    let hash = ContentHash(bytes[16..48].try_into().unwrap());
+    Ok((generation, hash))
+}
+
+fn parse_generation(filename: &str) -> Option<u64> {
+    filename.get(..20)?.parse().ok()
+}
+
+#[derive(Debug, Error)]
+pub enum TerrainStoreError {
+    #[error("terrain store I/O failed: {0}")]
+    Io(#[source] anyhow::Error),
+    #[error("invalid terrain root manifest")]
+    Manifest,
+    #[error("content-addressed terrain object hash mismatch")]
+    ObjectHash,
+    #[error("stored terrain page is invalid: {0}")]
+    Page(#[source] PageCodecError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interrupted_publish_keeps_the_previous_valid_root() {
+        virtual_fs::reset_to_local();
+        let temporary = tempfile::tempdir().unwrap();
+        let store = TerrainStore::new(temporary.path().join("terrain"));
+        let first = store.save(b"first canonical snapshot").unwrap();
+
+        virtual_fs::write_file(&store.pending_root_path(2), b"partial manifest").unwrap();
+        let recovered = store.load_latest().unwrap().unwrap();
+        assert_eq!(recovered, first);
+
+        virtual_fs::write_file(
+            &store
+                .roots_dir()
+                .join(format!("{:020}-{}.root", 2, ContentHash::default().to_hex())),
+            b"published but incomplete manifest",
+        )
+        .unwrap();
+        assert_eq!(store.load_latest().unwrap().unwrap(), first);
+
+        let second = store.save(b"second canonical snapshot").unwrap();
+        assert_eq!(second.generation, 2);
+        assert_eq!(store.load_latest().unwrap().unwrap(), second);
+    }
+
+    #[test]
+    fn pages_are_content_addressed_and_validated_on_load() {
+        virtual_fs::reset_to_local();
+        let temporary = tempfile::tempdir().unwrap();
+        let store = TerrainStore::new(temporary.path().join("terrain"));
+        let page = VoxelPage::constant(crate::CellWord::new(-1, 7, 0));
+        let page_id = store.store_page(&page).unwrap();
+        assert_eq!(page_id, page.page_id());
+        assert_eq!(store.load_page(page_id).unwrap(), page);
+
+        virtual_fs::write_file(&store.objects_dir().join(page_id.to_hex()), b"corrupt").unwrap();
+        assert!(matches!(
+            store.load_page(page_id),
+            Err(TerrainStoreError::ObjectHash)
+        ));
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/types.rs
+++ b/crates/subsystems/pulsar_terrain/src/types.rs
@@ -1,0 +1,170 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub type MaterialId = u8;
+pub const LOD0_CELL_SIZE_METERS: f64 = 0.1;
+pub const PAGE_EDGE_CELLS: i64 = 32;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PlanetId(pub [u8; 16]);
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PlanetPosition {
+    pub sector: [i64; 3],
+    pub offset_m: [f64; 3],
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PageKey {
+    pub lod: u8,
+    pub page_xyz: [i64; 3],
+}
+
+impl PageKey {
+    pub const fn new(lod: u8, page_xyz: [i64; 3]) -> Self {
+        Self { lod, page_xyz }
+    }
+
+    pub fn parent(self) -> Option<Self> {
+        Some(Self {
+            lod: self.lod.checked_add(1)?,
+            page_xyz: self.page_xyz.map(|axis| axis.div_euclid(2)),
+        })
+    }
+
+    pub fn lod0_min(self) -> Option<[i64; 3]> {
+        let scale = 1_i64.checked_shl(u32::from(self.lod))?;
+        Some([
+            self.page_xyz[0].checked_mul(scale)?,
+            self.page_xyz[1].checked_mul(scale)?,
+            self.page_xyz[2].checked_mul(scale)?,
+        ])
+    }
+
+    /// Number of canonical LOD0 cells covered by one axis of this page.
+    pub fn lod0_cell_span(self) -> Option<i64> {
+        PAGE_EDGE_CELLS.checked_shl(u32::from(self.lod))
+    }
+
+    /// Canonical minimum LOD0-cell coordinate covered by this page.
+    pub fn lod0_cell_min(self) -> Option<[i64; 3]> {
+        let span = self.lod0_cell_span()?;
+        Some([
+            self.page_xyz[0].checked_mul(span)?,
+            self.page_xyz[1].checked_mul(span)?,
+            self.page_xyz[2].checked_mul(span)?,
+        ])
+    }
+
+    /// Convert a canonical LOD0-cell coordinate into a page and its 0..32
+    /// cell coordinate at the requested LOD. Euclidean division keeps the
+    /// mapping continuous and unambiguous across every negative-axis boundary.
+    pub fn address_lod0_cell(lod: u8, cell_xyz: [i64; 3]) -> Option<(Self, [u8; 3])> {
+        let scale = 1_i64.checked_shl(u32::from(lod))?;
+        let span = PAGE_EDGE_CELLS.checked_mul(scale)?;
+        let page_xyz = cell_xyz.map(|axis| axis.div_euclid(span));
+        let local = cell_xyz.map(|axis| (axis.rem_euclid(span) / scale) as u8);
+        Some((Self { lod, page_xyz }, local))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ContentHash(pub [u8; 32]);
+
+impl ContentHash {
+    pub fn of(bytes: &[u8]) -> Self {
+        Self(Sha256::digest(bytes).into())
+    }
+
+    pub fn to_hex(self) -> String {
+        let mut output = String::with_capacity(64);
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        for byte in self.0 {
+            output.push(HEX[usize::from(byte >> 4)] as char);
+            output.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+        output
+    }
+}
+
+pub type PageId = ContentHash;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NodeState {
+    Air,
+    Solid(MaterialId),
+    Procedural(ContentHash),
+    Branch,
+    Page(PageId),
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CellWord(pub u32);
+
+impl CellWord {
+    pub const AIR: Self = Self::new(i16::MAX, 0, 0);
+
+    pub const fn new(density: i16, material: MaterialId, flags: u8) -> Self {
+        Self((density as u16 as u32) | ((material as u32) << 16) | ((flags as u32) << 24))
+    }
+
+    pub const fn density(self) -> i16 {
+        self.0 as u16 as i16
+    }
+
+    pub const fn material(self) -> MaterialId {
+        (self.0 >> 16) as u8
+    }
+
+    pub const fn flags(self) -> u8 {
+        (self.0 >> 24) as u8
+    }
+
+    pub const fn is_solid(self) -> bool {
+        self.density() <= 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signed_cell_to_page_conversion_is_exact_at_every_boundary() {
+        for lod in 0..=30 {
+            let scale = 1_i64 << lod;
+            let span = PAGE_EDGE_CELLS * scale;
+            let boundaries = [
+                -span - 1,
+                -span,
+                -span + 1,
+                -1,
+                0,
+                1,
+                span - 1,
+                span,
+                span + 1,
+            ];
+            for coordinate in boundaries {
+                let cell = [coordinate, -coordinate, coordinate.saturating_sub(1)];
+                let (key, local) = PageKey::address_lod0_cell(lod, cell).unwrap();
+                let page_min = key.lod0_cell_min().unwrap();
+                for axis in 0..3 {
+                    assert!(local[axis] < PAGE_EDGE_CELLS as u8);
+                    let reconstructed = page_min[axis] + i64::from(local[axis]) * scale;
+                    assert!(reconstructed <= cell[axis]);
+                    assert!(cell[axis] < reconstructed + scale);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn page_parent_uses_euclidean_division_on_negative_axes() {
+        assert_eq!(
+            PageKey::new(0, [-1, -2, -3]).parent(),
+            Some(PageKey::new(1, [-1, -1, -2]))
+        );
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/types.rs
+++ b/crates/subsystems/pulsar_terrain/src/types.rs
@@ -14,7 +14,9 @@ pub struct PlanetPosition {
     pub offset_m: [f64; 3],
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct PageKey {
     pub lod: u8,
     pub page_xyz: [i64; 3],
@@ -68,7 +70,9 @@ impl PageKey {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct ContentHash(pub [u8; 32]);
 
 impl ContentHash {

--- a/crates/subsystems/pulsar_terrain/tests/core_contract.rs
+++ b/crates/subsystems/pulsar_terrain/tests/core_contract.rs
@@ -1,0 +1,156 @@
+use pulsar_terrain::{
+    CellWord, DeterministicGenerator, EditLog, EditMode, EditOp, EditShape,
+    FixedSphereGenerator, NodeState, PageKey, SparseBrickTree, VoxelPage,
+};
+
+fn sphere() -> FixedSphereGenerator {
+    FixedSphereGenerator {
+        center_cell: [0; 3],
+        radius_cells: 64,
+        material: 2,
+    }
+}
+
+#[test]
+fn edit_order_is_deterministic_and_changes_page_hash() {
+    let generator = sphere();
+    let key = PageKey::new(0, [-1, 0, 0]);
+    let base = VoxelPage::generate(key, &generator, &EditLog::default()).unwrap();
+    let operation = EditOp {
+        sequence: 1,
+        stable_id: [1; 16],
+        shape: EditShape::Sphere {
+            center_cell: [-8, 8, 8],
+            radius_cells: 6,
+        },
+        mode: EditMode::Subtract,
+        material: 0,
+    };
+    let mut edits = EditLog::default();
+    edits.push(operation).unwrap();
+    edits.push(operation).unwrap();
+    let edited_a = VoxelPage::generate(key, &generator, &edits).unwrap();
+    let edited_b = VoxelPage::generate(key, &generator, &edits).unwrap();
+    assert_ne!(base.page_id(), edited_a.page_id());
+    assert_eq!(edited_a.page_id(), edited_b.page_id());
+}
+
+#[test]
+fn billion_cell_logical_region_cost_depends_on_touched_paths() {
+    let mut tree = SparseBrickTree::centered(24, NodeState::Procedural(sphere().hash())).unwrap();
+    for index in 0..128 {
+        tree.set(
+            PageKey::new(0, [index * 1024 - 65_536, -index * 37, index * 11]),
+            NodeState::Page(pulsar_terrain::ContentHash::of(&index.to_le_bytes())),
+        )
+        .unwrap();
+    }
+    assert!(tree.node_count() <= 1 + 128 * 8 * 24);
+    tree.set_root(NodeState::Air).unwrap();
+    assert_eq!(tree.node_count(), 1);
+}
+
+#[test]
+fn cell_word_layout_is_exactly_four_bytes() {
+    assert_eq!(std::mem::size_of::<CellWord>(), 4);
+    let word = CellWord::new(-123, 17, 9);
+    assert_eq!((word.density(), word.material(), word.flags()), (-123, 17, 9));
+}
+
+fn next_random(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    *state
+}
+
+#[test]
+fn randomized_sparse_hierarchy_matches_a_dense_reference_fixture() {
+    const ROOT_LOD: u8 = 5;
+    const ROOT_EDGE: usize = 1 << ROOT_LOD;
+    const ROOT_MIN: i64 = -(ROOT_EDGE as i64 / 2);
+    let mut tree = SparseBrickTree::centered(ROOT_LOD, NodeState::Air).unwrap();
+    let mut dense = vec![NodeState::Air; ROOT_EDGE * ROOT_EDGE * ROOT_EDGE];
+    let mut random = 0x4d59_5df4_d0f3_3173_u64;
+
+    for operation in 0..512 {
+        let lod = (next_random(&mut random) % 4) as u8;
+        let half = 1_i64 << (ROOT_LOD - 1 - lod);
+        let coordinate = |random: &mut u64| {
+            (next_random(random) % (2 * half) as u64) as i64 - half
+        };
+        let key = PageKey::new(
+            lod,
+            [
+                coordinate(&mut random),
+                coordinate(&mut random),
+                coordinate(&mut random),
+            ],
+        );
+        let state = if operation % 5 == 0 {
+            NodeState::Air
+        } else {
+            NodeState::Solid((operation % 13 + 1) as u8)
+        };
+        tree.set(key, state.clone()).unwrap();
+
+        let min = key.lod0_min().unwrap();
+        let edge = 1_i64 << lod;
+        for z in min[2]..min[2] + edge {
+            for y in min[1]..min[1] + edge {
+                for x in min[0]..min[0] + edge {
+                    let local = [x - ROOT_MIN, y - ROOT_MIN, z - ROOT_MIN];
+                    let index = local[0] as usize
+                        + ROOT_EDGE * (local[1] as usize + ROOT_EDGE * local[2] as usize);
+                    dense[index] = state.clone();
+                }
+            }
+        }
+    }
+
+    for z in ROOT_MIN..ROOT_MIN + ROOT_EDGE as i64 {
+        for y in ROOT_MIN..ROOT_MIN + ROOT_EDGE as i64 {
+            for x in ROOT_MIN..ROOT_MIN + ROOT_EDGE as i64 {
+                let local = [x - ROOT_MIN, y - ROOT_MIN, z - ROOT_MIN];
+                let index = local[0] as usize
+                    + ROOT_EDGE * (local[1] as usize + ROOT_EDGE * local[2] as usize);
+                assert_eq!(
+                    tree.resolve(PageKey::new(0, [x, y, z])).unwrap(),
+                    dense[index],
+                    "sparse mismatch at [{x}, {y}, {z}]"
+                );
+            }
+        }
+    }
+
+    let decoded = SparseBrickTree::decode(&tree.encode()).unwrap();
+    assert_eq!(decoded, tree);
+    tree.set_root(NodeState::Solid(9)).unwrap();
+    assert_eq!(tree.node_count(), 1);
+    assert_eq!(tree.resolve(PageKey::new(0, [-16; 3])).unwrap(), NodeState::Solid(9));
+}
+
+#[test]
+fn randomized_page_codecs_are_canonical_and_deterministic() {
+    let mut random = 0xa076_1d64_78bd_642f_u64;
+    for fixture in 0..32 {
+        let mut cells = Vec::with_capacity(pulsar_terrain::CELL_COUNT);
+        let mut current = CellWord::AIR;
+        for index in 0..pulsar_terrain::CELL_COUNT {
+            if index == 0 || next_random(&mut random) % 19 == 0 {
+                current = CellWord::new(
+                    next_random(&mut random) as i16,
+                    next_random(&mut random) as u8,
+                    fixture,
+                );
+            }
+            cells.push(current);
+        }
+        let page = VoxelPage::from_cells(cells).unwrap();
+        let encoded = page.encode();
+        let decoded = VoxelPage::decode(&encoded).unwrap();
+        assert_eq!(decoded, page);
+        assert_eq!(decoded.encode(), encoded);
+        assert_eq!(decoded.page_id(), page.page_id());
+    }
+}

--- a/crates/subsystems/pulsar_terrain/tests/core_contract.rs
+++ b/crates/subsystems/pulsar_terrain/tests/core_contract.rs
@@ -1,6 +1,6 @@
 use pulsar_terrain::{
-    CellWord, DeterministicGenerator, EditLog, EditMode, EditOp, EditShape,
-    FixedSphereGenerator, NodeState, PageKey, SparseBrickTree, VoxelPage,
+    CellWord, DeterministicGenerator, EditLog, EditMode, EditOp, EditShape, FixedSphereGenerator,
+    NodeState, PageKey, PlanetId, SparseBrickTree, TerrainCore, VoxelPage,
 };
 
 fn sphere() -> FixedSphereGenerator {
@@ -36,6 +36,34 @@ fn edit_order_is_deterministic_and_changes_page_hash() {
 }
 
 #[test]
+fn identical_core_inputs_produce_identical_hierarchy_page_and_snapshot_hashes() {
+    let build = || {
+        let mut core = TerrainCore::new(PlanetId([7; 16]), 12, sphere()).unwrap();
+        for sequence in 1..=3_u64 {
+            core.append_edit(EditOp {
+                sequence,
+                stable_id: [sequence as u8; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [sequence as i64 * 3, 8, -4],
+                    radius_cells: sequence as u32 + 1,
+                },
+                mode: EditMode::Subtract,
+                material: 0,
+            })
+            .unwrap();
+        }
+        let page = core.compact_page(PageKey::new(0, [0, 0, -1])).unwrap();
+        (
+            page.page_id,
+            core.hierarchy().content_hash(),
+            core.snapshot().content_hash().unwrap(),
+        )
+    };
+
+    assert_eq!(build(), build());
+}
+
+#[test]
 fn billion_cell_logical_region_cost_depends_on_touched_paths() {
     let mut tree = SparseBrickTree::centered(24, NodeState::Procedural(sphere().hash())).unwrap();
     for index in 0..128 {
@@ -54,7 +82,10 @@ fn billion_cell_logical_region_cost_depends_on_touched_paths() {
 fn cell_word_layout_is_exactly_four_bytes() {
     assert_eq!(std::mem::size_of::<CellWord>(), 4);
     let word = CellWord::new(-123, 17, 9);
-    assert_eq!((word.density(), word.material(), word.flags()), (-123, 17, 9));
+    assert_eq!(
+        (word.density(), word.material(), word.flags()),
+        (-123, 17, 9)
+    );
 }
 
 fn next_random(state: &mut u64) -> u64 {
@@ -76,9 +107,7 @@ fn randomized_sparse_hierarchy_matches_a_dense_reference_fixture() {
     for operation in 0..512 {
         let lod = (next_random(&mut random) % 4) as u8;
         let half = 1_i64 << (ROOT_LOD - 1 - lod);
-        let coordinate = |random: &mut u64| {
-            (next_random(random) % (2 * half) as u64) as i64 - half
-        };
+        let coordinate = |random: &mut u64| (next_random(random) % (2 * half) as u64) as i64 - half;
         let key = PageKey::new(
             lod,
             [
@@ -127,7 +156,10 @@ fn randomized_sparse_hierarchy_matches_a_dense_reference_fixture() {
     assert_eq!(decoded, tree);
     tree.set_root(NodeState::Solid(9)).unwrap();
     assert_eq!(tree.node_count(), 1);
-    assert_eq!(tree.resolve(PageKey::new(0, [-16; 3])).unwrap(), NodeState::Solid(9));
+    assert_eq!(
+        tree.resolve(PageKey::new(0, [-16; 3])).unwrap(),
+        NodeState::Solid(9)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Milestone

Implements the authoritative renderer-independent sparse planetary terrain core from #306 and the architecture tracked by #304.

This is deliberately Milestone 1 only. It does **not** claim the production planet goal is complete, and it does not replace or modify the existing Helio voxel demos.

## What this adds

- exact 10 cm planet-space addressing with signed negative-axis page coordinates
- 32^3 pages, 8^3 microbrick addressing, packed 32-bit cells, and allocation-free uniform pages
- mutable centered sparse brick hierarchy with exact high-level/root overrides and uniform collapse
- deterministic integer procedural generator contract
- ordered Union/Subtract/Replace/Paint edits with stable IDs, canonical encoding, and schedule-independent replay
- one-reference-per-edit sparse hierarchy attachment; page replay walks only root/ancestor candidates
- incremental page compaction and conservative thin-feature LOD reduction
- canonical page/hierarchy/edit/snapshot codecs and SHA-256 content identities
- content-addressed `engine_fs::virtual_fs` persistence with staged root publication and recovery fallback
- explicit work/memory/attachment counters
- randomized/property-style contract tests and a release benchmark

## Promotion evidence

- `cargo metadata --locked --format-version 1` — pass
- `cargo test -p pulsar_terrain --locked` — 27 passed, 0 failed
- `cargo clippy -p pulsar_terrain --lib --tests --no-deps --locked -- -D warnings` — pass for the new crate
- dependency boundary scan — no Helio, WGPU, Rapier, editor, or direct `std::fs` dependency/use in `pulsar_terrain`
- `git diff --check` — pass
- `cargo bench -p pulsar_terrain --bench terrain_core --locked` — pass

Latest release benchmark:

```text
terrain_core sparse_touches=10000 nodes=173473 sparse_ms=9.051 dense_sample_cells=2097152 dense_sample_bytes=8388608 dense_fill_ms=1.427 billion_dense_equivalent_bytes=4000000000 edited_page_bytes=6804 resident_dense_bytes=131072 generated_cells=32768 edit_attachment_regions=1 edit_attachment_refs=1 edit_candidates_replayed=1 edit_compact_ms=2.660 edit_radius_cells=[1,10,100,1000] edit_aabb_pages=[8,8,512,262144] root_delete_us=0.900
```

The timing row is a local microbenchmark, not a claim about final planet rendering. The structural gates are the important result: untouched logical volume is not walked/materialized, every edit has one sparse attachment, page replay visits only ancestor candidates, and whole-root deletion replaces one node.

## Existing warnings

The workspace emits pre-existing warnings from WGPUI/editor/engine dependencies. They are unchanged by this PR. The new terrain crate passes strict crate-local Clippy.

## Out of scope / next milestones

- Helio resident-page cache and GPU extraction
- view-driven streaming and real-radius camera-local rendering
- terrain component/editor tooling
- collision, detached bodies, replication, and production hardening

Closes #306