### PR TITLE
Add headless runtime reflection support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,6 @@ name = "engine_class_derive"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
- "pulsar_reflection",
  "quote",
  "syn 2.0.118",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,8 @@ window_manager                     = { path = "crates/core/window_manager" }
 pulsar_game                        = { path = "crates/core/pulsar_game" }
 pulsar_core                        = { path = "crates/core/pulsar_core" }
 pulsar_ecs                         = { path = "crates/core/pulsar_ecs" }
-pulsar_reflection                  = { path = "crates/core/pulsar_reflection" }
+# Runtime-safe baseline; UI and renderer consumers opt into their integrations locally.
+pulsar_reflection                  = { path = "crates/core/pulsar_reflection", default-features = false, features = ["prims-core", "prims-std"] }
 pulsar_events                      = { path = "crates/core/pulsar_events" }
 engine_class_derive                = { path = "crates/core/engine_class_derive" }
 pulsar_scene                       = { path = "crates/subsystems/pulsar_scene" }

--- a/crates/core/engine_backend/Cargo.toml
+++ b/crates/core/engine_backend/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = { workspace = true }
 dashmap = { workspace = true }
 
 # Reflection system
-pulsar_reflection.workspace = true
+pulsar_reflection = { workspace = true, features = ["ui", "prims-glam", "prims-helio"] }
 pulsar_events.workspace = true
 engine_state.workspace = true
 

--- a/crates/core/engine_class_derive/Cargo.toml
+++ b/crates/core/engine_class_derive/Cargo.toml
@@ -10,7 +10,6 @@ proc-macro = true
 syn = { workspace = true, features = ["full", "extra-traits"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
-pulsar_reflection = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/core/plugin_editor_api/Cargo.toml
+++ b/crates/core/plugin_editor_api/Cargo.toml
@@ -19,7 +19,7 @@ ui.workspace = true
 engine_subsystems = { workspace = true }
 
 # Reflection system (for EngineClass — plugin components use full reflection)
-pulsar_reflection = { workspace = true }
+pulsar_reflection = { workspace = true, features = ["ui"] }
 [build-dependencies]
 tracing = { workspace = true }
 

--- a/crates/core/pulsar_reflection/Cargo.toml
+++ b/crates/core/pulsar_reflection/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-default = ["prims-core", "prims-std", "prims-glam", "prims-helio"]
+default = ["ui", "prims-core", "prims-std", "prims-glam", "prims-helio"]
+ui = ["dep:gpui-ce", "dep:ui"]
 prims-core = []
 prims-std = ["prims-core"]
 prims-serde = ["prims-std"]
@@ -22,8 +23,8 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 dashmap = { workspace = true }
 glam = { workspace = true, features = ["serde"], optional = true }
 helio = { workspace = true, optional = true }
-gpui-ce.workspace = true
-ui = { workspace = true }
+gpui-ce = { workspace = true, optional = true }
+ui = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/core/pulsar_reflection/src/lib.rs
+++ b/crates/core/pulsar_reflection/src/lib.rs
@@ -29,6 +29,7 @@ pub mod dynamic_types;
 pub mod json_codec;
 pub mod runtime_registry;
 pub mod runtime_types;
+#[cfg(feature = "ui")]
 pub mod type_renderer;
 pub mod type_traits;
 
@@ -39,6 +40,7 @@ use serde_json::Value;
 use std::any::{Any, TypeId};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+#[cfg(feature = "ui")]
 use std::sync::Arc;
 
 // Re-export for convenience
@@ -62,6 +64,7 @@ pub use dynamic_types::{
 };
 
 // Re-export type renderer system
+#[cfg(feature = "ui")]
 pub use type_renderer::{
     RenderResult, TYPE_RENDERER_REGISTRY, TypeRenderer, TypeRendererRegistration,
     TypeRendererRegistry, register_type_renderer,
@@ -75,6 +78,7 @@ pub use pulsar_reflection_derive::{Reflectable, pulsar_type};
 /// Widget state is carried as a type-erased map so the reflection crate has
 /// zero knowledge of what widget types exist.  Each render function retrieves
 /// its own stateful entity by concrete type via [`get_widget`].
+#[cfg(feature = "ui")]
 pub struct PropertyEditorArgs<'a> {
     pub id_prefix: &'a str,
     pub class_name: &'a str,
@@ -87,6 +91,7 @@ pub struct PropertyEditorArgs<'a> {
     pub on_enum_select: Arc<dyn Fn(usize, &mut gpui::Window, &mut gpui::App) + Send + Sync>,
 }
 
+#[cfg(feature = "ui")]
 impl<'a> PropertyEditorArgs<'a> {
     pub fn get_widget<T: std::any::Any + Clone>(&self) -> Option<T> {
         self.widgets
@@ -117,6 +122,7 @@ impl<'a> PropertyEditorArgs<'a> {
 /// Only submit function pointers whose actual Rust type matches the above
 /// signature.  The transmute in `ui_common` is safe by construction as long as
 /// this invariant is upheld.
+#[cfg(feature = "ui")]
 pub struct UiPropertyEditorHint {
     /// [`TypeId`](std::any::TypeId) of the type this editor handles.
     pub type_id: std::any::TypeId,
@@ -125,6 +131,7 @@ pub struct UiPropertyEditorHint {
     pub fn_ptr: fn(),
 }
 
+#[cfg(feature = "ui")]
 inventory::collect!(UiPropertyEditorHint);
 
 /// Erase a two-argument render function to the opaque `fn()` stored in
@@ -137,6 +144,7 @@ inventory::collect!(UiPropertyEditorHint);
 ///
 /// This is a `const fn` so it can be called inside `inventory::submit!`
 /// static initialisers emitted by proc macros.
+#[cfg(feature = "ui")]
 pub const fn erase_property_editor_fn_ptr(
     f: fn(&PropertyEditorArgs<'_>, &gpui::App) -> gpui::AnyElement,
 ) -> fn() {

--- a/crates/core/pulsar_reflection/src/prims/core/bool.rs
+++ b/crates/core/pulsar_reflection/src/prims/core/bool.rs
@@ -2,11 +2,16 @@
 
 use crate::pulsar_type;
 
-#[pulsar_type(
+#[cfg_attr(feature = "ui", pulsar_type(
     serialize_json_with = serialize_bool_json,
     deserialize_json_with = deserialize_bool_json,
     editor = render_bool_editor
-)]
+))]
+#[cfg_attr(not(feature = "ui"), pulsar_type(
+    serialize_json_with = serialize_bool_json,
+    deserialize_json_with = deserialize_bool_json
+))]
+#[allow(dead_code)]
 type RegisteredBool = bool;
 
 fn serialize_bool_json(value: &bool) -> crate::ReflectResult<serde_json::Value> {
@@ -22,6 +27,7 @@ fn deserialize_bool_json(value: serde_json::Value) -> crate::ReflectResult<bool>
         })
 }
 
+#[cfg(feature = "ui")]
 fn render_bool_editor(args: &crate::PropertyEditorArgs<'_>, cx: &gpui::App) -> gpui::AnyElement {
     use gpui::{prelude::*, *};
     use ui::{ActiveTheme, Sizable, h_flex, switch::Switch};

--- a/crates/core/pulsar_reflection/src/prims/core/color.rs
+++ b/crates/core/pulsar_reflection/src/prims/core/color.rs
@@ -1,11 +1,16 @@
 //! [f32; 4] primitive type implementation (Color)
 use crate::pulsar_type;
 
-#[pulsar_type(
+#[cfg_attr(feature = "ui", pulsar_type(
     serialize_json_with = serialize_color_json,
     deserialize_json_with = deserialize_color_json,
     editor = render_color_editor
-)]
+))]
+#[cfg_attr(not(feature = "ui"), pulsar_type(
+    serialize_json_with = serialize_color_json,
+    deserialize_json_with = deserialize_color_json
+))]
+#[allow(dead_code)]
 type RegisteredColor = [f32; 4];
 
 fn serialize_color_json(value: &[f32; 4]) -> crate::ReflectResult<serde_json::Value> {
@@ -35,6 +40,7 @@ fn deserialize_color_json(value: serde_json::Value) -> crate::ReflectResult<[f32
     ])
 }
 
+#[cfg(feature = "ui")]
 fn render_color_editor(args: &crate::PropertyEditorArgs<'_>, cx: &gpui::App) -> gpui::AnyElement {
     use gpui::{Corner, prelude::*, *};
     use ui::{ActiveTheme, color_picker::ColorPicker, h_flex};

--- a/crates/core/pulsar_reflection/src/prims/core/f32.rs
+++ b/crates/core/pulsar_reflection/src/prims/core/f32.rs
@@ -2,11 +2,16 @@
 
 use crate::pulsar_type;
 
-#[pulsar_type(
+#[cfg_attr(feature = "ui", pulsar_type(
     serialize_json_with = serialize_f32_json,
     deserialize_json_with = deserialize_f32_json,
     editor = render_f32_editor
-)]
+))]
+#[cfg_attr(not(feature = "ui"), pulsar_type(
+    serialize_json_with = serialize_f32_json,
+    deserialize_json_with = deserialize_f32_json
+))]
+#[allow(dead_code)]
 type RegisteredF32 = f32;
 
 fn serialize_f32_json(value: &f32) -> crate::ReflectResult<serde_json::Value> {
@@ -23,6 +28,7 @@ fn deserialize_f32_json(value: serde_json::Value) -> crate::ReflectResult<f32> {
         })
 }
 
+#[cfg(feature = "ui")]
 fn render_f32_editor(args: &crate::PropertyEditorArgs<'_>, cx: &gpui::App) -> gpui::AnyElement {
     use gpui::{prelude::*, *};
     use ui::{ActiveTheme, Sizable, h_flex, input::NumberInput};

--- a/crates/core/pulsar_reflection/src/prims/core/i32.rs
+++ b/crates/core/pulsar_reflection/src/prims/core/i32.rs
@@ -2,11 +2,16 @@
 
 use crate::pulsar_type;
 
-#[pulsar_type(
+#[cfg_attr(feature = "ui", pulsar_type(
     serialize_json_with = serialize_i32_json,
     deserialize_json_with = deserialize_i32_json,
     editor = render_i32_editor
-)]
+))]
+#[cfg_attr(not(feature = "ui"), pulsar_type(
+    serialize_json_with = serialize_i32_json,
+    deserialize_json_with = deserialize_i32_json
+))]
+#[allow(dead_code)]
 type RegisteredI32 = i32;
 
 fn serialize_i32_json(value: &i32) -> crate::ReflectResult<serde_json::Value> {
@@ -23,6 +28,7 @@ fn deserialize_i32_json(value: serde_json::Value) -> crate::ReflectResult<i32> {
         })
 }
 
+#[cfg(feature = "ui")]
 fn render_i32_editor(args: &crate::PropertyEditorArgs<'_>, cx: &gpui::App) -> gpui::AnyElement {
     use gpui::{prelude::*, *};
     use ui::{ActiveTheme, Sizable, h_flex, input::NumberInput};

--- a/crates/core/pulsar_reflection/src/prims/core/vec3.rs
+++ b/crates/core/pulsar_reflection/src/prims/core/vec3.rs
@@ -2,11 +2,16 @@
 
 use crate::pulsar_type;
 
-#[pulsar_type(
+#[cfg_attr(feature = "ui", pulsar_type(
     serialize_json_with = serialize_vec3_json,
     deserialize_json_with = deserialize_vec3_json,
     editor = render_vec3_editor
-)]
+))]
+#[cfg_attr(not(feature = "ui"), pulsar_type(
+    serialize_json_with = serialize_vec3_json,
+    deserialize_json_with = deserialize_vec3_json
+))]
+#[allow(dead_code)]
 type RegisteredVec3 = [f32; 3];
 
 fn serialize_vec3_json(value: &[f32; 3]) -> crate::ReflectResult<serde_json::Value> {
@@ -35,6 +40,7 @@ fn deserialize_vec3_json(value: serde_json::Value) -> crate::ReflectResult<[f32;
     ])
 }
 
+#[cfg(feature = "ui")]
 fn render_vec3_editor(args: &crate::PropertyEditorArgs<'_>, cx: &gpui::App) -> gpui::AnyElement {
     use gpui::{prelude::*, *};
     use ui::{ActiveTheme, h_flex};

--- a/crates/core/pulsar_reflection/src/prims/glam/mat4.rs
+++ b/crates/core/pulsar_reflection/src/prims/glam/mat4.rs
@@ -33,4 +33,5 @@ fn deserialize_mat4_json(value: serde_json::Value) -> crate::ReflectResult<glam:
     serialize_json_with = serialize_mat4_json,
     deserialize_json_with = deserialize_mat4_json
 )]
+#[allow(dead_code)]
 type RegisteredMat4 = glam::Mat4;

--- a/crates/core/pulsar_reflection_derive/src/pulsar_type.rs
+++ b/crates/core/pulsar_reflection_derive/src/pulsar_type.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Expr, Item, ItemType, Meta, Path, parse_macro_input, punctuated::Punctuated};
+use syn::{Item, ItemType, Meta, Path, parse_macro_input, punctuated::Punctuated};
 
 use crate::util;
 

--- a/crates/core/pulsar_reflection_derive/src/struct_impl.rs
+++ b/crates/core/pulsar_reflection_derive/src/struct_impl.rs
@@ -1,5 +1,5 @@
 use quote::quote;
-use syn::{DataStruct, Fields, Ident, ImplGenerics, TypeGenerics, WhereClause, parse_quote};
+use syn::{DataStruct, Fields, Ident, ImplGenerics, TypeGenerics, WhereClause};
 
 use crate::field_info;
 

--- a/crates/core/pulsar_reflection_derive/src/util.rs
+++ b/crates/core/pulsar_reflection_derive/src/util.rs
@@ -1,17 +1,4 @@
-use syn::{Attribute, Expr, Ident, LitStr, Path};
-
-pub fn parse_ident_expr(expr: &Expr, arg_name: &str) -> syn::Result<Ident> {
-    if let Expr::Path(path) = expr {
-        if let Some(ident) = path.path.get_ident() {
-            return Ok(ident.clone());
-        }
-    }
-
-    Err(syn::Error::new_spanned(
-        expr,
-        format!("{} must be an identifier", arg_name),
-    ))
-}
+use syn::{Attribute, Expr, LitStr, Path};
 
 pub fn parse_path_expr(expr: &Expr, arg_name: &str) -> syn::Result<Path> {
     if let Expr::Path(path) = expr {

--- a/crates/editor/ui_common/Cargo.toml
+++ b/crates/editor/ui_common/Cargo.toml
@@ -22,7 +22,7 @@ engine_state.workspace = true
 pulsar_auth.workspace = true
 engine_fs.workspace = true
 plugin_editor_api.workspace = true
-pulsar_reflection.workspace = true
+pulsar_reflection = { workspace = true, features = ["ui"] }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "http2", "rustls-no-provider", "system-proxy"] }
 
 [lints]

--- a/crates/editor/ui_core/Cargo.toml
+++ b/crates/editor/ui_core/Cargo.toml
@@ -34,7 +34,7 @@ ui_friends.workspace = true
 engine_state.workspace = true
 engine_backend.workspace = true
 pulsar_physics.workspace = true
-pulsar_reflection.workspace = true
+pulsar_reflection = { workspace = true, features = ["ui"] }
 window_manager.workspace = true
 
 # Plugin system

--- a/crates/editor/ui_level_editor/Cargo.toml
+++ b/crates/editor/ui_level_editor/Cargo.toml
@@ -21,7 +21,7 @@ tool_registry = { workspace = true }
 # Engine
 engine_state.workspace = true
 engine_backend.workspace = true
-pulsar_reflection.workspace = true
+pulsar_reflection = { workspace = true, features = ["ui"] }
 engine_class_derive = { workspace = true }
 pulsar_rendering.workspace = true
 pulsar_physics.workspace = true

--- a/crates/subsystems/pulsar_rendering/Cargo.toml
+++ b/crates/subsystems/pulsar_rendering/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 engine_class_derive = { workspace = true }
-pulsar_reflection = { workspace = true }
+pulsar_reflection = { workspace = true, features = ["ui", "prims-glam", "prims-helio"] }
 pulsar_events = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

- add an explicit UI feature to pulsar_reflection while preserving it in the default feature set
- make GPUI/UI optional for runtime-only reflection consumers
- keep primitive serialization/reflection registrations in headless builds while compiling editor renderers only with UI
- remove the unnecessary pulsar_reflection dependency from the proc-macro crate
- remove stale derive warnings exposed by strict headless validation
- make the workspace reflection dependency a headless runtime baseline
- explicitly opt UI/render consumers into only the integrations they own

Closes #313.

## Compatibility

Default features still enable UI, glam primitives, and Helio primitives, so external callers using pulsar_reflection directly retain the existing behavior.

Inside the workspace, the baseline is now default-features = false with prims-core and prims-std. Rendering and engine_backend explicitly enable UI, glam, and Helio registrations; plugin/editor UI crates explicitly enable UI. Runtime-only ECS and physics consumers therefore no longer resolve the editor or renderer reflection stack.

This is an engine change and is intentionally left for maintainer merge.

## Validation

- cargo clippy -p pulsar_reflection --no-default-features --features prims-core,prims-std --all-targets --locked -- -D warnings
- cargo tree -p pulsar_ecs -e features -i pulsar_reflection --locked: only prims-core and prims-std
- cargo tree -p pulsar_physics -e features -i pulsar_reflection --locked: only prims-core and prims-std
- cargo tree for pulsar_rendering, plugin_editor_api, and engine_backend confirms their explicit UI/render opt-ins
- cargo check -p pulsar_ecs -p pulsar_physics -p pulsar_std -p pulsar_scene -p engine_fs -p pulsar_game --locked
- cargo check -p pulsar_rendering -p plugin_editor_api -p engine_backend -p ui_common -p ui_level_editor -p ui_core --locked
- cargo test -p pulsar_reflection --locked: 190 tests passed, 7 doctests ignored, 0 failures
- all-target ECS validation reaches the existing Rand 0.10 stress-test error at tests/stress.rs:495; the exact thread_rng failure was reproduced on untouched main