### PR TITLE
fix(lsp): preserve absolute paths when decoding file:// URIs

### DIFF
--- a/crates/core/pulsar_lsp/src/rust_analyzer/mod.rs
+++ b/crates/core/pulsar_lsp/src/rust_analyzer/mod.rs
@@ -6,7 +6,7 @@
 //! components can subscribe to indexing progress and diagnostics.
 
 mod path_utils;
-pub use path_utils::path_to_uri;
+pub use path_utils::{path_to_uri, uri_to_path};
 
 use anyhow::{anyhow, Result};
 use gpui::{Context, EventEmitter, Window};
@@ -1181,7 +1181,7 @@ impl RustAnalyzerManager {
         if let Some(params) = msg.get("params") {
             if let Some(diagnostics_array) = params.get("diagnostics").and_then(|d| d.as_array()) {
                 if let Some(uri) = params.get("uri").and_then(|u| u.as_str()) {
-                    let file_path = uri.trim_start_matches("file:///").replace("%20", " ");
+                    let file_path = path_utils::uri_to_path(uri);
                     let diagnostics: Vec<Diagnostic> = diagnostics_array
                         .iter()
                         .filter_map(|diag| Self::parse_diagnostic(diag, &file_path))
@@ -1279,7 +1279,7 @@ impl RustAnalyzerManager {
         if let Some(changes) = edit.get("changes").and_then(|c| c.as_object()) {
             for (edit_uri, edit_array) in changes {
                 if let Some(edit_list) = edit_array.as_array() {
-                    let edit_file = edit_uri.trim_start_matches("file:///").replace("%20", " ");
+                    let edit_file = path_utils::uri_to_path(edit_uri);
                     for text_edit in edit_list {
                         if let Some(te) = Self::parse_text_edit(text_edit, &edit_file) {
                             edits.push(te);
@@ -1297,7 +1297,7 @@ impl RustAnalyzerManager {
                     let edit_file = text_doc
                         .get("uri")
                         .and_then(|u| u.as_str())
-                        .map(|u| u.trim_start_matches("file:///").replace("%20", " "))
+                        .map(path_utils::uri_to_path)
                         .unwrap_or_default();
 
                     if let Some(edit_list) = doc_change.get("edits").and_then(|e| e.as_array()) {
@@ -1345,9 +1345,7 @@ impl RustAnalyzerManager {
                                     let info_uri = location
                                         .get("uri")
                                         .and_then(|u| u.as_str())
-                                        .map(|u| {
-                                            u.trim_start_matches("file:///").replace("%20", " ")
-                                        })
+                                        .map(path_utils::uri_to_path)
                                         .unwrap_or_else(|| file_path.to_string());
 
                                     let edit = TextEdit {
@@ -2003,13 +2001,7 @@ impl RustAnalyzerManager {
 
     /// Convert a file URI to a local path string.
     fn uri_to_path(uri: &str) -> String {
-        let path = uri.trim_start_matches("file:///");
-        path.replace("%20", " ")
-            .replace("%3A", ":")
-            .replace("%5C", "\\")
-            .replace("%2F", "/")
-            .replace("%23", "#")
-            .replace("%25", "%")
+        path_utils::uri_to_path(uri)
     }
 
     /// Return unresolved code actions (have `data` but no `edit`).

--- a/crates/core/pulsar_lsp/src/rust_analyzer/path_utils.rs
+++ b/crates/core/pulsar_lsp/src/rust_analyzer/path_utils.rs
@@ -15,6 +15,48 @@ pub fn path_to_uri(path: &Path) -> String {
     }
 }
 
+/// Convert an LSP `file://` URI back to a local path string.
+///
+/// The inverse of [`path_to_uri`]: preserves the root slash of Unix absolute
+/// paths (`file:///Users/x` → `/Users/x`), strips the extra slash before
+/// Windows drive letters (`file:///C:/x` → `C:/x`), and percent-decodes all
+/// escapes, not just `%20`.
+pub fn uri_to_path(uri: &str) -> String {
+    let raw = uri.strip_prefix("file://").unwrap_or(uri);
+    let decoded = percent_decode(raw);
+
+    // Windows drive-letter URIs arrive as /C:/… — drop the authority slash.
+    let bytes = decoded.as_bytes();
+    if bytes.len() >= 3 && bytes[0] == b'/' && bytes[1].is_ascii_alphabetic() && bytes[2] == b':' {
+        decoded[1..].to_string()
+    } else {
+        decoded
+    }
+}
+
+/// Single-pass percent-decoding; invalid escapes pass through unchanged.
+fn percent_decode(input: &str) -> String {
+    fn hex_val(b: u8) -> Option<u8> {
+        (b as char).to_digit(16).map(|v| v as u8)
+    }
+
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push(hi * 16 + lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -30,5 +72,48 @@ mod tests {
     fn test_unix_path() {
         let path = PathBuf::from("/home/user/file.rs");
         assert_eq!(path_to_uri(&path), "file:///home/user/file.rs");
+    }
+
+    #[test]
+    fn uri_to_path_preserves_unix_root_slash() {
+        // #242: stripping "file:///" ate the leading slash, turning absolute
+        // paths relative — the diagnostics panel then couldn't open the file.
+        assert_eq!(
+            uri_to_path("file:///Users/tristan/project/src/mod.rs"),
+            "/Users/tristan/project/src/mod.rs"
+        );
+    }
+
+    #[test]
+    fn uri_to_path_strips_slash_before_windows_drive() {
+        assert_eq!(
+            uri_to_path("file:///C:/Users/test/file.rs"),
+            "C:/Users/test/file.rs"
+        );
+    }
+
+    #[test]
+    fn uri_to_path_decodes_all_percent_escapes() {
+        assert_eq!(
+            uri_to_path("file:///C%3A/Users/a%20b/file.rs"),
+            "C:/Users/a b/file.rs"
+        );
+        assert_eq!(
+            uri_to_path("file:///home/user/caf%C3%A9/%2525.rs"),
+            "/home/user/café/%25.rs"
+        );
+    }
+
+    #[test]
+    fn uri_to_path_round_trips_with_path_to_uri() {
+        for original in ["/home/user/file.rs", "C:/Users/test/file.rs"] {
+            let uri = path_to_uri(&PathBuf::from(original));
+            assert_eq!(uri_to_path(&uri), original);
+        }
+    }
+
+    #[test]
+    fn uri_to_path_passes_through_invalid_escapes() {
+        assert_eq!(uri_to_path("file:///tmp/50%25done%Zq.rs"), "/tmp/50%done%Zq.rs");
     }
 }


### PR DESCRIPTION
Fixes #242

## Root cause

Every LSP URI→path conversion in `pulsar_lsp` stripped `file:///` wholesale:

```rust
let file_path = uri.trim_start_matches("file:///").replace("%20", " ");
```

On macOS/Linux this eats the root slash of absolute paths — `file:///Users/x/mod.rs` becomes `Users/x/mod.rs`, a *relative* path. That single defect explains all three screenshots in the issue:

1. The panel header displays `Users/tristanpoland/...` (no leading slash) — the corrupted path, visible in the issue's third screenshot.
2. Clicking the diagnostic sends that relative path to the script editor, which can't resolve it → file never opens.
3. The workspace root derived from the relative path doesn't exist, so `Command::current_dir(...).spawn()` for rust-analyzer fails → the "Failed to spawn after installation: No such file or directory (os error 2)" toast.

Windows survived by accident (`file:///C:/...` → `C:/...` is still absolute), which is why the panel worked there. Percent-decoding was also incomplete everywhere: four sites decoded only `%20`; a fifth had an ad-hoc escape list — none handled arbitrary `%XX` or multi-byte UTF-8.

## Fix

One correct, tested `path_utils::uri_to_path` — the inverse of the existing `path_to_uri`:

- preserves the Unix root slash (`file:///Users/x` → `/Users/x`)
- strips only the authority slash before Windows drive letters (`/C:/x` → `C:/x`)
- percent-decodes all escapes in a single pass, at the byte level (multi-byte UTF-8 safe; invalid escapes pass through)

All five hand-rolled sites in `rust_analyzer/mod.rs` now delegate to it.

## Verification

- TDD: 5 new unit tests written first and watched fail (the failure output reproduces the screenshot verbatim: `left: "Users/tristan/..."` vs `right: "/Users/tristan/..."`), then pass — including `path_to_uri` round-trips for both platforms.
- `cargo test -p pulsar_lsp --lib`: 7 passed, 0 failed. `cargo check -p pulsar_lsp -p ui_core` clean.
- Note: the pre-fix failure is not reproducible on Windows (drive-letter URIs accidentally survived the old code), so the in-editor repro should be confirmed on macOS/Linux — @tristanpoland's setup matches the affected path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
