### PR TITLE
Add headless virtual filesystem support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ ui-macros    = { path = "crates/ui/wgpui-component/crates/ui-macros" }
 
 # ---------- Core Engine ----------
 profiling                          = { path = "crates/core/profiling" }
-engine_fs                          = { path = "crates/core/engine_fs" }
+engine_fs                          = { path = "crates/core/engine_fs", default-features = false }
 pulsar_std                         = { path = "crates/core/pulsar_std" }
 engine_state                       = { path = "crates/core/engine_state" }
 engine_subsystems                  = { path = "crates/subsystems/engine_subsystems" }

--- a/crates/agent-providers/agent_chat_tools/Cargo.toml
+++ b/crates/agent-providers/agent_chat_tools/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 anyhow = { workspace = true }
 engine_state = { workspace = true }
 serde_json = { workspace = true }
-engine_fs = { workspace = true }
+engine_fs = { workspace = true, features = ["editor"] }
 plugin_manager = { workspace = true }
 tracing.workspace = true
 tool_registry = { workspace = true }

--- a/crates/core/engine_fs/Cargo.toml
+++ b/crates/core/engine_fs/Cargo.toml
@@ -3,31 +3,51 @@ name = "engine_fs"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["editor", "remote", "p2p"]
+editor = [
+    "dep:ui_types_common",
+    "dep:pulsar_reflection",
+    "dep:uuid",
+    "dep:dashmap",
+    "dep:plugin_manager",
+    "dep:plugin_editor_api",
+    "dep:notify",
+    "dep:walkdir",
+    "dep:profiling",
+    "dep:image",
+    "dep:helio-snapshot",
+    "dep:tool_registry",
+    "dep:tool_registry_macros",
+]
+remote = ["dep:urlencoding", "dep:ureq", "dep:base64"]
+p2p = ["dep:pulsar-multiplayer-core", "dep:futures"]
+
 [dependencies]
-ui_types_common = { workspace = true }
-pulsar_reflection = { workspace = true }
-uuid = { workspace = true }
-dashmap = { workspace = true }
-plugin_manager = { workspace = true }
-plugin_editor_api = { workspace = true }
+ui_types_common = { workspace = true, optional = true }
+pulsar_reflection = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
+dashmap = { workspace = true, optional = true }
+plugin_manager = { workspace = true, optional = true }
+plugin_editor_api = { workspace = true, optional = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-notify = { workspace = true }
-walkdir = { workspace = true }
-profiling = { workspace = true }
-image = { workspace = true }
-helio-snapshot = { workspace = true }
+notify = { workspace = true, optional = true }
+walkdir = { workspace = true, optional = true }
+profiling = { workspace = true, optional = true }
+image = { workspace = true, optional = true }
+helio-snapshot = { workspace = true, optional = true }
 parking_lot = { workspace = true }
-urlencoding = { workspace = true }
-ureq = { version = "3.0", features = ["json"] }
-base64 = { workspace = true }
-tool_registry = { workspace = true }
-tool_registry_macros = { workspace = true }
+urlencoding = { workspace = true, optional = true }
+ureq = { version = "3.0", features = ["json"], optional = true }
+base64 = { workspace = true, optional = true }
+tool_registry = { workspace = true, optional = true }
+tool_registry_macros = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync"] }
-futures = { workspace = true }
-pulsar-multiplayer-core = { path = "../pulsar-multiplayer-core" }
+futures = { workspace = true, optional = true }
+pulsar-multiplayer-core = { path = "../pulsar-multiplayer-core", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/core/engine_fs/src/lib.rs
+++ b/crates/core/engine_fs/src/lib.rs
@@ -23,34 +23,48 @@
 //! will automatically target the right backend.
 
 // Module declarations
+#[cfg(feature = "editor")]
 pub mod asset_index;
+#[cfg(feature = "editor")]
 mod engine_fs;
 pub mod events;
+#[cfg(feature = "editor")]
 pub mod operations;
 pub mod providers;
+#[cfg(feature = "editor")]
 mod scanner;
+#[cfg(feature = "editor")]
 pub mod templates;
+#[cfg(feature = "editor")]
 pub mod thumbnails;
+#[cfg(feature = "editor")]
 pub mod tooling;
+#[cfg(feature = "editor")]
 pub mod user_types;
 pub mod virtual_fs;
+#[cfg(feature = "editor")]
 pub mod watchers;
 
 // Re-export main types
+#[cfg(feature = "editor")]
 pub use asset_index::{AssetIndex, AssetInfo};
+#[cfg(feature = "editor")]
 pub use engine_fs::EngineFs;
+#[cfg(feature = "editor")]
 pub use user_types::{UserTypeInfo, UserTypeRegistry};
 
 // Re-export provider types
-pub use providers::{
-    FsEntry, FsMetadata, FsProvider, LocalFsProvider, ManifestEntry, RemoteConfig, RemoteFsProvider,
-};
+pub use providers::{FsEntry, FsMetadata, FsProvider, LocalFsProvider, ManifestEntry};
+#[cfg(feature = "remote")]
+pub use providers::{RemoteConfig, RemoteFsProvider};
 
 // Re-export operations
 pub use events::{emit, subscribe, FsChangeKind, FsEvent};
+#[cfg(feature = "editor")]
 pub use operations::AssetOperations;
 
 // Re-export template types
+#[cfg(feature = "editor")]
 pub use templates::{AssetCategory, AssetKind};
 
 // Re-export commonly used virtual_fs functions
@@ -61,10 +75,21 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    #[cfg(feature = "editor")]
     #[test]
     fn test_engine_fs_creation() {
         let temp_dir = TempDir::new().unwrap();
         let fs = EngineFs::new(temp_dir.path().to_path_buf());
         assert!(fs.is_ok());
+    }
+
+    #[test]
+    fn headless_virtual_fs_keeps_local_provider_operations() {
+        virtual_fs::reset_to_local();
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("headless-vfs.bin");
+        virtual_fs::write_file(&path, b"runtime").unwrap();
+        assert_eq!(virtual_fs::read_file(&path).unwrap(), b"runtime");
+        assert!(virtual_fs::exists(&path).unwrap());
     }
 }

--- a/crates/core/engine_fs/src/providers/mod.rs
+++ b/crates/core/engine_fs/src/providers/mod.rs
@@ -4,12 +4,16 @@
 //! for both local disk and remote (HTTP-based) filesystems.
 
 mod local;
+#[cfg(feature = "p2p")]
 pub mod p2p;
 mod provider_trait;
+#[cfg(feature = "remote")]
 mod remote;
 
 // Re-export all public types
 pub use local::LocalFsProvider;
+#[cfg(feature = "p2p")]
 pub use p2p::P2pFsProvider;
 pub use provider_trait::{FsEntry, FsMetadata, FsProvider, ManifestEntry};
+#[cfg(feature = "remote")]
 pub use remote::{RemoteConfig, RemoteFsProvider};

--- a/crates/core/engine_fs/src/providers/p2p.rs
+++ b/crates/core/engine_fs/src/providers/p2p.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Context as _, Result};
-use std::collections::HashSet;
 use std::future::Future;
 use std::path::Path;
 use std::sync::Arc;
@@ -15,15 +14,11 @@ use crate::events;
 
 pub struct P2pFsProvider {
     channel: Arc<dyn SessionChannel>,
-    project_id: String,
 }
 
 impl P2pFsProvider {
-    pub fn new(channel: Arc<dyn SessionChannel>, project_id: String) -> Self {
-        Self {
-            channel,
-            project_id,
-        }
+    pub fn new(channel: Arc<dyn SessionChannel>, _project_id: String) -> Self {
+        Self { channel }
     }
 
     fn to_rel(&self, path: &Path) -> String {

--- a/crates/core/engine_fs/src/providers/remote.rs
+++ b/crates/core/engine_fs/src/providers/remote.rs
@@ -194,7 +194,15 @@ impl FsProvider for RemoteFsProvider {
             .body_mut()
             .read_json()
             .context("RemoteFs read: JSON parse error")?;
-        decode_b64(&body.content)
+        let bytes = decode_b64(&body.content)?;
+        if bytes.len() as u64 != body.size {
+            bail!(
+                "RemoteFs read returned {} decoded bytes but declared {}",
+                bytes.len(),
+                body.size
+            );
+        }
+        Ok(bytes)
     }
 
     fn write_file(&self, path: &Path, content: &[u8]) -> Result<()> {

--- a/crates/core/engine_fs/tests/p2p_provider_test.rs
+++ b/crates/core/engine_fs/tests/p2p_provider_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "p2p")]
+
 use std::collections::VecDeque;
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/core/engine_state/Cargo.toml
+++ b/crates/core/engine_state/Cargo.toml
@@ -37,7 +37,7 @@ pulsar_auth.workspace = true
 
 # Multiplayer session bridge
 pulsar-multiplayer-core = { path = "../pulsar-multiplayer-core" }
-engine_fs = { workspace = true }
+engine_fs = { workspace = true, features = ["editor"] }
 futures = { workspace = true }
 
 [lints]

--- a/crates/editor/ui_common/Cargo.toml
+++ b/crates/editor/ui_common/Cargo.toml
@@ -20,7 +20,7 @@ smallvec.workspace = true
 smol = { workspace = true }
 engine_state.workspace = true
 pulsar_auth.workspace = true
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["editor"] }
 plugin_editor_api.workspace = true
 pulsar_reflection.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "http2", "rustls-no-provider", "system-proxy"] }

--- a/crates/editor/ui_entry/Cargo.toml
+++ b/crates/editor/ui_entry/Cargo.toml
@@ -13,7 +13,7 @@ ui_common.workspace = true
 engine_state.workspace = true
 engine_backend.workspace = true
 window_manager.workspace = true
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["remote"] }
 pulsar_auth.workspace = true
 ui_git_manager.workspace = true
 ui_friends.workspace = true

--- a/crates/editor/ui_file_manager/Cargo.toml
+++ b/crates/editor/ui_file_manager/Cargo.toml
@@ -15,7 +15,7 @@ ui_common.workspace = true
 ui_types_common.workspace = true
 
 # Engine
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["editor"] }
 engine_state.workspace = true
 tracing.workspace = true
 

--- a/crates/editor/ui_multiplayer/Cargo.toml
+++ b/crates/editor/ui_multiplayer/Cargo.toml
@@ -12,7 +12,7 @@ ui_common.workspace = true
 window_manager.workspace = true
 engine_backend.workspace = true
 engine_state.workspace = true
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["p2p"] }
 serde_json = { workspace = true }
 futures = { workspace = true }
 tracing.workspace = true

--- a/crates/editor/ui_type_debugger/Cargo.toml
+++ b/crates/editor/ui_type_debugger/Cargo.toml
@@ -14,7 +14,7 @@ ui_common.workspace = true
 window_manager.workspace = true
 
 # Engine dependencies
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["editor"] }
 plugin_editor_api.workspace = true
 rust-i18n.workspace = true
 


### PR DESCRIPTION
## Summary

- add explicit `editor`, `remote`, and `p2p` features to `engine_fs` while preserving all existing behavior in the default feature set
- keep the local `virtual_fs` provider and filesystem events available to runtime-only consumers
- allow remote and P2P persistence backends to be selected independently without GPUI, Helio, editor plugins, thumbnails, or tooling
- make the workspace dependency local-only by default and explicitly declare the minimum feature set at every editor/transport consumer
- retain constructor compatibility for the P2P provider while removing unused stored state
- validate remote response lengths before accepting decoded file content

Closes #315.

## Consumer adoption

- Local-only: `engine_backend`, `pulsar_terrain`, `pulsar_scene`, `pulsar_std`, `ui_level_editor`
- Editor surface: `engine_state`, `agent_chat_tools`, `ui_type_debugger`, `ui_file_manager`, `ui_common`
- Remote transport: `ui_entry`
- P2P transport: `ui_multiplayer`

Cargo feature-tree checks confirm terrain receives no optional VFS feature, engine state receives `editor`, cloud entry receives `remote`, and multiplayer receives `p2p`.

## Compatibility

The `engine_fs` package default still enables editor, remote, and P2P surfaces, so existing external engine/editor callers retain their current imports and behavior. In-repository callers now declare the minimum correct surface, and runtime terrain can inherit the local-only workspace baseline.

This is a shared-engine change and is intentionally left for maintainer validation and merge.

## Validation

Focused and consumer checks:

- `cargo test -p engine_fs --no-default-features --locked` — 3 passed
- `cargo clippy -p engine_fs --no-default-features --features remote,p2p --all-targets --locked -- -D warnings` — pass
- runtime dependency tree — no GPUI, UI, Helio, or editor-plugin packages
- `cargo test -p engine_fs --no-default-features --features remote,p2p --locked` — 3 unit + 10 P2P tests passed
- remote-only and P2P-only package checks — pass
- `cargo test -p engine_fs --locked` — 6 unit + 10 P2P tests passed with the default/editor graph
- local/runtime consumers (`pulsar_terrain`, `pulsar_std`, `pulsar_scene`, `engine_backend`) — pass
- editor/transport consumers (`engine_state`, `agent_chat_tools`, `ui_type_debugger`, `ui_file_manager`, `ui_common`, `ui_entry`, `ui_multiplayer`, `ui_level_editor`) — pass
- `git diff --check` — pass

Engine-wide differential check:

- Pulsar CI command: `cargo check --workspace --exclude pulsar_docs --all-targets --locked`
- The repository configuration first requires an unavailable external AWS-LC bindgen CLI on both this branch and untouched `main`.
- With `AWS_LC_SYS_NO_PREFIX=0`, both proceed through the engine graph.
- This branch introduces no VFS or consumer error and reaches only base failures reproduced on untouched `main`: vendored UI test fixture/type mismatches and stale `pulsar_bp_executor` tests against Graphy's current API.

Existing broad workspace warnings and those confirmed base failures are unchanged by this PR.