### PR TITLE
Add SceneDB telemetry HTTP snapshot server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9187,7 +9187,9 @@ dependencies = [
  "pulsar_core",
  "pulsar_reflection",
  "rand 0.8.7",
+ "serde",
  "serde_json",
+ "socket2 0.5.10",
  "tracing",
  "wgpu 30.0.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ log = "0.4.29"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_repr = "0.1.20"
 serde_json = "1.0.149"
+socket2 = "0.5"
 schemars = "1.2.0"
 smallvec = "1.15.1"
 image = { version = "0.25.9", default-features = false, features = ["png", "jpeg", "bmp", "tga", "gif", "webp"] }

--- a/crates/core/pulsar_scenedb/Cargo.toml
+++ b/crates/core/pulsar_scenedb/Cargo.toml
@@ -7,6 +7,7 @@ description = "SceneDB 2.0 — engine-wide spatial database (Layer 1 storage cor
 [features]
 default = []
 gpu = ["dep:wgpu"]
+telemetry = ["dep:socket2", "dep:serde", "gpu"]
 
 [dependencies]
 pulsar_core       = { workspace = true }
@@ -37,6 +38,8 @@ pulsar_core       = { workspace = true }
 # remains the workspace dep for legacy consumers until the M4 gate.
 pulsar_reflection = { workspace = true }
 serde_json        = { workspace = true }
+socket2           = { workspace = true, optional = true }
+serde             = { workspace = true, optional = true }
 ahash             = "0.8"
 profiling         = { workspace = true }
 tracing           = { workspace = true }

--- a/crates/core/pulsar_scenedb/src/cell.rs
+++ b/crates/core/pulsar_scenedb/src/cell.rs
@@ -363,11 +363,35 @@ impl CellStorage {
         self.page.column_slice_mut::<T>(user_col + 1)
     }
 
+    /// Access the token→user-column index (telemetry).
+    pub(crate) fn token_index_slice(&self) -> &[(ComponentId, usize)] {
+        &self.token_index
+    }
+
+    /// Access the generic-column index (telemetry).
+    pub(crate) fn generic_token_index_slice(&self) -> &[(ComponentId, TypeId, usize)] {
+        &self.generic_token_index
+    }
+
+    /// Number of user columns (telemetry).
+    pub(crate) fn user_column_count(&self) -> usize {
+        self.user_column_count
+    }
+
+    /// Column capacity (telemetry).
+    pub(crate) fn capacity(&self) -> u32 {
+        self.page.layout().capacity()
+    }
+
+    /// Element size of a physical column (telemetry).
+    pub(crate) fn column_size_pub(&self, col: usize) -> usize {
+        self.column_size(col)
+    }
+
     pub fn live_count(&self) -> u32 {
         self.liveness.live_count()
     }
 
-    /// Physical rows currently occupied (live + not-yet-compacted dead).
     pub fn rows_in_use(&self) -> u32 {
         self.page.len()
     }

--- a/crates/core/pulsar_scenedb/src/gpu/region.rs
+++ b/crates/core/pulsar_scenedb/src/gpu/region.rs
@@ -72,6 +72,11 @@ impl RegionPool {
     pub fn free_count(&self) -> u32 {
         self.free.len() as u32
     }
+
+    /// Total number of regions this pool manages (allocated + free + pinned).
+    pub fn total_regions(&self) -> u32 {
+        self.count
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/pulsar_scenedb/src/gpu/scene_store.rs
+++ b/crates/core/pulsar_scenedb/src/gpu/scene_store.rs
@@ -108,29 +108,29 @@ enum Phase {
     Compacted,
 }
 
-struct QueuedRetire {
-    pending: PendingRetire,
-    serial: u64,
+pub(crate) struct QueuedRetire {
+    pub(crate) pending: PendingRetire,
+    pub(crate) serial: u64,
 }
 
 /// Per-cell GPU-side bookkeeping: the region assignment, the dirty state
 /// that used to live on `GpuStore` directly (M2a), and the deferred-retire
 /// queue (now one per cell rather than store-wide).
-struct CellGpuState {
+pub(crate) struct CellGpuState {
     /// Size class this cell was registered under (M2b-β `unregister_cell`:
     /// selects which `row_pools`/`slot_pools` entry to return the region
     /// pair to at eviction).
-    class: usize,
-    row_base: u32,
-    slot_base: u32,
+    pub(crate) class: usize,
+    pub(crate) row_base: u32,
+    pub(crate) slot_base: u32,
     /// Class capacity + headroom; bounds every gen/slot write into this
     /// cell's region.
-    slot_capacity: u32,
+    pub(crate) slot_capacity: u32,
     /// Per-column dirty masks keyed by `ComponentId`.  Replaces the old
     /// named `dirty_transforms` / `dirty_infos` fields (pre-work item 2).
     /// The slot-mirror dirty mask (`dirty_slots`) is kept separate because
     /// it is driven by the self-healing boundary scan, not by column writes.
-    dirty_columns: HashMap<ComponentId, DirtyMask>,
+    pub(crate) dirty_columns: HashMap<ComponentId, DirtyMask>,
     dirty_slots: DirtyMask,
     /// Per-row global-slot staging. `sync_all`'s self-healing boundary scan
     /// is scan-first, not dirty-mask-first: it compares `slot_shadow` against
@@ -151,7 +151,7 @@ struct CellGpuState {
     slot_shadow: Vec<u32>,
     /// Per-cell deferred-retire queue; nondecreasing serials (debug-asserted,
     /// T11).
-    pending: VecDeque<QueuedRetire>,
+    pub(crate) pending: VecDeque<QueuedRetire>,
     /// CPU-side shadow of the last generation uploaded per LOCAL slot (§4
     /// delta-minimality on the write path), seeded from the registry at
     /// `register_cell`. Atomic because `write_transform` takes `&self`.
@@ -939,5 +939,27 @@ impl SceneGpuStore {
     /// Per-cell metadata SSBO (α: allocated, no writer).
     pub fn cell_metadata_buffer(&self) -> &wgpu::Buffer {
         &self.cell_metadata
+    }
+
+    // ── Telemetry / snapshot accessors (pub(crate)) ──────────────────────
+
+    /// GPU buffers map for telemetry snapshot.
+    pub(crate) fn telemetry_gpu_buffers(&self) -> &HashMap<ComponentId, Box<dyn GpuBufferDispatch>> {
+        &self.gpu_buffers
+    }
+
+    /// Row region pools for telemetry snapshot.
+    pub(crate) fn telemetry_row_pools(&self) -> &[RegionPool] {
+        &self.row_pools
+    }
+
+    /// Slot region pools for telemetry snapshot.
+    pub(crate) fn telemetry_slot_pools(&self) -> &[RegionPool] {
+        &self.slot_pools
+    }
+
+    /// Per-cell GPU state for telemetry snapshot.
+    pub(crate) fn telemetry_cells(&self) -> &[Option<CellGpuState>] {
+        &self.cells
     }
 }

--- a/crates/core/pulsar_scenedb/src/lib.rs
+++ b/crates/core/pulsar_scenedb/src/lib.rs
@@ -89,6 +89,9 @@ pub mod world;
 #[cfg(feature = "gpu")]
 pub mod gpu;
 
+#[cfg(feature = "telemetry")]
+pub mod telemetry;
+
 pub use actor::{Actor, ActorRegistry};
 pub use archetype::{Archetype, ArchetypeId, ArchetypeKey};
 pub use cell::CellStorage;
@@ -116,3 +119,6 @@ pub use spatial::{
 pub use gpu::{GpuBufferDispatch, GpuColumnDesc, GpuColumnSet, MirrorMode};
 pub use token::{HasTypeToken, TypeToken};
 pub use world::World;
+
+#[cfg(feature = "telemetry")]
+pub use telemetry::{TelemetryServer, TelemetrySnapshot};

--- a/crates/core/pulsar_scenedb/src/telemetry.rs
+++ b/crates/core/pulsar_scenedb/src/telemetry.rs
@@ -1,0 +1,531 @@
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, SocketAddrV4, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use socket2::{Domain, Protocol, Socket, Type};
+
+use serde::Serialize;
+
+use crate::cell::CellStorage;
+use crate::cell_type::RegisteredCellType;
+use crate::component::ComponentId;
+use crate::gpu::{CellId, GpuBufferDispatch, SceneGpuStore};
+use crate::page::Pod;
+use crate::token::TypeToken;
+
+// ── Telemetry data types ──────────────────────────────────────────────────
+
+/// Complete snapshot of SceneDB state, collected from the main thread
+/// and served to HTTP clients by the background telemetry server.
+#[derive(Serialize)]
+pub struct TelemetrySnapshot {
+    /// Per-cell storage data (from CellStorage).
+    pub cells: Vec<CellSnapshot>,
+    /// GPU store metadata (from SceneGpuStore).
+    pub gpu: GpuSnapshot,
+    /// Registered component types → column layouts.
+    pub schema: Vec<TypeSchema>,
+    /// Row pool + slot pool status.
+    pub pools: PoolSnapshot,
+}
+
+#[derive(Serialize)]
+pub struct CellSnapshot {
+    pub id: u32,
+    pub rows_in_use: u32,
+    pub capacity: u32,
+    pub user_column_count: usize,
+    /// Token→column index map for Pod columns.
+    pub pod_columns: Vec<(u32, usize)>,
+    /// Generic column type IDs → column index.
+    pub generic_columns: Vec<(String, usize)>,
+    /// Pod column data: component_id → rows of raw hex bytes.
+    pub pod_data: Vec<ColumnData>,
+    /// Slot column (one u32 per row).
+    pub slot_column: Vec<u32>,
+    /// Liveness mask: rows 0..rows_in_use, packed bits.
+    pub liveness_bits: Vec<u64>,
+    /// Registered cell type name, if available.
+    pub cell_type_name: String,
+}
+
+#[derive(Serialize)]
+pub struct ColumnData {
+    pub component_id: u32,
+    pub element_size: usize,
+    /// Hex-encoded raw bytes, row-major: [row0_bytes, row1_bytes, ...]
+    pub rows_hex: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct GpuSnapshot {
+    pub gen_writes: u64,
+    pub buffers: Vec<GpuBufferSnapshot>,
+    /// Per-cell GPU state (dirty column counts, pending retires).
+    pub cell_gpu_states: Vec<CellGpuSnapshot>,
+}
+
+#[derive(Serialize)]
+pub struct GpuBufferSnapshot {
+    pub component_id: u32,
+    pub element_size: usize,
+    pub capacity: u32,
+}
+
+#[derive(Serialize)]
+pub struct CellGpuSnapshot {
+    pub id: u32,
+    pub class: usize,
+    pub row_base: u32,
+    pub slot_base: u32,
+    pub slot_capacity: u32,
+    pub dirty_column_count: usize,
+    pub pending_retire_count: usize,
+    pub alive: bool,
+}
+
+#[derive(Serialize)]
+pub struct TypeSchema {
+    pub component_id: u32,
+    pub type_name: String,
+    pub size: usize,
+    pub align: usize,
+}
+
+#[derive(Serialize)]
+pub struct PoolSnapshot {
+    pub row: Vec<PoolInfo>,
+    pub slot: Vec<PoolInfo>,
+}
+
+#[derive(Serialize)]
+pub struct PoolInfo {
+    pub region_size: u32,
+    pub total: u32,
+    pub free: u32,
+}
+
+// ── Snapshot collection ───────────────────────────────────────────────────
+
+pub fn collect_gpu_snapshot(store: &SceneGpuStore) -> GpuSnapshot {
+    GpuSnapshot {
+        gen_writes: store.generation_write_count(),
+        buffers: store
+            .telemetry_gpu_buffers()
+            .iter()
+            .map(|(id, buf)| GpuBufferSnapshot {
+                component_id: id.0,
+                element_size: buf.element_size(),
+                capacity: buf.capacity(),
+            })
+            .collect(),
+        cell_gpu_states: store
+            .telemetry_cells()
+            .iter()
+            .enumerate()
+            .map(|(i, c)| match c {
+                Some(state) => CellGpuSnapshot {
+                    id: i as u32,
+                    class: state.class,
+                    row_base: state.row_base,
+                    slot_base: state.slot_base,
+                    slot_capacity: state.slot_capacity,
+                    dirty_column_count: state.dirty_columns.len(),
+                    pending_retire_count: state.pending.len(),
+                    alive: true,
+                },
+                None => CellGpuSnapshot {
+                    id: i as u32,
+                    class: 0,
+                    row_base: 0,
+                    slot_base: 0,
+                    slot_capacity: 0,
+                    dirty_column_count: 0,
+                    pending_retire_count: 0,
+                    alive: false,
+                },
+            })
+            .collect(),
+    }
+}
+
+pub fn collect_pool_snapshot(store: &SceneGpuStore) -> PoolSnapshot {
+    PoolSnapshot {
+        row: store
+            .telemetry_row_pools()
+            .iter()
+            .map(|p| PoolInfo {
+                region_size: p.region_size(),
+                total: p.total_regions(),
+                free: p.free_count(),
+            })
+            .collect(),
+        slot: store
+            .telemetry_slot_pools()
+            .iter()
+            .map(|p| PoolInfo {
+                region_size: p.region_size(),
+                total: p.total_regions(),
+                free: p.free_count(),
+            })
+            .collect(),
+    }
+}
+
+fn collect_schema_snapshot() -> Vec<TypeSchema> {
+    // Schemas are derived from TypeToken registrations, which are lazy.
+    // For now return an empty list; a future iteration can maintain a
+    // global registry of registered types accessible by ComponentId.
+    Vec::new()
+}
+
+fn collect_cell_snapshot(id: u32, cell: &CellStorage) -> CellSnapshot {
+    let rows = cell.rows_in_use();
+    let capacity = cell.capacity();
+    let user_cols = cell.user_column_count();
+
+    // Pod columns: token_index maps ComponentId → user-col index.
+    let pod_columns: Vec<(u32, usize)> = cell
+        .token_index_slice()
+        .iter()
+        .map(|(cid, idx)| (cid.0, *idx))
+        .collect();
+
+    // Generic columns.
+    let generic_columns: Vec<(String, usize)> = cell
+        .generic_token_index_slice()
+        .iter()
+        .map(|(cid, _, idx)| (format!("{:?}", cid), *idx))
+        .collect();
+
+    // Pod column data: dump raw bytes per column.
+    let mut pod_data: Vec<ColumnData> = Vec::new();
+    for (cid, col_idx) in cell.token_index_slice() {
+        let element_size = cell.column_size_pub(*col_idx + 1) as usize;
+        let mut rows_hex: Vec<String> = Vec::new();
+        for row in 0..rows {
+            let raw = cell.column_raw_bytes(*cid).unwrap_or(&[]);
+            let row_start = row as usize * element_size;
+            if row_start + element_size <= raw.len() {
+                rows_hex.push(hex_encode(&raw[row_start..row_start + element_size]));
+            }
+        }
+        pod_data.push(ColumnData {
+            component_id: cid.0,
+            element_size,
+            rows_hex,
+        });
+    }
+
+    // Slot column.
+    let slot_col = cell.slot_column();
+    let slot_column: Vec<u32> = slot_col.iter().copied().collect();
+
+    // Liveness mask.
+    let liveness = cell.liveness();
+    let liveness_words = (rows as usize + 63) / 64;
+    let liveness_bits: Vec<u64> = (0..liveness_words)
+        .map(|w| {
+            let mut bits = 0u64;
+            for b in 0..64.min(rows as usize - w * 64) {
+                if liveness.is_live((w * 64 + b) as u32) {
+                    bits |= 1u64 << b;
+                }
+            }
+            bits
+        })
+        .collect();
+
+    CellSnapshot {
+        id,
+        rows_in_use: rows,
+        capacity,
+        user_column_count: user_cols,
+        pod_columns,
+        generic_columns,
+        pod_data,
+        slot_column,
+        liveness_bits,
+        cell_type_name: String::new(),
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(hex_char(b >> 4));
+        s.push(hex_char(b & 0xf));
+    }
+    s
+}
+
+fn hex_char(v: u8) -> char {
+    if v < 10 {
+        (b'0' + v) as char
+    } else {
+        (b'a' + v - 10) as char
+    }
+}
+
+impl TelemetrySnapshot {
+    /// Collect a full snapshot from GPU store + cell storage pairs.
+    pub fn collect(store: &SceneGpuStore, cells: &[(CellId, &CellStorage)]) -> Self {
+        let gpu = collect_gpu_snapshot(store);
+        let pools = collect_pool_snapshot(store);
+        let schema = collect_schema_snapshot();
+
+        let mut cell_snapshots: Vec<CellSnapshot> = Vec::new();
+        for (id, cell) in cells {
+            cell_snapshots.push(collect_cell_snapshot(id.0, cell));
+        }
+
+        TelemetrySnapshot {
+            cells: cell_snapshots,
+            gpu,
+            schema,
+            pools,
+        }
+    }
+}
+
+// ── Expose column_size on CellStorage for telemetry ───────────────────────
+// (column_size is already pub(crate) — we make it crate-visible for telemetry)
+
+// ── HTTP response helpers ─────────────────────────────────────────────────
+
+struct HttpResponse {
+    status: &'static str,
+    body: String,
+}
+
+fn json_response(data: &impl Serialize) -> HttpResponse {
+    match serde_json::to_string_pretty(data) {
+        Ok(body) => HttpResponse {
+            status: "200 OK",
+            body,
+        },
+        Err(e) => HttpResponse {
+            status: "500 Internal Server Error",
+            body: format!("{{\"error\":\"serialization failed: {}\"}}", e),
+        },
+    }
+}
+
+fn error_response(status: &'static str, msg: &str) -> HttpResponse {
+    HttpResponse {
+        status,
+        body: format!("{{\"error\":\"{}\"}}", msg),
+    }
+}
+
+// ── Route handlers ────────────────────────────────────────────────────────
+
+fn handle_route(path: &str, snap: &TelemetrySnapshot) -> HttpResponse {
+    match path {
+        "/" | "/endpoints" => json_response(&ENDPOINTS),
+        "/cells" => json_response(&snap.cells),
+        "/gpu/buffers" => json_response(&snap.gpu.buffers),
+        "/gpu" => json_response(&snap.gpu),
+        "/pools" => json_response(&snap.pools),
+        "/schema" => json_response(&snap.schema),
+        "/stats" => {
+            let alive = snap.cells.iter().filter(|c| c.rows_in_use > 0).count();
+            json_response(&serde_json::json!({
+                "cells": snap.cells.len(),
+                "cells_alive": alive,
+                "total_rows": snap.cells.iter().map(|c| c.rows_in_use as u64).sum::<u64>(),
+                "gpu_buffers": snap.gpu.buffers.len(),
+                "gen_writes": snap.gpu.gen_writes,
+            }))
+        }
+        "/health" => HttpResponse {
+            status: "200 OK",
+            body: "{\"status\":\"ok\"}".into(),
+        },
+        _ if path.starts_with("/cells/") => {
+            let rest = &path[7..];
+            if let Some(cell_id_str) = rest.split('/').next() {
+                if let Ok(id) = cell_id_str.parse::<u32>() {
+                    if let Some(info) = snap.cells.iter().find(|c| c.id == id) {
+                        // Check for sub-path: /cells/{id}/columns/{col}
+                        if rest.contains("/columns/") {
+                            let col_str = rest.split("/columns/").nth(1).unwrap_or("");
+                            let col_idx: usize = col_str.parse().unwrap_or(usize::MAX);
+                            let col = info.pod_data.iter().find(|c| c.component_id as usize == col_idx);
+                            return match col {
+                                Some(col) => json_response(col),
+                                None => {
+                                    // Try generic columns
+                                    error_response("404 Not Found", &format!("column {} not found in cell {}", col_idx, id))
+                                }
+                            };
+                        }
+                        return json_response(info);
+                    }
+                    return error_response("404 Not Found", &format!("cell {} not found", id));
+                }
+            }
+            error_response("400 Bad Request", "invalid path")
+        }
+        _ if path.starts_with("/query") => {
+            // Parse query string: /query?cell=N&col=M&rows=start..end
+            let query_part = path.split('?').nth(1).unwrap_or("");
+            let params: std::collections::HashMap<&str, &str> = query_part
+                .split('&')
+                .filter_map(|kv| {
+                    let mut parts = kv.splitn(2, '=');
+                    Some((parts.next()?, parts.next()?))
+                })
+                .collect();
+
+            let cell_id: u32 = params.get("cell").and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
+            let col_id: u32 = params.get("col").and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
+            let row_start: usize = params.get("start").and_then(|s| s.parse().ok()).unwrap_or(0);
+            let row_end: usize = params.get("end").and_then(|s| s.parse().ok()).unwrap_or(usize::MAX);
+
+            let cell = match snap.cells.iter().find(|c| c.id == cell_id) {
+                Some(c) => c,
+                None => return error_response("404 Not Found", &format!("cell {} not found", cell_id)),
+            };
+
+            let col = match cell.pod_data.iter().find(|c| c.component_id == col_id) {
+                Some(c) => c,
+                None => return error_response("404 Not Found", &format!("column {} not found in cell {}", col_id, cell_id)),
+            };
+
+            let filtered: Vec<&str> = col.rows_hex[row_start..row_end.min(col.rows_hex.len())]
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+
+            json_response(&serde_json::json!({
+                "cell": cell_id,
+                "component_id": col_id,
+                "element_size": col.element_size,
+                "row_start": row_start,
+                "row_end": row_start + filtered.len(),
+                "rows": filtered,
+            }))
+        }
+        _ => error_response("404 Not Found", "unknown endpoint"),
+    }
+}
+
+const ENDPOINTS: &[(&str, &str)] = &[
+    ("/", "this help"),
+    ("/cells", "list all cells"),
+    ("/cells/{id}", "cell detail"),
+    ("/cells/{id}/columns/{component_id}", "column raw data"),
+    ("/gpu", "GPU store state"),
+    ("/gpu/buffers", "GPU buffer info"),
+    ("/pools", "row and slot pool status"),
+    ("/schema", "registered type schemas"),
+    ("/stats", "telemetry counters"),
+    ("/query?cell=N&col=M&start=R1&end=R2", "query raw row data"),
+    ("/health", "health check"),
+];
+
+// ── Connection handler ────────────────────────────────────────────────────
+
+fn handle_connection(mut stream: TcpStream, snap: &TelemetrySnapshot) {
+    let mut buf = [0u8; 4096];
+    let n = match stream.read(&mut buf) {
+        Ok(n) if n > 0 => n,
+        _ => return,
+    };
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let path = request
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("/")
+        .split('?')
+        .next()
+        .unwrap_or("/");
+
+    let response = handle_route(path, snap);
+    let header = format!(
+        "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        response.status,
+        response.body.len(),
+    );
+    let mut resp = header.into_bytes();
+    resp.extend_from_slice(response.body.as_bytes());
+    let _ = stream.write_all(&resp);
+}
+
+// ── Server ────────────────────────────────────────────────────────────────
+
+/// Background HTTP server that serves SceneDB telemetry snapshots.
+///
+/// The main thread pushes snapshots via [`push_snapshot`], and the server
+/// thread serves the latest snapshot to HTTP clients on the given port.
+pub struct TelemetryServer {
+    handle: Option<JoinHandle<()>>,
+    shutdown: Arc<AtomicBool>,
+    latest: Arc<Mutex<Option<TelemetrySnapshot>>>,
+}
+
+impl TelemetryServer {
+    /// Start the telemetry HTTP server on `port` in a background thread.
+    pub fn start(port: u16) -> std::io::Result<Self> {
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
+        socket.set_reuse_address(true)?;
+        let addr = socket2::SockAddr::from(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port));
+        socket.bind(&addr)?;
+        socket.listen(128)?;
+        socket.set_nonblocking(false)?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_flag = Arc::clone(&shutdown);
+        let latest: Arc<Mutex<Option<TelemetrySnapshot>>> = Arc::new(Mutex::new(None));
+        let latest_server = Arc::clone(&latest);
+
+        let handle = thread::Builder::new()
+            .name("scenedb-telemetry".into())
+            .spawn(move || {
+                loop {
+                    if shutdown_flag.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    match socket.accept() {
+                        Ok((conn, _)) => {
+                            let stream: TcpStream = conn.into();
+                            let snap_guard = latest_server.lock().unwrap();
+                            if let Some(ref snap) = *snap_guard {
+                                handle_connection(stream, snap);
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            })?;
+
+        Ok(Self {
+            handle: Some(handle),
+            shutdown,
+            latest,
+        })
+    }
+
+    /// Push a fresh snapshot for the server to serve.
+    /// Call this from the main thread at frame boundaries or on demand.
+    pub fn push_snapshot(&self, snap: TelemetrySnapshot) {
+        *self.latest.lock().unwrap() = Some(snap);
+    }
+
+    /// Signal the server thread to shut down and wait for it.
+    pub fn shutdown(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for TelemetryServer {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}


### PR DESCRIPTION
Introduce a new optional `telemetry` feature in `pulsar_scenedb` that collects SceneDB/GPU state snapshots and serves them over a lightweight HTTP server. The change adds `TelemetrySnapshot`/`TelemetryServer`, endpoint routing for cells, GPU buffers, pools, stats, and health, and wires crate exports behind the feature flag. It also adds targeted internal accessors/visibility updates in cell and GPU store types so telemetry can read runtime state without changing core behavior.