### PR TITLE
Remove checked category unwrap from engine class macro

### DIFF
--- a/crates/core/engine_class_derive/src/lib.rs
+++ b/crates/core/engine_class_derive/src/lib.rs
@@ -370,11 +370,11 @@ pub fn engine_class(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! { #[derive(#(#derive_additions),*)] }
     };
 
-    let category_attr = if category.is_some() && !has_engine_class_category_attr {
-        let cat = category.unwrap();
-        quote! { #[engine_class_category(#cat)] }
-    } else {
-        quote! {}
+    let category_attr = match category {
+        Some(category) if !has_engine_class_category_attr => {
+            quote! { #[engine_class_category(#category)] }
+        }
+        _ => quote! {},
     };
 
     let no_register_attr = if no_register {


### PR DESCRIPTION
## Summary

Replace the checked `Option::unwrap` in `#[engine_class]` category handling with a guarded `match` that moves the category token directly into the generated attribute.

Fixes #317.

## Behavior and caller audit

The generated output is unchanged:

- `Some(category)` without an existing `#[engine_class_category]` emits `#[engine_class_category(category)]`
- an existing category attribute is not duplicated
- no category emits nothing

Direct macro consumers were identified from workspace manifests and all compile:

- `pulsar_rendering`
- `pulsar_physics`
- `ui_level_editor`

## Validation

- `cargo fmt --check -p engine_class_derive` — pass
- `cargo test -p engine_class_derive --locked` — pass (unit target + doctest target; one documented doctest ignored by the crate)
- `cargo clippy -p engine_class_derive --all-targets --no-deps --locked -- -D warnings` — pass for the affected crate
- `cargo check -p pulsar_rendering -p pulsar_physics -p ui_level_editor --locked` — pass

The broader workspace emits existing warnings from WGPUI/reflection/editor dependencies; this PR introduces none and does not modify those crates.

## Merge ownership

Shared engine change: validated and ready for maintainer review/merge. Codex will not merge it.