### PR TITLE
Restore planetary terrain after SceneDB merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9299,6 +9299,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulsar_terrain"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossbeam-channel",
+ "engine_class_derive",
+ "engine_fs",
+ "engine_subsystems",
+ "pulsar_reflection",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ pulsar_reflection                  = { path = "crates/core/pulsar_reflection" }
 pulsar_events                      = { path = "crates/core/pulsar_events" }
 engine_class_derive                = { path = "crates/core/engine_class_derive" }
 pulsar_scene                       = { path = "crates/subsystems/pulsar_scene" }
+pulsar_terrain                     = { path = "crates/subsystems/pulsar_terrain" }
 
 # ---------- Agent Providers ----------
 agent_chat_core                    = { path = "crates/agent-providers/agent_chat_core" }

--- a/crates/subsystems/pulsar_terrain/Cargo.toml
+++ b/crates/subsystems/pulsar_terrain/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "pulsar_terrain"
+version = "0.1.0"
+edition = "2021"
+description = "Authoritative sparse planetary voxel terrain core for Pulsar"
+
+[dependencies]
+anyhow = { workspace = true }
+crossbeam-channel = { workspace = true }
+engine_class_derive = { workspace = true }
+engine_fs = { workspace = true }
+engine_subsystems = { workspace = true }
+pulsar_reflection = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[[bench]]
+name = "terrain_core"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
+++ b/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
@@ -1,0 +1,84 @@
+use pulsar_terrain::{
+    CellWord, ContentHash, EditMode, EditOp, EditShape, FixedSphereGenerator, NodeState, PageKey,
+    PlanetId, SparseBrickTree, TerrainCore,
+};
+use std::time::Instant;
+
+fn main() {
+    const TOUCHES: i64 = 10_000;
+    let started = Instant::now();
+    let mut sparse = SparseBrickTree::centered(24, NodeState::Air).unwrap();
+    for index in 0..TOUCHES {
+        sparse
+            .set(
+                PageKey::new(0, [index - TOUCHES / 2, index % 97, -(index % 193)]),
+                NodeState::Page(ContentHash::of(&index.to_le_bytes())),
+            )
+            .unwrap();
+    }
+    let sparse_time = started.elapsed();
+
+    const DENSE_EDGE: usize = 128;
+    let dense_started = Instant::now();
+    let dense = vec![CellWord::AIR; DENSE_EDGE * DENSE_EDGE * DENSE_EDGE];
+    std::hint::black_box(&dense);
+    let dense_time = dense_started.elapsed();
+
+    let mut core = TerrainCore::new(
+        PlanetId([1; 16]),
+        24,
+        FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 63_710_000,
+            material: 1,
+        },
+    )
+    .unwrap();
+    core.append_edit(EditOp {
+        sequence: 1,
+        stable_id: [1; 16],
+        shape: EditShape::Sphere {
+            center_cell: [0; 3],
+            radius_cells: 10,
+        },
+        mode: EditMode::Subtract,
+        material: 0,
+    })
+    .unwrap();
+    let edit_started = Instant::now();
+    let compacted = core.compact_page(PageKey::new(0, [0; 3])).unwrap();
+    let edit_time = edit_started.elapsed();
+
+    let delete_started = Instant::now();
+    core.set_root(NodeState::Air).unwrap();
+    let delete_time = delete_started.elapsed();
+
+    let edit_amplification = [1_u32, 10, 100, 1_000].map(|radius_cells| {
+        EditShape::Sphere {
+            center_cell: [0; 3],
+            radius_cells,
+        }
+        .affected_lod0_page_count()
+    });
+    let memory = core.memory_counters();
+    let work = core.work_counters();
+
+    // A billion logical cells are represented by the root without allocation.
+    let logical_dense_bytes = 1_000_000_000_u64 * 4;
+    println!(
+        "terrain_core sparse_touches={TOUCHES} nodes={} sparse_ms={:.3} dense_sample_cells={} dense_sample_bytes={} dense_fill_ms={:.3} billion_dense_equivalent_bytes={logical_dense_bytes} edited_page_bytes={} resident_dense_bytes={} generated_cells={} edit_attachment_regions={} edit_attachment_refs={} edit_candidates_replayed={} edit_compact_ms={:.3} edit_radius_cells=[1,10,100,1000] edit_aabb_pages={edit_amplification:?} root_delete_us={:.3}",
+        sparse.node_count(),
+        sparse_time.as_secs_f64() * 1_000.0,
+        dense.len(),
+        dense.len() * std::mem::size_of::<CellWord>(),
+        dense_time.as_secs_f64() * 1_000.0,
+        core.page(compacted.key).unwrap().encode().len(),
+        memory.resident_dense_bytes,
+        work.cells_generated,
+        memory.edit_attachment_regions,
+        memory.edit_attachment_references,
+        work.edit_candidates_replayed,
+        edit_time.as_secs_f64() * 1_000.0,
+        delete_time.as_secs_f64() * 1_000_000.0,
+    );
+}

--- a/crates/subsystems/pulsar_terrain/src/component.rs
+++ b/crates/subsystems/pulsar_terrain/src/component.rs
@@ -1,0 +1,285 @@
+use crate::{PlanetId, PlanetIdParseError, TerrainRuntimeHandle};
+use engine_class_derive::{engine_class, register_runtime_behavior};
+use pulsar_reflection::{ComponentRuntimeBehavior, ComponentRuntimeContext, RuntimeComponentOwner};
+use serde_json::Value;
+use thiserror::Error;
+
+pub const PLANET_TERRAIN_CLASS_NAME: &str = "PlanetTerrainComponent";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlanetDefinition {
+    pub planet_id: PlanetId,
+    pub center_cell: [i64; 3],
+    pub radius_cells: u64,
+    pub material: u8,
+    pub root_lod: u8,
+    pub max_resident_pages: usize,
+}
+
+/// Runtime-owned planetary terrain definition. Legacy editor terrain
+/// components remain separate while this production contract is validated.
+#[engine_class(category = "Terrain", clone, debug, serialize, deserialize)]
+pub struct PlanetTerrainComponent {
+    #[property]
+    pub enabled: bool,
+    /// Optional 32-character hexadecimal ID. An empty value derives a stable
+    /// ID from the owning scene object and component index.
+    #[property]
+    pub planet_id: String,
+    #[property]
+    pub center_cell_x: i64,
+    #[property]
+    pub center_cell_y: i64,
+    #[property]
+    pub center_cell_z: i64,
+    /// Canonical radius in 10 cm LOD0 cells.
+    #[property]
+    pub radius_cells: u64,
+    #[property]
+    pub material: u64,
+    #[property]
+    pub root_lod: u64,
+    #[property]
+    pub max_resident_pages: u64,
+}
+
+impl Default for PlanetTerrainComponent {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            planet_id: String::new(),
+            center_cell_x: 0,
+            center_cell_y: 0,
+            center_cell_z: 0,
+            radius_cells: 63_710_000,
+            material: 1,
+            root_lod: 22,
+            max_resident_pages: 8_192,
+        }
+    }
+}
+
+impl PlanetTerrainComponent {
+    pub fn definition(&self, stable_owner_key: &str) -> Result<PlanetDefinition, ComponentError> {
+        if self.radius_cells == 0 {
+            return Err(ComponentError::ZeroRadius);
+        }
+        let material = u8::try_from(self.material)
+            .ok()
+            .filter(|material| *material != 0)
+            .ok_or(ComponentError::Material(self.material))?;
+        let root_lod = u8::try_from(self.root_lod)
+            .ok()
+            .filter(|lod| (1..=62).contains(lod))
+            .ok_or(ComponentError::RootLod(self.root_lod))?;
+        let max_resident_pages = usize::try_from(self.max_resident_pages)
+            .ok()
+            .filter(|pages| *pages != 0)
+            .ok_or(ComponentError::ResidentPages(self.max_resident_pages))?;
+        let explicit_id = self.planet_id.trim();
+        let planet_id = if explicit_id.is_empty() {
+            PlanetId::from_stable_name(stable_owner_key)
+        } else {
+            PlanetId::from_hex(explicit_id)?
+        };
+        Ok(PlanetDefinition {
+            planet_id,
+            center_cell: [self.center_cell_x, self.center_cell_y, self.center_cell_z],
+            radius_cells: self.radius_cells,
+            material,
+            root_lod,
+            max_resident_pages,
+        })
+    }
+}
+
+#[register_runtime_behavior]
+impl ComponentRuntimeBehavior for PlanetTerrainComponent {
+    const CLASS_NAME: &'static str = PLANET_TERRAIN_CLASS_NAME;
+
+    fn sync_component(
+        owner: &RuntimeComponentOwner,
+        component_index: usize,
+        component_data: &Value,
+        context: &mut dyn ComponentRuntimeContext,
+    ) {
+        let component = match serde_json::from_value::<Self>(component_data.clone()) {
+            Ok(component) => component,
+            Err(error) => {
+                context.report_error(format!(
+                    "{PLANET_TERRAIN_CLASS_NAME} on '{}' is invalid: {error}",
+                    owner.scene_object_id
+                ));
+                return;
+            }
+        };
+        let source_key = format!("{}:{component_index}", owner.scene_object_id);
+        let result = if component.enabled {
+            component.definition(&source_key).and_then(|definition| {
+                context
+                    .subsystems_mut()
+                    .get_mut::<TerrainRuntimeHandle>()
+                    .ok_or(ComponentError::RuntimeUnavailable)?
+                    .upsert_component(source_key, definition)
+                    .map(|_| ())
+                    .map_err(ComponentError::Runtime)
+            })
+        } else {
+            context
+                .subsystems_mut()
+                .get_mut::<TerrainRuntimeHandle>()
+                .ok_or(ComponentError::RuntimeUnavailable)
+                .and_then(|runtime| {
+                    runtime
+                        .remove_component(&source_key)
+                        .map_err(ComponentError::Runtime)
+                })
+        };
+        if let Err(error) = result {
+            context.report_error(format!(
+                "{PLANET_TERRAIN_CLASS_NAME} on '{}': {error}",
+                owner.scene_object_id
+            ));
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ComponentError {
+    #[error(transparent)]
+    PlanetId(#[from] PlanetIdParseError),
+    #[error("radius_cells must be greater than zero")]
+    ZeroRadius,
+    #[error("material must be in 1..=255, got {0}")]
+    Material(u64),
+    #[error("root_lod must be in 1..=62, got {0}")]
+    RootLod(u64),
+    #[error("max_resident_pages must fit usize and be greater than zero, got {0}")]
+    ResidentPages(u64),
+    #[error("TerrainRuntimeHandle is not registered in the component context")]
+    RuntimeUnavailable,
+    #[error(transparent)]
+    Runtime(#[from] crate::TerrainRuntimeError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TerrainRuntimeConfig, TerrainSubsystem};
+    use engine_subsystems::{Subsystem, SubsystemContext};
+    use pulsar_reflection::{
+        apply_runtime_behavior_for_class, ComponentRuntimeContext, EngineClass,
+        RuntimeComponentOwner, Subsystems,
+    };
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    struct TestRuntimeContext {
+        project_root: PathBuf,
+        subsystems: Subsystems,
+        errors: Vec<String>,
+    }
+
+    impl ComponentRuntimeContext for TestRuntimeContext {
+        fn subsystems_mut(&mut self) -> &mut Subsystems {
+            &mut self.subsystems
+        }
+
+        fn project_root(&self) -> &Path {
+            &self.project_root
+        }
+
+        fn report_error(&mut self, message: String) {
+            self.errors.push(message);
+        }
+    }
+
+    #[test]
+    fn component_round_trips_with_stable_runtime_name() {
+        let component = PlanetTerrainComponent::default();
+        let json = serde_json::to_value(&component).unwrap();
+        let decoded: PlanetTerrainComponent = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.radius_cells, component.radius_cells);
+        assert_eq!(decoded.root_lod, component.root_lod);
+        assert_eq!(
+            <PlanetTerrainComponent as ComponentRuntimeBehavior>::CLASS_NAME,
+            PLANET_TERRAIN_CLASS_NAME
+        );
+        assert_eq!(
+            PlanetTerrainComponent::class_name(),
+            PLANET_TERRAIN_CLASS_NAME
+        );
+        assert_eq!(component.get_properties().len(), 9);
+    }
+
+    #[test]
+    fn empty_component_id_is_stable_and_explicit_id_round_trips() {
+        let component = PlanetTerrainComponent::default();
+        let first = component.definition("earth:0").unwrap();
+        let second = component.definition("earth:0").unwrap();
+        assert_eq!(first.planet_id, second.planet_id);
+
+        let explicit = PlanetTerrainComponent {
+            planet_id: first.planet_id.to_hex(),
+            ..PlanetTerrainComponent::default()
+        };
+        assert_eq!(
+            explicit.definition("different").unwrap().planet_id,
+            first.planet_id
+        );
+    }
+
+    #[test]
+    fn registered_runtime_behavior_upserts_and_removes_the_planet() {
+        let config = TerrainRuntimeConfig {
+            worker_count: 1,
+            ..TerrainRuntimeConfig::default()
+        };
+        let mut terrain = TerrainSubsystem::new(config).unwrap();
+        terrain.init(&SubsystemContext::new()).unwrap();
+        let handle = terrain.runtime_handle();
+
+        let mut subsystems = Subsystems::new();
+        subsystems.register(handle.clone());
+        let mut context = TestRuntimeContext {
+            project_root: PathBuf::from("."),
+            subsystems,
+            errors: Vec::new(),
+        };
+        let props = HashMap::new();
+        let owner = RuntimeComponentOwner {
+            scene_object_id: "earth",
+            position: [0.0; 3],
+            rotation: [0.0; 3],
+            scale: [1.0; 3],
+            props: &props,
+        };
+
+        let component = PlanetTerrainComponent::default();
+        assert!(apply_runtime_behavior_for_class(
+            PLANET_TERRAIN_CLASS_NAME,
+            &owner,
+            0,
+            &serde_json::to_value(&component).unwrap(),
+            &mut context,
+        ));
+        assert!(context.errors.is_empty());
+        assert_eq!(handle.counters().planets, 1);
+
+        let disabled = PlanetTerrainComponent {
+            enabled: false,
+            ..component
+        };
+        assert!(apply_runtime_behavior_for_class(
+            PLANET_TERRAIN_CLASS_NAME,
+            &owner,
+            0,
+            &serde_json::to_value(disabled).unwrap(),
+            &mut context,
+        ));
+        assert!(context.errors.is_empty());
+        assert_eq!(handle.counters().planets, 0);
+
+        terrain.shutdown().unwrap();
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/core.rs
+++ b/crates/subsystems/pulsar_terrain/src/core.rs
@@ -1,0 +1,580 @@
+use crate::edit::EditIndex;
+use crate::{
+    CompactedPageRecord, DeterministicGenerator, EditError, EditLog, EditOp, HierarchyError,
+    NodeState, PageCodecError, PageKey, PlanetId, SparseBrickTree, TerrainSnapshot, VoxelPage,
+};
+use std::collections::BTreeMap;
+use thiserror::Error;
+
+/// Owning authoritative state for one planet's sparse terrain.
+///
+/// GPU pages, extracted meshes, and collision data are deliberately absent;
+/// those are generation-tagged consumers of this state in later milestones.
+pub struct TerrainCore<G> {
+    planet_id: PlanetId,
+    generator: G,
+    hierarchy: SparseBrickTree,
+    edits: EditLog,
+    edit_index: EditIndex,
+    pages: BTreeMap<PageKey, VoxelPage>,
+    compacted: BTreeMap<PageKey, CompactedPageRecord>,
+    work: TerrainWorkCounters,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerrainWorkCounters {
+    pub edits_appended: u64,
+    pub hierarchy_overrides: u64,
+    pub pages_compacted: u64,
+    pub cells_generated: u64,
+    pub cells_replayed: u64,
+    pub edit_candidates_replayed: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerrainMemoryCounters {
+    pub hierarchy_nodes: usize,
+    pub hierarchy_encoded_bytes: usize,
+    pub edit_operations: usize,
+    pub edit_attachment_regions: usize,
+    pub edit_attachment_references: usize,
+    pub resident_pages: usize,
+    pub resident_dense_bytes: usize,
+    pub compacted_page_records: usize,
+}
+
+#[derive(Clone, Debug)]
+pub enum PageBuildPreparation<G> {
+    Current(CompactedPageRecord),
+    Build(PageBuildRequest<G>),
+}
+
+/// Immutable input for one off-thread page build. Preparing this value never
+/// mutates canonical terrain state; publishing requires a later generation
+/// check through [`TerrainCore::commit_page_build`].
+#[derive(Clone, Debug)]
+pub struct PageBuildRequest<G> {
+    key: PageKey,
+    generator: G,
+    base_page: Option<VoxelPage>,
+    base_page_id: Option<crate::PageId>,
+    previous_sequence: u64,
+    target_sequence: u64,
+    operations: Vec<EditOp>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PageBuildResult {
+    key: PageKey,
+    page: VoxelPage,
+    base_page_id: Option<crate::PageId>,
+    previous_sequence: u64,
+    target_sequence: u64,
+    replayed_operations: usize,
+    reused_resident_page: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PageBuildCommitOutcome {
+    Committed(CompactedPageRecord),
+    Duplicate(CompactedPageRecord),
+    Stale { newest_sequence: u64 },
+}
+
+impl<G: DeterministicGenerator> PageBuildRequest<G> {
+    pub fn key(&self) -> PageKey {
+        self.key
+    }
+
+    pub fn target_sequence(&self) -> u64 {
+        self.target_sequence
+    }
+
+    pub fn execute(self) -> Result<PageBuildResult, TerrainCoreError> {
+        let reused_resident_page = self.base_page.is_some();
+        let page = if let Some(base_page) = self.base_page {
+            base_page.apply_edit_tail(self.key, &self.operations)?
+        } else {
+            VoxelPage::generate_with_operations(self.key, &self.generator, &self.operations)?
+        };
+        Ok(PageBuildResult {
+            key: self.key,
+            page,
+            base_page_id: self.base_page_id,
+            previous_sequence: self.previous_sequence,
+            target_sequence: self.target_sequence,
+            replayed_operations: self.operations.len(),
+            reused_resident_page,
+        })
+    }
+}
+
+impl PageBuildResult {
+    pub fn key(&self) -> PageKey {
+        self.key
+    }
+
+    pub fn target_sequence(&self) -> u64 {
+        self.target_sequence
+    }
+
+    pub fn page(&self) -> &VoxelPage {
+        &self.page
+    }
+}
+
+impl<G: DeterministicGenerator> TerrainCore<G> {
+    pub fn new(planet_id: PlanetId, root_lod: u8, generator: G) -> Result<Self, TerrainCoreError> {
+        let hierarchy =
+            SparseBrickTree::centered(root_lod, NodeState::Procedural(generator.hash()))?;
+        Ok(Self {
+            planet_id,
+            generator,
+            hierarchy,
+            edits: EditLog::default(),
+            edit_index: EditIndex::new(root_lod),
+            pages: BTreeMap::new(),
+            compacted: BTreeMap::new(),
+            work: TerrainWorkCounters::default(),
+        })
+    }
+
+    pub fn hierarchy(&self) -> &SparseBrickTree {
+        &self.hierarchy
+    }
+
+    pub fn planet_id(&self) -> PlanetId {
+        self.planet_id
+    }
+
+    pub fn edit_log(&self) -> &EditLog {
+        &self.edits
+    }
+
+    pub fn append_edit(&mut self, operation: EditOp) -> Result<(), TerrainCoreError> {
+        let previous_len = self.edits.operations().len();
+        self.edits.push(operation)?;
+        if self.edits.operations().len() != previous_len {
+            self.edit_index.insert(previous_len, operation);
+            self.work.edits_appended = self.work.edits_appended.saturating_add(1);
+        }
+        Ok(())
+    }
+
+    pub fn prepare_page_build(
+        &self,
+        key: PageKey,
+    ) -> Result<PageBuildPreparation<G>, TerrainCoreError>
+    where
+        G: Clone,
+    {
+        let previous_sequence = self
+            .compacted
+            .get(&key)
+            .map_or(0, |record| record.compacted_through_sequence);
+        let latest_sequence = self.edits.latest_sequence();
+        if previous_sequence == latest_sequence {
+            if let Some(record) = self.compacted.get(&key) {
+                if self.pages.contains_key(&key) {
+                    return Ok(PageBuildPreparation::Current(*record));
+                }
+                return Err(TerrainCoreError::BasePageUnavailable(key));
+            }
+        }
+
+        let relevant = self
+            .edit_index
+            .operations_for_page(&self.edits, key, previous_sequence);
+        let base_page = self.pages.get(&key).cloned();
+        if previous_sequence != 0 && base_page.is_none() {
+            return Err(TerrainCoreError::BasePageUnavailable(key));
+        }
+        Ok(PageBuildPreparation::Build(PageBuildRequest {
+            key,
+            generator: self.generator.clone(),
+            base_page_id: base_page.as_ref().map(VoxelPage::page_id),
+            base_page,
+            previous_sequence,
+            target_sequence: latest_sequence,
+            operations: relevant,
+        }))
+    }
+
+    pub fn commit_page_build(
+        &mut self,
+        result: PageBuildResult,
+    ) -> Result<PageBuildCommitOutcome, TerrainCoreError> {
+        let latest_sequence = self.edits.latest_sequence();
+        if result.target_sequence != latest_sequence {
+            return Ok(PageBuildCommitOutcome::Stale {
+                newest_sequence: latest_sequence,
+            });
+        }
+        if let Some(current) = self.compacted.get(&result.key).copied() {
+            if current.compacted_through_sequence == result.target_sequence
+                && self.pages.contains_key(&result.key)
+            {
+                return Ok(PageBuildCommitOutcome::Duplicate(current));
+            }
+            if current.compacted_through_sequence != result.previous_sequence
+                || self.pages.get(&result.key).map(VoxelPage::page_id) != result.base_page_id
+            {
+                return Ok(PageBuildCommitOutcome::Stale {
+                    newest_sequence: current.compacted_through_sequence.max(latest_sequence),
+                });
+            }
+        } else if result.previous_sequence != 0 || result.base_page_id.is_some() {
+            return Ok(PageBuildCommitOutcome::Stale {
+                newest_sequence: latest_sequence,
+            });
+        }
+
+        let page_id = result.page.page_id();
+        let record = CompactedPageRecord {
+            key: result.key,
+            page_id,
+            compacted_through_sequence: result.target_sequence,
+        };
+        let state = result
+            .page
+            .constant_cell()
+            .map_or(NodeState::Page(page_id), |cell| {
+                if cell.is_solid() {
+                    NodeState::Solid(cell.material())
+                } else {
+                    NodeState::Air
+                }
+            });
+        self.hierarchy.set(result.key, state)?;
+        self.pages.insert(result.key, result.page);
+        self.compacted.insert(result.key, record);
+        self.work.pages_compacted = self.work.pages_compacted.saturating_add(1);
+        self.work.edit_candidates_replayed = self
+            .work
+            .edit_candidates_replayed
+            .saturating_add(result.replayed_operations as u64);
+        if result.reused_resident_page {
+            self.work.cells_replayed = self
+                .work
+                .cells_replayed
+                .saturating_add(crate::CELL_COUNT as u64);
+        } else {
+            self.work.cells_generated = self
+                .work
+                .cells_generated
+                .saturating_add(crate::CELL_COUNT as u64);
+        }
+        Ok(PageBuildCommitOutcome::Committed(record))
+    }
+
+    /// Fold the current ordered edit prefix into one content-addressed LOD0
+    /// page and publish that page into the canonical hierarchy.
+    pub fn compact_page(&mut self, key: PageKey) -> Result<CompactedPageRecord, TerrainCoreError>
+    where
+        G: Clone,
+    {
+        match self.prepare_page_build(key)? {
+            PageBuildPreparation::Current(record) => Ok(record),
+            PageBuildPreparation::Build(request) => {
+                match self.commit_page_build(request.execute()?)? {
+                    PageBuildCommitOutcome::Committed(record)
+                    | PageBuildCommitOutcome::Duplicate(record) => Ok(record),
+                    PageBuildCommitOutcome::Stale { .. } => {
+                        unreachable!("synchronous page build cannot become stale")
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn page(&self, key: PageKey) -> Option<&VoxelPage> {
+        self.pages.get(&key)
+    }
+
+    pub fn resident_page_keys(&self) -> impl ExactSizeIterator<Item = PageKey> + '_ {
+        self.pages.keys().copied()
+    }
+
+    /// Exact whole-root replacement. Resident pages remain disposable caches;
+    /// the root state is immediately authoritative without iterating over them.
+    pub fn set_root(&mut self, state: NodeState) -> Result<(), TerrainCoreError> {
+        self.hierarchy.set_root(state)?;
+        self.work.hierarchy_overrides = self.work.hierarchy_overrides.saturating_add(1);
+        Ok(())
+    }
+
+    /// Attach an exact uniform or content-addressed override at any hierarchy
+    /// level. Descendants are resolved lazily and never expanded here.
+    pub fn set_region(&mut self, key: PageKey, state: NodeState) -> Result<(), TerrainCoreError> {
+        self.hierarchy.set(key, state)?;
+        self.work.hierarchy_overrides = self.work.hierarchy_overrides.saturating_add(1);
+        Ok(())
+    }
+
+    pub fn snapshot(&self) -> TerrainSnapshot {
+        TerrainSnapshot {
+            planet_id: self.planet_id,
+            generator_hash: self.generator.hash(),
+            hierarchy: self.hierarchy.clone(),
+            edit_tail: self.edits.clone(),
+            compacted_pages: self.compacted.values().copied().collect(),
+        }
+    }
+
+    pub fn resident_page_count(&self) -> usize {
+        self.pages.len()
+    }
+
+    pub fn work_counters(&self) -> TerrainWorkCounters {
+        self.work
+    }
+
+    pub fn memory_counters(&self) -> TerrainMemoryCounters {
+        TerrainMemoryCounters {
+            hierarchy_nodes: self.hierarchy.node_count(),
+            hierarchy_encoded_bytes: self.hierarchy.encode().len(),
+            edit_operations: self.edits.operations().len(),
+            edit_attachment_regions: self.edit_index.region_count(),
+            edit_attachment_references: self.edit_index.reference_count(),
+            resident_pages: self.pages.len(),
+            resident_dense_bytes: self
+                .pages
+                .values()
+                .map(VoxelPage::dense_allocation_bytes)
+                .sum(),
+            compacted_page_records: self.compacted.len(),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum TerrainCoreError {
+    #[error(transparent)]
+    Hierarchy(#[from] HierarchyError),
+    #[error(transparent)]
+    Edit(#[from] EditError),
+    #[error(transparent)]
+    Page(#[from] PageCodecError),
+    #[error(
+        "compacted page {0:?} is not resident; reload it from the content store before replay"
+    )]
+    BasePageUnavailable(PageKey),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EditMode, EditShape, FixedSphereGenerator};
+
+    #[test]
+    fn compaction_publishes_a_hashed_page_and_snapshot() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([1; 16]), 12, generator).unwrap();
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [8; 16],
+            shape: EditShape::Sphere {
+                center_cell: [4, 4, 4],
+                radius_cells: 3,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        })
+        .unwrap();
+        let key = PageKey::new(0, [0, 0, 0]);
+        let record = core.compact_page(key).unwrap();
+        assert_eq!(record.page_id, core.page(key).unwrap().page_id());
+        assert_eq!(
+            core.hierarchy().resolve(key).unwrap(),
+            NodeState::Page(record.page_id)
+        );
+        assert_eq!(core.snapshot().compacted_pages, vec![record]);
+
+        core.set_root(NodeState::Air).unwrap();
+        assert_eq!(core.hierarchy().node_count(), 1);
+        assert_eq!(core.resident_page_count(), 1);
+        assert_eq!(core.work_counters().edits_appended, 1);
+        assert_eq!(core.work_counters().pages_compacted, 1);
+        assert_eq!(
+            core.work_counters().cells_generated,
+            crate::CELL_COUNT as u64
+        );
+        assert_eq!(core.memory_counters().resident_pages, 1);
+
+        core.append_edit(EditOp {
+            sequence: 2,
+            stable_id: [9; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8, 8, 8],
+                radius_cells: 2,
+            },
+            mode: EditMode::Paint,
+            material: 11,
+        })
+        .unwrap();
+        let updated = core.compact_page(key).unwrap();
+        assert_eq!(updated.compacted_through_sequence, 2);
+        assert_eq!(
+            core.work_counters().cells_generated,
+            crate::CELL_COUNT as u64
+        );
+        assert_eq!(
+            core.work_counters().cells_replayed,
+            crate::CELL_COUNT as u64
+        );
+        assert_eq!(core.work_counters().pages_compacted, 2);
+    }
+
+    #[test]
+    fn uniform_compaction_and_high_level_override_remain_sparse() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([2; 16]), 24, generator).unwrap();
+        let far_page = PageKey::new(0, [1_000_000, 0, 0]);
+        core.compact_page(far_page).unwrap();
+        assert_eq!(core.hierarchy().resolve(far_page).unwrap(), NodeState::Air);
+        assert_eq!(core.page(far_page).unwrap().dense_allocation_bytes(), 0);
+
+        let continent = PageKey::new(16, [-2, 1, 0]);
+        core.set_region(continent, NodeState::Air).unwrap();
+        assert_eq!(core.hierarchy().resolve(continent).unwrap(), NodeState::Air);
+        assert!(core.hierarchy().node_count() <= 1 + 8 * 24 + 8 * 8);
+        assert_eq!(core.work_counters().hierarchy_overrides, 1);
+    }
+
+    #[test]
+    fn page_compaction_replays_only_spatially_attached_edit_candidates() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([3; 16]), 24, generator).unwrap();
+        for sequence in 1..=64_u64 {
+            let page = 1_000 + sequence as i64;
+            core.append_edit(EditOp {
+                sequence,
+                stable_id: [sequence as u8; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [page * crate::PAGE_EDGE_CELLS + 8; 3],
+                    radius_cells: 1,
+                },
+                mode: EditMode::Subtract,
+                material: 0,
+            })
+            .unwrap();
+        }
+        core.append_edit(EditOp {
+            sequence: 65,
+            stable_id: [65; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8; 3],
+                radius_cells: 2,
+            },
+            mode: EditMode::Paint,
+            material: 9,
+        })
+        .unwrap();
+
+        core.compact_page(PageKey::new(0, [0; 3])).unwrap();
+        assert_eq!(core.work_counters().edit_candidates_replayed, 1);
+        assert_eq!(core.memory_counters().edit_attachment_references, 65);
+        assert_eq!(core.memory_counters().edit_attachment_regions, 65);
+    }
+
+    #[test]
+    fn stale_off_thread_page_build_cannot_replace_newer_terrain() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([4; 16]), 12, generator).unwrap();
+        let key = PageKey::new(0, [0; 3]);
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [1; 16],
+            shape: EditShape::Sphere {
+                center_cell: [4; 3],
+                radius_cells: 2,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        })
+        .unwrap();
+        let request = match core.prepare_page_build(key).unwrap() {
+            PageBuildPreparation::Build(request) => request,
+            PageBuildPreparation::Current(_) => panic!("first request must require a build"),
+        };
+        let result = request.execute().unwrap();
+
+        core.append_edit(EditOp {
+            sequence: 2,
+            stable_id: [2; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8; 3],
+                radius_cells: 1,
+            },
+            mode: EditMode::Paint,
+            material: 9,
+        })
+        .unwrap();
+
+        assert_eq!(
+            core.commit_page_build(result).unwrap(),
+            PageBuildCommitOutcome::Stale { newest_sequence: 2 }
+        );
+        assert!(core.page(key).is_none());
+        assert_eq!(core.work_counters().pages_compacted, 0);
+        assert_eq!(core.memory_counters().compacted_page_records, 0);
+    }
+
+    #[test]
+    fn duplicate_off_thread_page_build_is_idempotent() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([5; 16]), 12, generator).unwrap();
+        let key = PageKey::new(0, [0; 3]);
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [3; 16],
+            shape: EditShape::Sphere {
+                center_cell: [4; 3],
+                radius_cells: 2,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        })
+        .unwrap();
+
+        let first = match core.prepare_page_build(key).unwrap() {
+            PageBuildPreparation::Build(request) => request.execute().unwrap(),
+            PageBuildPreparation::Current(_) => panic!("first request must require a build"),
+        };
+        let duplicate = match core.prepare_page_build(key).unwrap() {
+            PageBuildPreparation::Build(request) => request.execute().unwrap(),
+            PageBuildPreparation::Current(_) => panic!("uncommitted request cannot be current"),
+        };
+
+        let committed = match core.commit_page_build(first).unwrap() {
+            PageBuildCommitOutcome::Committed(record) => record,
+            outcome => panic!("unexpected first commit outcome: {outcome:?}"),
+        };
+        assert_eq!(
+            core.commit_page_build(duplicate).unwrap(),
+            PageBuildCommitOutcome::Duplicate(committed)
+        );
+        assert_eq!(core.work_counters().pages_compacted, 1);
+        assert_eq!(core.memory_counters().compacted_page_records, 1);
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/edit.rs
+++ b/crates/subsystems/pulsar_terrain/src/edit.rs
@@ -1,0 +1,579 @@
+use crate::{CellWord, ContentHash, MaterialId, PageKey};
+use std::collections::BTreeMap;
+use thiserror::Error;
+
+const EDIT_LOG_MAGIC: &[u8; 8] = b"PTEDIT01";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditMode {
+    Union,
+    Subtract,
+    Replace,
+    Paint,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditShape {
+    Sphere {
+        center_cell: [i64; 3],
+        radius_cells: u32,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EditOp {
+    pub sequence: u64,
+    pub stable_id: [u8; 16],
+    pub shape: EditShape,
+    pub mode: EditMode,
+    pub material: MaterialId,
+}
+
+impl EditOp {
+    pub fn apply(self, cell_xyz: [i64; 3], cell: CellWord) -> CellWord {
+        let shape_distance = self.shape.signed_distance(cell_xyz);
+        if shape_distance > 0 && matches!(self.mode, EditMode::Replace | EditMode::Paint) {
+            return cell;
+        }
+        let old_distance = i32::from(cell.density());
+        let density = match self.mode {
+            EditMode::Union => old_distance.min(shape_distance),
+            EditMode::Subtract => old_distance.max(-shape_distance),
+            EditMode::Replace => shape_distance,
+            EditMode::Paint => old_distance,
+        }
+        .clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
+
+        let affects_material = shape_distance <= 0
+            && matches!(
+                self.mode,
+                EditMode::Union | EditMode::Replace | EditMode::Paint
+            );
+        let material = if affects_material && density <= 0 {
+            self.material
+        } else if density > 0 {
+            0
+        } else {
+            cell.material()
+        };
+        CellWord::new(density, material, cell.flags())
+    }
+}
+
+impl EditShape {
+    pub fn bounds(self) -> ([i64; 3], [i64; 3]) {
+        match self {
+            Self::Sphere {
+                center_cell,
+                radius_cells,
+            } => {
+                let radius = i64::from(radius_cells);
+                (
+                    center_cell.map(|axis| axis.saturating_sub(radius)),
+                    center_cell.map(|axis| axis.saturating_add(radius).saturating_add(1)),
+                )
+            }
+        }
+    }
+
+    /// Conservative count of LOD0 pages intersected by the shape's integer
+    /// cell AABB. This is used for scheduling and edit-amplification budgets;
+    /// it does not materialize or visit any page.
+    pub fn affected_lod0_page_count(self) -> u128 {
+        let (min, max) = self.bounds();
+        (0..3)
+            .map(|axis| {
+                let first = min[axis].div_euclid(crate::PAGE_EDGE_CELLS);
+                let last = max[axis]
+                    .saturating_sub(1)
+                    .div_euclid(crate::PAGE_EDGE_CELLS);
+                u128::try_from(last.saturating_sub(first).saturating_add(1)).unwrap_or(u128::MAX)
+            })
+            .fold(1_u128, u128::saturating_mul)
+    }
+
+    /// Smallest canonical hierarchy region that contains the edit AABB.
+    ///
+    /// Edits that cross the centered root split (or extend beyond the root)
+    /// attach to the root. This keeps insertion bounded without enumerating
+    /// intersected pages; exact shape bounds are still checked during replay.
+    fn covering_attachment(self, root_lod: u8) -> EditAttachment {
+        let (min_cell, max_cell) = self.bounds();
+        let min_page = min_cell.map(|axis| axis.div_euclid(crate::PAGE_EDGE_CELLS));
+        let max_page =
+            max_cell.map(|axis| axis.saturating_sub(1).div_euclid(crate::PAGE_EDGE_CELLS));
+        let half = 1_i64 << (root_lod - 1);
+        let root_min = -half;
+        let root_max = half - 1;
+        if (0..3).any(|axis| min_page[axis] < root_min || max_page[axis] > root_max) {
+            return EditAttachment::Root;
+        }
+
+        let relative_min = min_page.map(|axis| (axis - root_min) as u64);
+        let relative_max = max_page.map(|axis| (axis - root_min) as u64);
+        let differing = (relative_min[0] ^ relative_max[0])
+            | (relative_min[1] ^ relative_max[1])
+            | (relative_min[2] ^ relative_max[2]);
+        if differing == 0 {
+            return EditAttachment::Region(PageKey::new(0, min_page));
+        }
+
+        let lod = (u64::BITS - differing.leading_zeros()) as u8;
+        if lod >= root_lod {
+            EditAttachment::Root
+        } else {
+            let scale = 1_i64 << lod;
+            EditAttachment::Region(PageKey::new(
+                lod,
+                min_page.map(|axis| axis.div_euclid(scale)),
+            ))
+        }
+    }
+
+    fn signed_distance(self, cell_xyz: [i64; 3]) -> i32 {
+        match self {
+            Self::Sphere {
+                center_cell,
+                radius_cells,
+            } => {
+                let delta = [
+                    i128::from(cell_xyz[0]) - i128::from(center_cell[0]),
+                    i128::from(cell_xyz[1]) - i128::from(center_cell[1]),
+                    i128::from(cell_xyz[2]) - i128::from(center_cell[2]),
+                ];
+                let squared = delta
+                    .iter()
+                    .map(|axis| axis.saturating_mul(*axis) as u128)
+                    .sum::<u128>();
+                let distance = integer_sqrt(squared).min(i32::MAX as u128) as i32;
+                distance.saturating_sub(radius_cells.min(i32::MAX as u32) as i32)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EditAttachment {
+    Root,
+    Region(PageKey),
+}
+
+/// Derived sparse spatial index for the canonical edit log.
+///
+/// Every edit contributes exactly one reference, either at the root or at its
+/// smallest covering hierarchy region. Page replay walks only the page's
+/// ancestor chain, so work is proportional to relevant candidates rather than
+/// the total logical volume or the total global edit count.
+#[derive(Clone, Debug)]
+pub(crate) struct EditIndex {
+    root_lod: u8,
+    root: Vec<usize>,
+    regions: BTreeMap<PageKey, Vec<usize>>,
+}
+
+impl EditIndex {
+    pub(crate) fn new(root_lod: u8) -> Self {
+        Self {
+            root_lod,
+            root: Vec::new(),
+            regions: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, operation_index: usize, operation: EditOp) {
+        match operation.shape.covering_attachment(self.root_lod) {
+            EditAttachment::Root => self.root.push(operation_index),
+            EditAttachment::Region(key) => {
+                self.regions.entry(key).or_default().push(operation_index);
+            }
+        }
+    }
+
+    pub(crate) fn operations_for_page(
+        &self,
+        log: &EditLog,
+        key: PageKey,
+        after_sequence: u64,
+    ) -> Vec<EditOp> {
+        let mut indices = self.root.clone();
+        let mut ancestor = Some(key);
+        while let Some(key) = ancestor.filter(|key| key.lod < self.root_lod) {
+            if let Some(attached) = self.regions.get(&key) {
+                indices.extend_from_slice(attached);
+            }
+            ancestor = key.parent();
+        }
+        indices.sort_unstable();
+        indices
+            .into_iter()
+            .filter_map(|index| log.operations().get(index).copied())
+            .filter(|operation| operation.sequence > after_sequence)
+            .collect()
+    }
+
+    pub(crate) fn region_count(&self) -> usize {
+        self.regions.len() + usize::from(!self.root.is_empty())
+    }
+
+    pub(crate) fn reference_count(&self) -> usize {
+        self.root.len() + self.regions.values().map(Vec::len).sum::<usize>()
+    }
+}
+
+fn integer_sqrt(value: u128) -> u128 {
+    if value < 2 {
+        return value;
+    }
+    let mut low = 1_u128;
+    let mut high = 1_u128 << (128 - value.leading_zeros()).div_ceil(2);
+    while low + 1 < high {
+        let middle = low + (high - low) / 2;
+        if middle <= value / middle {
+            low = middle;
+        } else {
+            high = middle;
+        }
+    }
+    low
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum EditError {
+    #[error("edit sequence {received} must be greater than {latest}")]
+    OutOfOrder { latest: u64, received: u64 },
+    #[error("edit id was already applied at a different sequence")]
+    DuplicateId,
+    #[error("invalid canonical edit-log encoding")]
+    Codec,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EditLog {
+    operations: Vec<EditOp>,
+}
+
+impl EditLog {
+    /// Canonicalize operations delivered by independent workers or network
+    /// scheduling. Authoritative sequence numbers, not arrival order, define
+    /// replay order.
+    pub fn from_scheduled(mut operations: Vec<EditOp>) -> Result<Self, EditError> {
+        operations.sort_unstable_by_key(|operation| (operation.sequence, operation.stable_id));
+        let mut log = Self::default();
+        for operation in operations {
+            log.push(operation)?;
+        }
+        Ok(log)
+    }
+
+    pub fn push(&mut self, operation: EditOp) -> Result<(), EditError> {
+        if let Some(existing) = self
+            .operations
+            .iter()
+            .find(|existing| existing.stable_id == operation.stable_id)
+        {
+            return if *existing == operation {
+                Ok(())
+            } else {
+                Err(EditError::DuplicateId)
+            };
+        }
+        if let Some(latest) = self.operations.last().map(|op| op.sequence) {
+            if operation.sequence <= latest {
+                return Err(EditError::OutOfOrder {
+                    latest,
+                    received: operation.sequence,
+                });
+            }
+        }
+        self.operations.push(operation);
+        Ok(())
+    }
+
+    pub fn operations(&self) -> &[EditOp] {
+        &self.operations
+    }
+
+    pub fn latest_sequence(&self) -> u64 {
+        self.operations
+            .last()
+            .map_or(0, |operation| operation.sequence)
+    }
+
+    pub fn apply(&self, cell_xyz: [i64; 3], mut cell: CellWord) -> CellWord {
+        for operation in &self.operations {
+            let (min, max) = operation.shape.bounds();
+            if (0..3).all(|axis| cell_xyz[axis] >= min[axis] && cell_xyz[axis] < max[axis]) {
+                cell = operation.apply(cell_xyz, cell);
+            }
+        }
+        cell
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut output = Vec::with_capacity(12 + self.operations.len() * 56);
+        output.extend_from_slice(EDIT_LOG_MAGIC);
+        output.extend_from_slice(&(self.operations.len() as u32).to_le_bytes());
+        for operation in &self.operations {
+            output.extend_from_slice(&operation.sequence.to_le_bytes());
+            output.extend_from_slice(&operation.stable_id);
+            output.push(match operation.mode {
+                EditMode::Union => 0,
+                EditMode::Subtract => 1,
+                EditMode::Replace => 2,
+                EditMode::Paint => 3,
+            });
+            output.push(operation.material);
+            match operation.shape {
+                EditShape::Sphere {
+                    center_cell,
+                    radius_cells,
+                } => {
+                    output.push(0);
+                    output.push(0);
+                    for axis in center_cell {
+                        output.extend_from_slice(&axis.to_le_bytes());
+                    }
+                    output.extend_from_slice(&radius_cells.to_le_bytes());
+                }
+            }
+        }
+        output
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, EditError> {
+        if bytes.get(..8) != Some(EDIT_LOG_MAGIC) || bytes.len() < 12 {
+            return Err(EditError::Codec);
+        }
+        let count = read_u32(bytes, 8)? as usize;
+        let expected = 12_usize
+            .checked_add(count.checked_mul(56).ok_or(EditError::Codec)?)
+            .ok_or(EditError::Codec)?;
+        if bytes.len() != expected {
+            return Err(EditError::Codec);
+        }
+        let mut log = Self::default();
+        let mut cursor = 12;
+        for _ in 0..count {
+            let sequence = read_u64(bytes, cursor)?;
+            let stable_id = bytes
+                .get(cursor + 8..cursor + 24)
+                .ok_or(EditError::Codec)?
+                .try_into()
+                .map_err(|_| EditError::Codec)?;
+            let mode = match *bytes.get(cursor + 24).ok_or(EditError::Codec)? {
+                0 => EditMode::Union,
+                1 => EditMode::Subtract,
+                2 => EditMode::Replace,
+                3 => EditMode::Paint,
+                _ => return Err(EditError::Codec),
+            };
+            let material = *bytes.get(cursor + 25).ok_or(EditError::Codec)?;
+            if bytes.get(cursor + 26..cursor + 28) != Some(&[0, 0]) {
+                return Err(EditError::Codec);
+            }
+            let mut center_cell = [0_i64; 3];
+            for (axis, value) in center_cell.iter_mut().enumerate() {
+                *value = read_i64(bytes, cursor + 28 + axis * 8)?;
+            }
+            let radius_cells = read_u32(bytes, cursor + 52)?;
+            log.push(EditOp {
+                sequence,
+                stable_id,
+                shape: EditShape::Sphere {
+                    center_cell,
+                    radius_cells,
+                },
+                mode,
+                material,
+            })?;
+            cursor += 56;
+        }
+        Ok(log)
+    }
+
+    pub fn content_hash(&self) -> ContentHash {
+        ContentHash::of(&self.encode())
+    }
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, EditError> {
+    Ok(u32::from_le_bytes(
+        bytes
+            .get(offset..offset + 4)
+            .ok_or(EditError::Codec)?
+            .try_into()
+            .map_err(|_| EditError::Codec)?,
+    ))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, EditError> {
+    Ok(u64::from_le_bytes(
+        bytes
+            .get(offset..offset + 8)
+            .ok_or(EditError::Codec)?
+            .try_into()
+            .map_err(|_| EditError::Codec)?,
+    ))
+}
+
+fn read_i64(bytes: &[u8], offset: usize) -> Result<i64, EditError> {
+    Ok(i64::from_le_bytes(
+        bytes
+            .get(offset..offset + 8)
+            .ok_or(EditError::Codec)?
+            .try_into()
+            .map_err(|_| EditError::Codec)?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_edit_log_round_trips_and_rejects_reordering() {
+        let first = EditOp {
+            sequence: 4,
+            stable_id: [4; 16],
+            shape: EditShape::Sphere {
+                center_cell: [-9, 2, 17],
+                radius_cells: 6,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        };
+        let second = EditOp {
+            sequence: 9,
+            stable_id: [9; 16],
+            shape: EditShape::Sphere {
+                center_cell: [3, -7, 1],
+                radius_cells: 2,
+            },
+            mode: EditMode::Paint,
+            material: 8,
+        };
+        let mut log = EditLog::default();
+        log.push(first).unwrap();
+        log.push(second).unwrap();
+        let decoded = EditLog::decode(&log.encode()).unwrap();
+        assert_eq!(decoded.operations(), log.operations());
+        assert_eq!(decoded.content_hash(), log.content_hash());
+        assert_eq!(
+            log.push(EditOp {
+                sequence: 2,
+                stable_id: [2; 16],
+                ..first
+            }),
+            Err(EditError::OutOfOrder {
+                latest: 9,
+                received: 2
+            })
+        );
+    }
+
+    #[test]
+    fn worker_arrival_order_does_not_change_canonical_replay() {
+        let operations = (1..=32)
+            .map(|sequence| EditOp {
+                sequence,
+                stable_id: [sequence as u8; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [sequence as i64 - 16, -(sequence as i64), 3],
+                    radius_cells: (sequence % 7 + 1) as u32,
+                },
+                mode: if sequence % 2 == 0 {
+                    EditMode::Union
+                } else {
+                    EditMode::Subtract
+                },
+                material: sequence as u8,
+            })
+            .collect::<Vec<_>>();
+        let forward = EditLog::from_scheduled(operations.clone()).unwrap();
+        let reverse = EditLog::from_scheduled(operations.into_iter().rev().collect()).unwrap();
+        assert_eq!(forward, reverse);
+        assert_eq!(forward.content_hash(), reverse.content_hash());
+        for coordinate in [[-20, 0, 3], [0, -10, 3], [20, -30, 3]] {
+            assert_eq!(
+                forward.apply(coordinate, CellWord::AIR),
+                reverse.apply(coordinate, CellWord::AIR)
+            );
+        }
+    }
+
+    #[test]
+    fn edit_page_amplification_is_bounded_without_visiting_pages() {
+        let one_cell = EditShape::Sphere {
+            center_cell: [0; 3],
+            radius_cells: 0,
+        };
+        assert_eq!(one_cell.affected_lod0_page_count(), 1);
+
+        let across_negative_boundary = EditShape::Sphere {
+            center_cell: [0; 3],
+            radius_cells: 1,
+        };
+        assert_eq!(across_negative_boundary.affected_lod0_page_count(), 8);
+    }
+
+    #[test]
+    fn edits_attach_once_and_page_queries_visit_only_ancestors() {
+        let operations = [
+            EditOp {
+                sequence: 1,
+                stable_id: [1; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [3_208, 3_208, 3_208],
+                    radius_cells: 1,
+                },
+                mode: EditMode::Subtract,
+                material: 0,
+            },
+            EditOp {
+                sequence: 2,
+                stable_id: [2; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [8, 8, 8],
+                    radius_cells: 1,
+                },
+                mode: EditMode::Paint,
+                material: 4,
+            },
+            EditOp {
+                sequence: 3,
+                stable_id: [3; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [0; 3],
+                    radius_cells: 1,
+                },
+                mode: EditMode::Union,
+                material: 7,
+            },
+        ];
+        let mut log = EditLog::default();
+        let mut index = EditIndex::new(12);
+        for operation in operations {
+            let operation_index = log.operations().len();
+            log.push(operation).unwrap();
+            index.insert(operation_index, operation);
+        }
+
+        let local = index.operations_for_page(&log, PageKey::new(0, [0; 3]), 0);
+        assert_eq!(
+            local
+                .iter()
+                .map(|operation| operation.sequence)
+                .collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+        let far = index.operations_for_page(&log, PageKey::new(0, [100; 3]), 1);
+        assert_eq!(
+            far.iter()
+                .map(|operation| operation.sequence)
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+        assert_eq!(index.region_count(), 3);
+        assert_eq!(index.reference_count(), operations.len());
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/generator.rs
+++ b/crates/subsystems/pulsar_terrain/src/generator.rs
@@ -1,0 +1,84 @@
+use crate::{CellWord, ContentHash, MaterialId};
+
+/// Deterministic canonical terrain source. Implementations must use integer or
+/// fixed-point math and include every behavior-changing parameter in `hash`.
+pub trait DeterministicGenerator: Send + Sync {
+    fn hash(&self) -> ContentHash;
+    fn sample_cell(&self, cell_xyz: [i64; 3]) -> CellWord;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FixedSphereGenerator {
+    pub center_cell: [i64; 3],
+    pub radius_cells: u64,
+    pub material: MaterialId,
+}
+
+impl DeterministicGenerator for FixedSphereGenerator {
+    fn hash(&self) -> ContentHash {
+        let mut bytes = Vec::with_capacity(34);
+        bytes.extend_from_slice(b"pulsar.fixed-sphere.v1");
+        for axis in self.center_cell {
+            bytes.extend_from_slice(&axis.to_le_bytes());
+        }
+        bytes.extend_from_slice(&self.radius_cells.to_le_bytes());
+        bytes.push(self.material);
+        ContentHash::of(&bytes)
+    }
+
+    fn sample_cell(&self, cell_xyz: [i64; 3]) -> CellWord {
+        let delta = [
+            i128::from(cell_xyz[0]) - i128::from(self.center_cell[0]),
+            i128::from(cell_xyz[1]) - i128::from(self.center_cell[1]),
+            i128::from(cell_xyz[2]) - i128::from(self.center_cell[2]),
+        ];
+        let distance_squared = delta
+            .iter()
+            .map(|axis| axis.saturating_mul(*axis) as u128)
+            .sum::<u128>();
+        let distance = integer_sqrt(distance_squared);
+        let signed_distance = (distance as i128 - i128::from(self.radius_cells))
+            .clamp(i128::from(i16::MIN), i128::from(i16::MAX)) as i16;
+        let material = if signed_distance <= 0 {
+            self.material
+        } else {
+            0
+        };
+        CellWord::new(signed_distance, material, 0)
+    }
+}
+
+fn integer_sqrt(value: u128) -> u128 {
+    if value < 2 {
+        return value;
+    }
+    let mut low = 1_u128;
+    let mut high = 1_u128 << (128 - value.leading_zeros()).div_ceil(2);
+    while low + 1 < high {
+        let middle = low + (high - low) / 2;
+        if middle <= value / middle {
+            low = middle;
+        } else {
+            high = middle;
+        }
+    }
+    low
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_sphere_is_stable_and_signed() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 10,
+            material: 7,
+        };
+        assert!(generator.sample_cell([0; 3]).is_solid());
+        assert_eq!(generator.sample_cell([0; 3]).material(), 7);
+        assert!(!generator.sample_cell([20, 0, 0]).is_solid());
+        assert_eq!(generator.hash(), generator.hash());
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/hierarchy.rs
+++ b/crates/subsystems/pulsar_terrain/src/hierarchy.rs
@@ -1,0 +1,332 @@
+use crate::{ContentHash, NodeState, PageKey};
+use thiserror::Error;
+
+const HIERARCHY_MAGIC: &[u8; 8] = b"PTHIER01";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum TreeNode {
+    Leaf(NodeState),
+    Branch(Box<[TreeNode; 8]>),
+}
+
+/// A mutable sparse brick hierarchy covering a centered cube of LOD0 pages.
+/// Splitting one address allocates only eight siblings per traversed level.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SparseBrickTree {
+    root_lod: u8,
+    root_min_page: [i64; 3],
+    root: TreeNode,
+}
+
+impl SparseBrickTree {
+    pub fn centered(root_lod: u8, state: NodeState) -> Result<Self, HierarchyError> {
+        if root_lod == 0 || root_lod > 62 || state == NodeState::Branch {
+            return Err(HierarchyError::InvalidRoot);
+        }
+        let half = 1_i64 << (root_lod - 1);
+        Ok(Self {
+            root_lod,
+            root_min_page: [-half; 3],
+            root: TreeNode::Leaf(state),
+        })
+    }
+
+    pub fn root_state(&self) -> NodeState {
+        match &self.root {
+            TreeNode::Leaf(state) => state.clone(),
+            TreeNode::Branch(_) => NodeState::Branch,
+        }
+    }
+
+    pub fn root_lod(&self) -> u8 {
+        self.root_lod
+    }
+
+    /// Exact O(1) root replacement, including whole-planet deletion.
+    pub fn set_root(&mut self, state: NodeState) -> Result<(), HierarchyError> {
+        if state == NodeState::Branch {
+            return Err(HierarchyError::BranchIsInternal);
+        }
+        self.root = TreeNode::Leaf(state);
+        Ok(())
+    }
+
+    pub fn set(&mut self, key: PageKey, state: NodeState) -> Result<(), HierarchyError> {
+        if state == NodeState::Branch {
+            return Err(HierarchyError::BranchIsInternal);
+        }
+        let path = self.path_for(key)?;
+        set_recursive(&mut self.root, &path, state);
+        Ok(())
+    }
+
+    pub fn resolve(&self, key: PageKey) -> Result<NodeState, HierarchyError> {
+        let path = self.path_for(key)?;
+        let mut node = &self.root;
+        for child in path {
+            match node {
+                TreeNode::Leaf(state) => return Ok(state.clone()),
+                TreeNode::Branch(children) => node = &children[child],
+            }
+        }
+        Ok(match node {
+            TreeNode::Leaf(state) => state.clone(),
+            TreeNode::Branch(_) => NodeState::Branch,
+        })
+    }
+
+    pub fn node_count(&self) -> usize {
+        count_nodes(&self.root)
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut output = Vec::with_capacity(40 + self.node_count() * 2);
+        output.extend_from_slice(HIERARCHY_MAGIC);
+        output.push(self.root_lod);
+        output.extend_from_slice(&[0; 7]);
+        for axis in self.root_min_page {
+            output.extend_from_slice(&axis.to_le_bytes());
+        }
+        encode_node(&self.root, &mut output);
+        output
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, HierarchyError> {
+        if bytes.len() < 41
+            || bytes.get(..8) != Some(HIERARCHY_MAGIC)
+            || bytes.get(9..16) != Some(&[0; 7])
+        {
+            return Err(HierarchyError::Codec);
+        }
+        let root_lod = bytes[8];
+        if root_lod == 0 || root_lod > 62 {
+            return Err(HierarchyError::Codec);
+        }
+        let mut root_min_page = [0_i64; 3];
+        for (axis, value) in root_min_page.iter_mut().enumerate() {
+            let offset = 16 + axis * 8;
+            *value = i64::from_le_bytes(
+                bytes
+                    .get(offset..offset + 8)
+                    .ok_or(HierarchyError::Codec)?
+                    .try_into()
+                    .map_err(|_| HierarchyError::Codec)?,
+            );
+        }
+        let expected_min = -(1_i64 << (root_lod - 1));
+        if root_min_page != [expected_min; 3] {
+            return Err(HierarchyError::Codec);
+        }
+        let mut cursor = 40;
+        let root = decode_node(bytes, &mut cursor, 0, root_lod)?;
+        if cursor != bytes.len() {
+            return Err(HierarchyError::Codec);
+        }
+        Ok(Self {
+            root_lod,
+            root_min_page,
+            root,
+        })
+    }
+
+    pub fn content_hash(&self) -> ContentHash {
+        ContentHash::of(&self.encode())
+    }
+
+    fn path_for(&self, key: PageKey) -> Result<Vec<usize>, HierarchyError> {
+        if key.lod >= self.root_lod {
+            return Err(HierarchyError::LodOutsideRoot(key.lod));
+        }
+        let target_min = key.lod0_min().ok_or(HierarchyError::CoordinateOverflow)?;
+        let target_size = 1_i64 << key.lod;
+        let root_size = 1_i64 << self.root_lod;
+        for axis in 0..3 {
+            let relative = target_min[axis]
+                .checked_sub(self.root_min_page[axis])
+                .ok_or(HierarchyError::CoordinateOverflow)?;
+            if relative < 0 || relative.saturating_add(target_size) > root_size {
+                return Err(HierarchyError::OutsideRoot(key));
+            }
+        }
+
+        let depth = usize::from(self.root_lod - key.lod);
+        let relative = [
+            target_min[0] - self.root_min_page[0],
+            target_min[1] - self.root_min_page[1],
+            target_min[2] - self.root_min_page[2],
+        ];
+        let mut path = Vec::with_capacity(depth);
+        for step in 0..depth {
+            let bit = u32::from(self.root_lod - 1 - step as u8);
+            let x = ((relative[0] >> bit) & 1) as usize;
+            let y = ((relative[1] >> bit) & 1) as usize;
+            let z = ((relative[2] >> bit) & 1) as usize;
+            path.push(x | (y << 1) | (z << 2));
+        }
+        Ok(path)
+    }
+}
+
+fn set_recursive(node: &mut TreeNode, path: &[usize], state: NodeState) {
+    if path.is_empty() {
+        *node = TreeNode::Leaf(state);
+        return;
+    }
+    if let TreeNode::Leaf(previous) = node {
+        let child = TreeNode::Leaf(previous.clone());
+        *node = TreeNode::Branch(Box::new(std::array::from_fn(|_| child.clone())));
+    }
+    let TreeNode::Branch(children) = node else {
+        unreachable!();
+    };
+    set_recursive(&mut children[path[0]], &path[1..], state);
+
+    let first = match &children[0] {
+        TreeNode::Leaf(first) => first.clone(),
+        TreeNode::Branch(_) => return,
+    };
+    if children
+        .iter()
+        .all(|child| matches!(child, TreeNode::Leaf(value) if *value == first))
+    {
+        *node = TreeNode::Leaf(first);
+    }
+}
+
+fn count_nodes(node: &TreeNode) -> usize {
+    match node {
+        TreeNode::Leaf(_) => 1,
+        TreeNode::Branch(children) => 1 + children.iter().map(count_nodes).sum::<usize>(),
+    }
+}
+
+fn encode_node(node: &TreeNode, output: &mut Vec<u8>) {
+    match node {
+        TreeNode::Leaf(NodeState::Air) => output.push(0),
+        TreeNode::Leaf(NodeState::Solid(material)) => {
+            output.push(1);
+            output.push(*material);
+        }
+        TreeNode::Leaf(NodeState::Procedural(hash)) => {
+            output.push(2);
+            output.extend_from_slice(&hash.0);
+        }
+        TreeNode::Branch(children) => {
+            output.push(3);
+            for child in children.iter() {
+                encode_node(child, output);
+            }
+        }
+        TreeNode::Leaf(NodeState::Page(hash)) => {
+            output.push(4);
+            output.extend_from_slice(&hash.0);
+        }
+        TreeNode::Leaf(NodeState::Branch) => unreachable!("Branch is stored structurally"),
+    }
+}
+
+fn decode_node(
+    bytes: &[u8],
+    cursor: &mut usize,
+    depth: u8,
+    root_lod: u8,
+) -> Result<TreeNode, HierarchyError> {
+    let tag = *bytes.get(*cursor).ok_or(HierarchyError::Codec)?;
+    *cursor += 1;
+    match tag {
+        0 => Ok(TreeNode::Leaf(NodeState::Air)),
+        1 => {
+            let material = *bytes.get(*cursor).ok_or(HierarchyError::Codec)?;
+            *cursor += 1;
+            Ok(TreeNode::Leaf(NodeState::Solid(material)))
+        }
+        2 | 4 => {
+            let hash = ContentHash(
+                bytes
+                    .get(*cursor..*cursor + 32)
+                    .ok_or(HierarchyError::Codec)?
+                    .try_into()
+                    .map_err(|_| HierarchyError::Codec)?,
+            );
+            *cursor += 32;
+            Ok(TreeNode::Leaf(if tag == 2 {
+                NodeState::Procedural(hash)
+            } else {
+                NodeState::Page(hash)
+            }))
+        }
+        3 if depth < root_lod => {
+            let mut children = Vec::with_capacity(8);
+            for _ in 0..8 {
+                children.push(decode_node(bytes, cursor, depth + 1, root_lod)?);
+            }
+            Ok(TreeNode::Branch(Box::new(
+                children.try_into().map_err(|_| HierarchyError::Codec)?,
+            )))
+        }
+        _ => Err(HierarchyError::Codec),
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum HierarchyError {
+    #[error("root LOD must be 1..=62 and root state must be uniform")]
+    InvalidRoot,
+    #[error("Branch is an internal state and cannot be assigned directly")]
+    BranchIsInternal,
+    #[error("LOD{0} is not a descendant of the root")]
+    LodOutsideRoot(u8),
+    #[error("page {0:?} is outside the centered root cube")]
+    OutsideRoot(PageKey),
+    #[error("page coordinate overflow")]
+    CoordinateOverflow,
+    #[error("invalid canonical sparse-hierarchy encoding")]
+    Codec,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn negative_coordinates_resolve_and_uniform_siblings_collapse() {
+        let mut tree = SparseBrickTree::centered(4, NodeState::Air).unwrap();
+        let parent = PageKey::new(1, [-1, 0, 0]);
+        for z in 0..2 {
+            for y in 0..2 {
+                for x in 0..2 {
+                    tree.set(PageKey::new(0, [-2 + x, y, z]), NodeState::Solid(4))
+                        .unwrap();
+                }
+            }
+        }
+        assert_eq!(tree.resolve(parent).unwrap(), NodeState::Solid(4));
+        assert!(tree.node_count() < 1 + 8 * 4);
+    }
+
+    #[test]
+    fn root_delete_drops_all_materialized_nodes() {
+        let mut tree = SparseBrickTree::centered(24, NodeState::Air).unwrap();
+        tree.set(PageKey::new(0, [12, -9, 3]), NodeState::Solid(1))
+            .unwrap();
+        assert!(tree.node_count() <= 1 + 8 * 24);
+        tree.set_root(NodeState::Air).unwrap();
+        assert_eq!(tree.node_count(), 1);
+    }
+
+    #[test]
+    fn canonical_hierarchy_round_trips_with_stable_hash() {
+        let generator = ContentHash::of(b"generator-v1");
+        let mut tree = SparseBrickTree::centered(12, NodeState::Procedural(generator)).unwrap();
+        tree.set(PageKey::new(0, [-3, 7, 2]), NodeState::Solid(6))
+            .unwrap();
+        tree.set(
+            PageKey::new(2, [4, -2, 1]),
+            NodeState::Page(ContentHash::of(b"page")),
+        )
+        .unwrap();
+        let decoded = SparseBrickTree::decode(&tree.encode()).unwrap();
+        assert_eq!(decoded, tree);
+        assert_eq!(decoded.content_hash(), tree.content_hash());
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/lib.rs
+++ b/crates/subsystems/pulsar_terrain/src/lib.rs
@@ -1,0 +1,44 @@
+//! Authoritative sparse planetary voxel terrain state.
+//!
+//! This crate owns canonical planet-space addressing, deterministic generation
+//! and edits, the mutable sparse hierarchy, stable page encoding, and durable
+//! snapshots. Rendering and physics consume derived data and never become the
+//! source of truth.
+
+mod component;
+mod core;
+mod edit;
+mod generator;
+mod hierarchy;
+mod page;
+mod runtime;
+mod snapshot;
+mod store;
+mod types;
+
+pub use component::{
+    ComponentError, PlanetDefinition, PlanetTerrainComponent, PLANET_TERRAIN_CLASS_NAME,
+};
+pub use core::{
+    PageBuildCommitOutcome, PageBuildPreparation, PageBuildRequest, PageBuildResult, TerrainCore,
+    TerrainCoreError, TerrainMemoryCounters, TerrainWorkCounters,
+};
+pub use edit::{EditError, EditLog, EditMode, EditOp, EditShape};
+pub use generator::{DeterministicGenerator, FixedSphereGenerator};
+pub use hierarchy::{HierarchyError, SparseBrickTree};
+pub use page::{
+    PageCodecError, VoxelPage, CELL_COUNT, MICROBRICKS_PER_AXIS, MICROBRICK_COUNT, MICROBRICK_EDGE,
+    PAGE_EDGE,
+};
+pub use runtime::{
+    TerrainBackpressure, TerrainRequestClass, TerrainRequestOutcome, TerrainRuntimeConfig,
+    TerrainRuntimeCounters, TerrainRuntimeError, TerrainRuntimeEvent, TerrainRuntimeHandle,
+    TerrainSubsystem, TERRAIN_SUBSYSTEM_ID,
+};
+pub use snapshot::{CompactedPageRecord, SnapshotCodecError, TerrainSnapshot};
+pub use store::{SnapshotRecord, TerrainStore, TerrainStoreError};
+pub use types::{
+    CellWord, ContentHash, MaterialId, NodeState, PageId, PageKey, PlanetFrame, PlanetFramePayload,
+    PlanetId, PlanetIdParseError, PlanetPosition, PositionError, LOD0_CELL_SIZE_METERS,
+    MILLIMETER_INTERACTION_RADIUS_METERS, PAGE_EDGE_CELLS,
+};

--- a/crates/subsystems/pulsar_terrain/src/page.rs
+++ b/crates/subsystems/pulsar_terrain/src/page.rs
@@ -1,0 +1,419 @@
+use crate::{CellWord, ContentHash, DeterministicGenerator, EditLog, EditOp, PageId, PageKey};
+use std::sync::Arc;
+use thiserror::Error;
+
+pub const PAGE_EDGE: usize = 32;
+pub const MICROBRICK_EDGE: usize = 8;
+pub const MICROBRICKS_PER_AXIS: usize = PAGE_EDGE / MICROBRICK_EDGE;
+pub const MICROBRICK_COUNT: usize =
+    MICROBRICKS_PER_AXIS * MICROBRICKS_PER_AXIS * MICROBRICKS_PER_AXIS;
+pub const CELL_COUNT: usize = PAGE_EDGE * PAGE_EDGE * PAGE_EDGE;
+const MAGIC: &[u8; 8] = b"PTRNPG01";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VoxelPage {
+    storage: PageStorage,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PageStorage {
+    Constant(CellWord),
+    Dense(Arc<[CellWord]>),
+}
+
+impl VoxelPage {
+    pub fn microbrick_address(local_cell: [usize; 3]) -> Option<(usize, [usize; 3])> {
+        if local_cell.iter().any(|axis| *axis >= PAGE_EDGE) {
+            return None;
+        }
+        let brick = local_cell.map(|axis| axis / MICROBRICK_EDGE);
+        let within = local_cell.map(|axis| axis % MICROBRICK_EDGE);
+        let index = brick[0] + MICROBRICKS_PER_AXIS * (brick[1] + MICROBRICKS_PER_AXIS * brick[2]);
+        Some((index, within))
+    }
+
+    pub fn constant(cell: CellWord) -> Self {
+        Self {
+            storage: PageStorage::Constant(cell),
+        }
+    }
+
+    pub fn from_cells(cells: Vec<CellWord>) -> Result<Self, PageCodecError> {
+        if cells.len() != CELL_COUNT {
+            return Err(PageCodecError::CellCount(cells.len()));
+        }
+        let first = cells[0];
+        if cells.iter().all(|cell| *cell == first) {
+            Ok(Self::constant(first))
+        } else {
+            Ok(Self {
+                storage: PageStorage::Dense(cells.into()),
+            })
+        }
+    }
+
+    pub fn generate(
+        key: PageKey,
+        generator: &dyn DeterministicGenerator,
+        edits: &EditLog,
+    ) -> Result<Self, PageCodecError> {
+        Self::generate_with_operations(key, generator, edits.operations())
+    }
+
+    pub(crate) fn generate_with_operations(
+        key: PageKey,
+        generator: &dyn DeterministicGenerator,
+        operations: &[EditOp],
+    ) -> Result<Self, PageCodecError> {
+        if key.lod != 0 {
+            return Err(PageCodecError::UnsupportedLod(key.lod));
+        }
+        let origin = key
+            .lod0_cell_min()
+            .ok_or(PageCodecError::CoordinateOverflow)?;
+        let mut cells = Vec::with_capacity(CELL_COUNT);
+        for z in 0..PAGE_EDGE as i64 {
+            for y in 0..PAGE_EDGE as i64 {
+                for x in 0..PAGE_EDGE as i64 {
+                    let coordinate = [origin[0] + x, origin[1] + y, origin[2] + z];
+                    let mut cell = generator.sample_cell(coordinate);
+                    for operation in operations {
+                        let (min, max) = operation.shape.bounds();
+                        if (0..3).all(|axis| {
+                            coordinate[axis] >= min[axis] && coordinate[axis] < max[axis]
+                        }) {
+                            cell = operation.apply(coordinate, cell);
+                        }
+                    }
+                    cells.push(cell);
+                }
+            }
+        }
+        Self::from_cells(cells)
+    }
+
+    /// Fold only the supplied ordered edit tail into an already materialized
+    /// LOD0 page. The procedural source and older edit prefix are not replayed.
+    pub fn apply_edit_tail(
+        &self,
+        key: PageKey,
+        operations: &[EditOp],
+    ) -> Result<Self, PageCodecError> {
+        if key.lod != 0 {
+            return Err(PageCodecError::UnsupportedLod(key.lod));
+        }
+        let origin = key
+            .lod0_cell_min()
+            .ok_or(PageCodecError::CoordinateOverflow)?;
+        let mut cells = Vec::with_capacity(CELL_COUNT);
+        for z in 0..PAGE_EDGE as i64 {
+            for y in 0..PAGE_EDGE as i64 {
+                for x in 0..PAGE_EDGE as i64 {
+                    let coordinate = [origin[0] + x, origin[1] + y, origin[2] + z];
+                    let mut cell = self.get([x as usize, y as usize, z as usize]).unwrap();
+                    for operation in operations {
+                        let (min, max) = operation.shape.bounds();
+                        if (0..3).all(|axis| {
+                            coordinate[axis] >= min[axis] && coordinate[axis] < max[axis]
+                        }) {
+                            cell = operation.apply(coordinate, cell);
+                        }
+                    }
+                    cells.push(cell);
+                }
+            }
+        }
+        Self::from_cells(cells)
+    }
+
+    /// Conservatively reduce eight LOD N children into one LOD N+1 page.
+    /// Any solid fine sample keeps the coarse cell solid, preventing thin
+    /// features from disappearing solely because of reduction.
+    pub fn reduce_children(children: [&Self; 8]) -> Self {
+        let mut cells = Vec::with_capacity(CELL_COUNT);
+        for z in 0..PAGE_EDGE {
+            for y in 0..PAGE_EDGE {
+                for x in 0..PAGE_EDGE {
+                    let mut samples = [CellWord::AIR; 8];
+                    let mut sample_index = 0;
+                    for dz in 0..2 {
+                        for dy in 0..2 {
+                            for dx in 0..2 {
+                                let fine = [x * 2 + dx, y * 2 + dy, z * 2 + dz];
+                                let child_xyz = fine.map(|axis| axis / PAGE_EDGE);
+                                let local = fine.map(|axis| axis % PAGE_EDGE);
+                                let child_index =
+                                    child_xyz[0] | (child_xyz[1] << 1) | (child_xyz[2] << 2);
+                                samples[sample_index] = children[child_index].get(local).unwrap();
+                                sample_index += 1;
+                            }
+                        }
+                    }
+                    let selected = samples
+                        .iter()
+                        .filter(|sample| sample.is_solid())
+                        .min_by_key(|sample| sample.density())
+                        .or_else(|| samples.iter().min_by_key(|sample| sample.density()))
+                        .copied()
+                        .unwrap();
+                    let flags = samples
+                        .iter()
+                        .fold(0, |flags, sample| flags | sample.flags());
+                    cells.push(CellWord::new(
+                        selected.density(),
+                        selected.material(),
+                        flags,
+                    ));
+                }
+            }
+        }
+        Self::from_cells(cells).expect("LOD reduction always produces exactly one page")
+    }
+
+    pub fn cells(&self) -> impl ExactSizeIterator<Item = CellWord> + '_ {
+        (0..CELL_COUNT).map(|index| self.cell_at_index(index))
+    }
+
+    pub fn constant_cell(&self) -> Option<CellWord> {
+        match self.storage {
+            PageStorage::Constant(cell) => Some(cell),
+            PageStorage::Dense(_) => None,
+        }
+    }
+
+    /// Heap bytes used by canonical cell storage, excluding the small page
+    /// object itself. Uniform pages deliberately report zero.
+    pub fn dense_allocation_bytes(&self) -> usize {
+        match &self.storage {
+            PageStorage::Constant(_) => 0,
+            PageStorage::Dense(cells) => cells.len() * std::mem::size_of::<CellWord>(),
+        }
+    }
+
+    pub fn get(&self, xyz: [usize; 3]) -> Option<CellWord> {
+        if xyz.iter().any(|axis| *axis >= PAGE_EDGE) {
+            return None;
+        }
+        Some(self.cell_at_index(xyz[0] + PAGE_EDGE * (xyz[1] + PAGE_EDGE * xyz[2])))
+    }
+
+    /// Stable little-endian RLE format. Halos are deliberately excluded.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut output = Vec::with_capacity(16 + CELL_COUNT * 8);
+        output.extend_from_slice(MAGIC);
+        output.extend_from_slice(&(CELL_COUNT as u32).to_le_bytes());
+        let mut index = 0;
+        while index < CELL_COUNT {
+            let value = self.cell_at_index(index);
+            let mut run = 1_usize;
+            while index + run < CELL_COUNT
+                && self.cell_at_index(index + run) == value
+                && run < u32::MAX as usize
+            {
+                run += 1;
+            }
+            output.extend_from_slice(&(run as u32).to_le_bytes());
+            output.extend_from_slice(&value.0.to_le_bytes());
+            index += run;
+        }
+        output
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, PageCodecError> {
+        if bytes.get(..8) != Some(MAGIC) {
+            return Err(PageCodecError::Magic);
+        }
+        let count = read_u32(bytes, 8)? as usize;
+        if count != CELL_COUNT {
+            return Err(PageCodecError::CellCount(count));
+        }
+        let mut cells = Vec::with_capacity(CELL_COUNT);
+        let mut cursor = 12;
+        let mut previous = None;
+        while cursor < bytes.len() && cells.len() < CELL_COUNT {
+            let run = read_u32(bytes, cursor)? as usize;
+            let value = CellWord(read_u32(bytes, cursor + 4)?);
+            cursor += 8;
+            if run == 0 || cells.len().saturating_add(run) > CELL_COUNT {
+                return Err(PageCodecError::RunLength);
+            }
+            if previous == Some(value) {
+                return Err(PageCodecError::NonCanonical);
+            }
+            cells.resize(cells.len() + run, value);
+            previous = Some(value);
+        }
+        if cells.len() != CELL_COUNT || cursor != bytes.len() {
+            return Err(PageCodecError::TruncatedOrTrailing);
+        }
+        Self::from_cells(cells)
+    }
+
+    pub fn page_id(&self) -> PageId {
+        ContentHash::of(&self.encode())
+    }
+
+    fn cell_at_index(&self, index: usize) -> CellWord {
+        match &self.storage {
+            PageStorage::Constant(cell) => *cell,
+            PageStorage::Dense(cells) => cells[index],
+        }
+    }
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, PageCodecError> {
+    let value = bytes
+        .get(offset..offset + 4)
+        .ok_or(PageCodecError::TruncatedOrTrailing)?;
+    Ok(u32::from_le_bytes(value.try_into().unwrap()))
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PageCodecError {
+    #[error("invalid terrain page magic/version")]
+    Magic,
+    #[error("terrain page has {0} cells instead of 32768")]
+    CellCount(usize),
+    #[error("invalid terrain page run length")]
+    RunLength,
+    #[error("terrain page is truncated or contains trailing bytes")]
+    TruncatedOrTrailing,
+    #[error("terrain page uses a non-canonical run encoding")]
+    NonCanonical,
+    #[error("materialized pages currently require LOD0, received LOD{0}")]
+    UnsupportedLod(u8),
+    #[error("terrain page coordinate overflow")]
+    CoordinateOverflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EditMode, EditShape, FixedSphereGenerator};
+
+    #[test]
+    fn constant_and_dense_pages_round_trip_with_stable_hashes() {
+        let constant = VoxelPage::constant(CellWord::new(-4, 3, 1));
+        assert_eq!(VoxelPage::decode(&constant.encode()).unwrap(), constant);
+        assert_eq!(constant.encode().len(), 20);
+        assert_eq!(constant.dense_allocation_bytes(), 0);
+
+        let cells = (0..CELL_COUNT)
+            .map(|index| CellWord::new(index as i16, (index % 251) as u8, 0))
+            .collect();
+        let dense = VoxelPage::from_cells(cells).unwrap();
+        assert_eq!(VoxelPage::decode(&dense.encode()).unwrap(), dense);
+        assert_eq!(dense.page_id(), ContentHash::of(&dense.encode()));
+        assert_eq!(
+            dense.dense_allocation_bytes(),
+            CELL_COUNT * std::mem::size_of::<CellWord>()
+        );
+    }
+
+    #[test]
+    fn codec_rejects_corruption_versions_and_noncanonical_runs() {
+        let page = VoxelPage::constant(CellWord::AIR);
+        let mut wrong_version = page.encode();
+        wrong_version[7] = b'2';
+        assert_eq!(
+            VoxelPage::decode(&wrong_version),
+            Err(PageCodecError::Magic)
+        );
+
+        let mut adjacent_runs = Vec::new();
+        adjacent_runs.extend_from_slice(MAGIC);
+        adjacent_runs.extend_from_slice(&(CELL_COUNT as u32).to_le_bytes());
+        adjacent_runs.extend_from_slice(&1_u32.to_le_bytes());
+        adjacent_runs.extend_from_slice(&CellWord::AIR.0.to_le_bytes());
+        adjacent_runs.extend_from_slice(&((CELL_COUNT - 1) as u32).to_le_bytes());
+        adjacent_runs.extend_from_slice(&CellWord::AIR.0.to_le_bytes());
+        assert_eq!(
+            VoxelPage::decode(&adjacent_runs),
+            Err(PageCodecError::NonCanonical)
+        );
+
+        let mut corrupt = page.encode();
+        corrupt.truncate(corrupt.len() - 1);
+        assert!(VoxelPage::decode(&corrupt).is_err());
+    }
+
+    #[test]
+    fn lod_reduction_preserves_a_single_thin_solid_sample() {
+        let air = VoxelPage::constant(CellWord::AIR);
+        let mut cells = vec![CellWord::AIR; CELL_COUNT];
+        cells[0] = CellWord::new(-1, 12, 4);
+        let feature = VoxelPage::from_cells(cells).unwrap();
+        let reduced =
+            VoxelPage::reduce_children([&feature, &air, &air, &air, &air, &air, &air, &air]);
+        let first = reduced.get([0, 0, 0]).unwrap();
+        assert!(first.is_solid());
+        assert_eq!(first.material(), 12);
+        assert_eq!(first.flags(), 4);
+    }
+
+    #[test]
+    fn microbrick_addressing_covers_every_page_cell_exactly() {
+        let mut hits = vec![0_u8; CELL_COUNT];
+        for z in 0..PAGE_EDGE {
+            for y in 0..PAGE_EDGE {
+                for x in 0..PAGE_EDGE {
+                    let (brick, local) = VoxelPage::microbrick_address([x, y, z]).unwrap();
+                    assert!(brick < MICROBRICK_COUNT);
+                    assert!(local.iter().all(|axis| *axis < MICROBRICK_EDGE));
+                    let reconstructed_brick = [
+                        brick % MICROBRICKS_PER_AXIS,
+                        (brick / MICROBRICKS_PER_AXIS) % MICROBRICKS_PER_AXIS,
+                        brick / (MICROBRICKS_PER_AXIS * MICROBRICKS_PER_AXIS),
+                    ];
+                    let reconstructed = [
+                        reconstructed_brick[0] * MICROBRICK_EDGE + local[0],
+                        reconstructed_brick[1] * MICROBRICK_EDGE + local[1],
+                        reconstructed_brick[2] * MICROBRICK_EDGE + local[2],
+                    ];
+                    assert_eq!(reconstructed, [x, y, z]);
+                    let linear = x + PAGE_EDGE * (y + PAGE_EDGE * z);
+                    hits[linear] += 1;
+                }
+            }
+        }
+        assert!(hits.into_iter().all(|count| count == 1));
+        assert_eq!(VoxelPage::microbrick_address([PAGE_EDGE, 0, 0]), None);
+    }
+
+    #[test]
+    fn incremental_edit_tail_matches_full_deterministic_replay() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 24,
+            material: 2,
+        };
+        let first = EditOp {
+            sequence: 1,
+            stable_id: [1; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8, 8, 8],
+                radius_cells: 5,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        };
+        let second = EditOp {
+            sequence: 2,
+            stable_id: [2; 16],
+            shape: EditShape::Sphere {
+                center_cell: [12, 8, 8],
+                radius_cells: 3,
+            },
+            mode: EditMode::Union,
+            material: 9,
+        };
+        let key = PageKey::new(0, [0; 3]);
+        let prefix = EditLog::from_scheduled(vec![first]).unwrap();
+        let complete = EditLog::from_scheduled(vec![second, first]).unwrap();
+        let prefix_page = VoxelPage::generate(key, &generator, &prefix).unwrap();
+        let incremental = prefix_page.apply_edit_tail(key, &[second]).unwrap();
+        let replayed = VoxelPage::generate(key, &generator, &complete).unwrap();
+        assert_eq!(incremental, replayed);
+        assert_eq!(incremental.page_id(), replayed.page_id());
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/runtime.rs
+++ b/crates/subsystems/pulsar_terrain/src/runtime.rs
@@ -1,0 +1,1676 @@
+use crate::{
+    CompactedPageRecord, EditOp, FixedSphereGenerator, PageBuildCommitOutcome,
+    PageBuildPreparation, PageBuildRequest, PageBuildResult, PageKey, PlanetDefinition, PlanetId,
+    TerrainCore, TerrainCoreError, CELL_COUNT,
+};
+use crossbeam_channel::{Receiver, Sender, TryRecvError};
+use engine_subsystems::{Subsystem, SubsystemContext, SubsystemError, SubsystemId};
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread::{self, JoinHandle};
+use thiserror::Error;
+
+pub const TERRAIN_SUBSYSTEM_ID: SubsystemId = SubsystemId::new("planetary_terrain");
+const DENSE_PAGE_BYTES: usize = CELL_COUNT * std::mem::size_of::<crate::CellWord>();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TerrainRequestClass {
+    Prefetch,
+    Visible,
+    Collision,
+    EditResponse,
+}
+
+impl TerrainRequestClass {
+    const fn priority(self) -> u8 {
+        match self {
+            Self::Prefetch => 0,
+            Self::Visible => 1,
+            Self::Collision => 2,
+            Self::EditResponse => 3,
+        }
+    }
+
+    const fn is_critical(self) -> bool {
+        matches!(self, Self::Collision | Self::EditResponse)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TerrainRuntimeConfig {
+    pub worker_count: usize,
+    pub max_planets: usize,
+    pub max_component_sources: usize,
+    pub request_capacity: usize,
+    pub critical_request_reserve: usize,
+    pub completion_capacity: usize,
+    pub event_capacity: usize,
+    pub max_resident_pages: usize,
+    pub max_resident_dense_bytes: usize,
+    pub max_completions_per_frame: usize,
+}
+
+impl Default for TerrainRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            worker_count: thread::available_parallelism()
+                .map_or(2, usize::from)
+                .saturating_sub(2)
+                .clamp(1, 8),
+            max_planets: 16,
+            max_component_sources: 64,
+            request_capacity: 1_024,
+            critical_request_reserve: 128,
+            completion_capacity: 1_024,
+            event_capacity: 2_048,
+            max_resident_pages: 8_192,
+            max_resident_dense_bytes: 1 << 30,
+            max_completions_per_frame: 64,
+        }
+    }
+}
+
+impl TerrainRuntimeConfig {
+    fn validate(&self) -> Result<(), TerrainRuntimeError> {
+        if self.worker_count == 0 {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "worker_count must be non-zero",
+            ));
+        }
+        if self.max_planets == 0 {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "max_planets must be non-zero",
+            ));
+        }
+        if self.max_component_sources == 0 {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "max_component_sources must be non-zero",
+            ));
+        }
+        if self.request_capacity == 0 {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "request_capacity must be non-zero",
+            ));
+        }
+        if self.critical_request_reserve >= self.request_capacity {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "critical_request_reserve must be smaller than request_capacity",
+            ));
+        }
+        if self.completion_capacity == 0 || self.event_capacity == 0 {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "completion_capacity and event_capacity must be non-zero",
+            ));
+        }
+        if self.critical_request_reserve >= self.completion_capacity {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "critical_request_reserve must be smaller than completion_capacity",
+            ));
+        }
+        if self.max_resident_pages == 0 || self.max_resident_dense_bytes < DENSE_PAGE_BYTES {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "resident budgets must hold at least one dense page",
+            ));
+        }
+        if self.max_completions_per_frame == 0 {
+            return Err(TerrainRuntimeError::InvalidConfig(
+                "max_completions_per_frame must be non-zero",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerrainBackpressure {
+    RequestQueue,
+    CompletionSlots,
+    EventQueue,
+    PlanetCapacity,
+    ComponentCapacity,
+    ResidentPages,
+    ResidentBytes,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TerrainRuntimeEvent {
+    PageReady {
+        planet_id: PlanetId,
+        page_key: PageKey,
+        planet_generation: u64,
+        page_generation: u64,
+        request_class: TerrainRequestClass,
+        record: CompactedPageRecord,
+    },
+    EvictPlanet {
+        planet_id: PlanetId,
+        retired_generation: u64,
+    },
+    StaleRejected {
+        planet_id: PlanetId,
+        page_key: PageKey,
+        planet_generation: u64,
+        page_generation: u64,
+    },
+    Backpressure {
+        planet_id: Option<PlanetId>,
+        page_key: Option<PageKey>,
+        kind: TerrainBackpressure,
+    },
+    Error {
+        planet_id: PlanetId,
+        page_key: PageKey,
+        message: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerrainRuntimeCounters {
+    pub planets: usize,
+    pub queued: usize,
+    pub in_flight: usize,
+    pub completed: usize,
+    pub events: usize,
+    pub outstanding: usize,
+    pub resident_pages: usize,
+    pub resident_dense_bytes: usize,
+    pub reserved_new_pages: usize,
+    pub reserved_result_bytes: usize,
+    pub queue_high_water: usize,
+    pub in_flight_high_water: usize,
+    pub completed_high_water: usize,
+    pub event_high_water: usize,
+    pub resident_page_high_water: usize,
+    pub resident_dense_byte_high_water: usize,
+    pub accepted: u64,
+    pub coalesced: u64,
+    pub priority_upgrades: u64,
+    pub cancelled: u64,
+    pub stale_rejected: u64,
+    pub backpressured: u64,
+    pub published: u64,
+    pub errors: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerrainRequestOutcome {
+    Queued {
+        planet_generation: u64,
+        page_generation: u64,
+    },
+    Coalesced {
+        planet_generation: u64,
+        page_generation: u64,
+        upgraded: bool,
+    },
+    Current {
+        planet_generation: u64,
+        page_generation: u64,
+        record: CompactedPageRecord,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum TerrainRuntimeError {
+    #[error("invalid terrain runtime configuration: {0}")]
+    InvalidConfig(&'static str),
+    #[error("terrain runtime is not running")]
+    NotRunning,
+    #[error("terrain runtime has already been initialized")]
+    AlreadyInitialized,
+    #[error("planet {0:?} is not registered")]
+    PlanetMissing(PlanetId),
+    #[error("planet capacity {capacity} is exhausted")]
+    PlanetCapacity { capacity: usize },
+    #[error("terrain component-source capacity {capacity} is exhausted")]
+    ComponentCapacity { capacity: usize },
+    #[error("request queue is saturated for {class:?}")]
+    RequestBackpressure { class: TerrainRequestClass },
+    #[error("completion capacity {capacity} is exhausted")]
+    CompletionBackpressure { capacity: usize },
+    #[error("runtime event capacity {capacity} is exhausted")]
+    EventBackpressure { capacity: usize },
+    #[error("planet {planet_id:?} resident-page budget {capacity} is exhausted")]
+    PlanetResidentPageBudget {
+        planet_id: PlanetId,
+        capacity: usize,
+    },
+    #[error("global resident-page budget {capacity} is exhausted")]
+    GlobalResidentPageBudget { capacity: usize },
+    #[error("global resident dense-byte budget {capacity} is exhausted")]
+    ResidentByteBudget { capacity: usize },
+    #[error("terrain generation counter overflowed")]
+    GenerationOverflow,
+    #[error(transparent)]
+    Core(#[from] TerrainCoreError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct RequestIdentity {
+    planet_id: PlanetId,
+    page_key: PageKey,
+    planet_generation: u64,
+    page_generation: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RequestPhase {
+    Queued,
+    Running,
+    Completed,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ActiveRequest {
+    phase: RequestPhase,
+    class: TerrainRequestClass,
+    deadline_tick: u64,
+    reserved_new_page: bool,
+}
+
+struct WorkJob {
+    identity: RequestIdentity,
+    request: PageBuildRequest<FixedSphereGenerator>,
+    class: TerrainRequestClass,
+    deadline_tick: u64,
+    order: u64,
+}
+
+struct WorkQueueState {
+    jobs: Vec<WorkJob>,
+    stopped: bool,
+}
+
+struct WorkQueue {
+    capacity: usize,
+    noncritical_capacity: usize,
+    state: Mutex<WorkQueueState>,
+    wake: Condvar,
+}
+
+impl WorkQueue {
+    fn new(config: &TerrainRuntimeConfig) -> Self {
+        Self {
+            capacity: config.request_capacity,
+            noncritical_capacity: config
+                .request_capacity
+                .saturating_sub(config.critical_request_reserve),
+            state: Mutex::new(WorkQueueState {
+                jobs: Vec::with_capacity(config.request_capacity),
+                stopped: false,
+            }),
+            wake: Condvar::new(),
+        }
+    }
+
+    fn try_push(&self, job: WorkJob) -> bool {
+        let mut state = lock(&self.state);
+        let limit = if job.class.is_critical() {
+            self.capacity
+        } else {
+            self.noncritical_capacity
+        };
+        if state.stopped || state.jobs.len() >= limit {
+            return false;
+        }
+        state.jobs.push(job);
+        self.wake.notify_one();
+        true
+    }
+
+    fn upgrade(&self, identity: RequestIdentity, class: TerrainRequestClass, deadline_tick: u64) {
+        let mut state = lock(&self.state);
+        if let Some(job) = state.jobs.iter_mut().find(|job| job.identity == identity) {
+            if class.priority() > job.class.priority() {
+                job.class = class;
+            }
+            job.deadline_tick = job.deadline_tick.min(deadline_tick);
+        }
+    }
+
+    fn pop(&self) -> Option<WorkJob> {
+        let mut state = lock(&self.state);
+        loop {
+            if state.stopped {
+                return None;
+            }
+            if !state.jobs.is_empty() {
+                let index = state
+                    .jobs
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, job)| {
+                        (Reverse(job.class.priority()), job.deadline_tick, job.order)
+                    })
+                    .map(|(index, _)| index)
+                    .expect("non-empty queue has a selected job");
+                return Some(state.jobs.swap_remove(index));
+            }
+            state = self
+                .wake
+                .wait(state)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+    }
+
+    fn cancel_where(&self, predicate: impl Fn(&WorkJob) -> bool) -> Vec<WorkJob> {
+        let mut state = lock(&self.state);
+        let mut retained = Vec::with_capacity(state.jobs.len());
+        let mut cancelled = Vec::new();
+        for job in state.jobs.drain(..) {
+            if predicate(&job) {
+                cancelled.push(job);
+            } else {
+                retained.push(job);
+            }
+        }
+        state.jobs = retained;
+        cancelled
+    }
+
+    fn stop(&self) -> Vec<WorkJob> {
+        let mut state = lock(&self.state);
+        state.stopped = true;
+        let cancelled = state.jobs.drain(..).collect();
+        self.wake.notify_all();
+        cancelled
+    }
+}
+
+struct PlanetRuntime {
+    definition: PlanetDefinition,
+    generation: u64,
+    core: TerrainCore<FixedSphereGenerator>,
+    page_generations: BTreeMap<PageKey, u64>,
+}
+
+impl PlanetRuntime {
+    fn new(definition: PlanetDefinition, generation: u64) -> Result<Self, TerrainCoreError> {
+        let generator = FixedSphereGenerator {
+            center_cell: definition.center_cell,
+            radius_cells: definition.radius_cells,
+            material: definition.material,
+        };
+        let core = TerrainCore::new(definition.planet_id, definition.root_lod, generator)?;
+        Ok(Self {
+            definition,
+            generation,
+            core,
+            page_generations: BTreeMap::new(),
+        })
+    }
+}
+
+struct RuntimeState {
+    running: bool,
+    ever_initialized: bool,
+    next_planet_generation: u64,
+    next_job_order: u64,
+    planets: HashMap<PlanetId, PlanetRuntime>,
+    component_sources: HashMap<String, PlanetId>,
+    active: HashMap<RequestIdentity, ActiveRequest>,
+    events: VecDeque<TerrainRuntimeEvent>,
+    counters: TerrainRuntimeCounters,
+}
+
+impl RuntimeState {
+    fn new(config: &TerrainRuntimeConfig) -> Self {
+        Self {
+            running: false,
+            ever_initialized: false,
+            next_planet_generation: 1,
+            next_job_order: 1,
+            planets: HashMap::with_capacity(config.max_planets),
+            component_sources: HashMap::with_capacity(config.max_component_sources),
+            active: HashMap::with_capacity(config.completion_capacity),
+            events: VecDeque::with_capacity(config.event_capacity),
+            counters: TerrainRuntimeCounters::default(),
+        }
+    }
+
+    fn allocate_planet_generation(&mut self) -> Result<u64, TerrainRuntimeError> {
+        let generation = self.next_planet_generation;
+        self.next_planet_generation = generation
+            .checked_add(1)
+            .ok_or(TerrainRuntimeError::GenerationOverflow)?;
+        Ok(generation)
+    }
+
+    fn cancel_active(&mut self, identity: RequestIdentity) {
+        if let Some(active) = self.active.remove(&identity) {
+            match active.phase {
+                RequestPhase::Queued => {
+                    self.counters.queued = self.counters.queued.saturating_sub(1)
+                }
+                RequestPhase::Running => {
+                    self.counters.in_flight = self.counters.in_flight.saturating_sub(1)
+                }
+                RequestPhase::Completed => {
+                    self.counters.completed = self.counters.completed.saturating_sub(1)
+                }
+            }
+            if active.reserved_new_page {
+                self.counters.reserved_new_pages =
+                    self.counters.reserved_new_pages.saturating_sub(1);
+            }
+            self.counters.reserved_result_bytes = self
+                .counters
+                .reserved_result_bytes
+                .saturating_sub(DENSE_PAGE_BYTES);
+            self.counters.cancelled = self.counters.cancelled.saturating_add(1);
+        }
+    }
+
+    fn push_event(&mut self, event: TerrainRuntimeEvent, capacity: usize) -> bool {
+        if self.events.len() >= capacity {
+            return false;
+        }
+        self.events.push_back(event);
+        self.counters.events = self.events.len();
+        self.counters.event_high_water = self.counters.event_high_water.max(self.events.len());
+        true
+    }
+
+    fn refresh_resident_counters(&mut self) {
+        let memory = self
+            .planets
+            .values()
+            .map(|planet| planet.core.memory_counters())
+            .fold((0_usize, 0_usize), |totals, memory| {
+                (
+                    totals.0.saturating_add(memory.resident_pages),
+                    totals.1.saturating_add(memory.resident_dense_bytes),
+                )
+            });
+        self.counters.planets = self.planets.len();
+        self.counters.resident_pages = memory.0;
+        self.counters.resident_dense_bytes = memory.1;
+        self.counters.resident_page_high_water =
+            self.counters.resident_page_high_water.max(memory.0);
+        self.counters.resident_dense_byte_high_water =
+            self.counters.resident_dense_byte_high_water.max(memory.1);
+        self.counters.outstanding = self.active.len();
+    }
+}
+
+enum WorkerResult {
+    Built(Result<PageBuildResult, String>),
+    Cancelled,
+}
+
+struct WorkCompletion {
+    identity: RequestIdentity,
+    result: WorkerResult,
+}
+
+struct RuntimeShared {
+    config: TerrainRuntimeConfig,
+    state: Mutex<RuntimeState>,
+    queue: WorkQueue,
+    completion_tx: Sender<WorkCompletion>,
+    completion_rx: Receiver<WorkCompletion>,
+}
+
+impl RuntimeShared {
+    fn new(config: TerrainRuntimeConfig) -> Self {
+        let (completion_tx, completion_rx) = crossbeam_channel::bounded(config.completion_capacity);
+        Self {
+            queue: WorkQueue::new(&config),
+            state: Mutex::new(RuntimeState::new(&config)),
+            completion_tx,
+            completion_rx,
+            config,
+        }
+    }
+
+    fn worker_started(&self, identity: RequestIdentity) -> bool {
+        let mut state = lock(&self.state);
+        let valid = state.running
+            && state
+                .planets
+                .get(&identity.planet_id)
+                .is_some_and(|planet| {
+                    planet.generation == identity.planet_generation
+                        && planet.page_generations.get(&identity.page_key).copied()
+                            == Some(identity.page_generation)
+                });
+        let transitioned = state.active.get_mut(&identity).is_some_and(|active| {
+            if active.phase != RequestPhase::Queued {
+                return false;
+            }
+            active.phase = RequestPhase::Running;
+            true
+        });
+        if transitioned {
+            state.counters.queued = state.counters.queued.saturating_sub(1);
+            state.counters.in_flight = state.counters.in_flight.saturating_add(1);
+            state.counters.in_flight_high_water = state
+                .counters
+                .in_flight_high_water
+                .max(state.counters.in_flight);
+        }
+        valid
+    }
+
+    fn publish_worker_completion(&self, completion: WorkCompletion) {
+        let mut state = lock(&self.state);
+        let identity = completion.identity;
+        let transitioned = state.active.get_mut(&identity).is_some_and(|active| {
+            if active.phase != RequestPhase::Running {
+                return false;
+            }
+            active.phase = RequestPhase::Completed;
+            true
+        });
+        if transitioned {
+            state.counters.in_flight = state.counters.in_flight.saturating_sub(1);
+            state.counters.completed = state.counters.completed.saturating_add(1);
+            state.counters.completed_high_water = state
+                .counters
+                .completed_high_water
+                .max(state.counters.completed);
+            assert!(
+                self.completion_tx.try_send(completion).is_ok(),
+                "every active request reserves one bounded completion slot"
+            );
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TerrainRuntimeHandle {
+    shared: Arc<RuntimeShared>,
+}
+
+impl TerrainRuntimeHandle {
+    pub fn is_running(&self) -> bool {
+        lock(&self.shared.state).running
+    }
+
+    pub fn upsert_planet(&self, definition: PlanetDefinition) -> Result<u64, TerrainRuntimeError> {
+        validate_definition(&definition, &self.shared.config)?;
+        let mut state = lock(&self.shared.state);
+        if !state.running {
+            return Err(TerrainRuntimeError::NotRunning);
+        }
+        if let Some(existing) = state.planets.get(&definition.planet_id) {
+            if existing.definition == definition {
+                return Ok(existing.generation);
+            }
+            if state.events.len() >= self.shared.config.event_capacity {
+                state.counters.backpressured = state.counters.backpressured.saturating_add(1);
+                return Err(TerrainRuntimeError::EventBackpressure {
+                    capacity: self.shared.config.event_capacity,
+                });
+            }
+        } else if state.planets.len() >= self.shared.config.max_planets {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(definition.planet_id),
+                None,
+                TerrainBackpressure::PlanetCapacity,
+            );
+            return Err(TerrainRuntimeError::PlanetCapacity {
+                capacity: self.shared.config.max_planets,
+            });
+        }
+
+        let retired = state
+            .planets
+            .get(&definition.planet_id)
+            .map(|planet| planet.generation);
+        let generation = state.allocate_planet_generation()?;
+        let runtime = PlanetRuntime::new(definition.clone(), generation)?;
+        let cancelled = self
+            .shared
+            .queue
+            .cancel_where(|job| job.identity.planet_id == definition.planet_id);
+        for job in cancelled {
+            state.cancel_active(job.identity);
+        }
+        state.planets.insert(definition.planet_id, runtime);
+        if let Some(retired_generation) = retired {
+            let pushed = state.push_event(
+                TerrainRuntimeEvent::EvictPlanet {
+                    planet_id: definition.planet_id,
+                    retired_generation,
+                },
+                self.shared.config.event_capacity,
+            );
+            debug_assert!(pushed, "event capacity was checked before replacement");
+        }
+        state.refresh_resident_counters();
+        Ok(generation)
+    }
+
+    pub fn remove_planet(&self, planet_id: PlanetId) -> Result<bool, TerrainRuntimeError> {
+        let mut state = lock(&self.shared.state);
+        if !state.running {
+            return Err(TerrainRuntimeError::NotRunning);
+        }
+        let Some(retired_generation) = state
+            .planets
+            .get(&planet_id)
+            .map(|planet| planet.generation)
+        else {
+            return Ok(false);
+        };
+        if state.events.len() >= self.shared.config.event_capacity {
+            state.counters.backpressured = state.counters.backpressured.saturating_add(1);
+            return Err(TerrainRuntimeError::EventBackpressure {
+                capacity: self.shared.config.event_capacity,
+            });
+        }
+        let cancelled = self
+            .shared
+            .queue
+            .cancel_where(|job| job.identity.planet_id == planet_id);
+        for job in cancelled {
+            state.cancel_active(job.identity);
+        }
+        state.planets.remove(&planet_id);
+        state.component_sources.retain(|_, id| *id != planet_id);
+        let pushed = state.push_event(
+            TerrainRuntimeEvent::EvictPlanet {
+                planet_id,
+                retired_generation,
+            },
+            self.shared.config.event_capacity,
+        );
+        debug_assert!(pushed, "event capacity was checked before removal");
+        state.refresh_resident_counters();
+        Ok(true)
+    }
+
+    pub fn upsert_component(
+        &self,
+        source_key: String,
+        definition: PlanetDefinition,
+    ) -> Result<u64, TerrainRuntimeError> {
+        let previous = {
+            let mut state = lock(&self.shared.state);
+            if !state.running {
+                return Err(TerrainRuntimeError::NotRunning);
+            }
+            if !state.component_sources.contains_key(&source_key)
+                && state.component_sources.len() >= self.shared.config.max_component_sources
+            {
+                record_backpressure(
+                    &mut state,
+                    &self.shared.config,
+                    Some(definition.planet_id),
+                    None,
+                    TerrainBackpressure::ComponentCapacity,
+                );
+                return Err(TerrainRuntimeError::ComponentCapacity {
+                    capacity: self.shared.config.max_component_sources,
+                });
+            }
+            state.component_sources.get(&source_key).copied()
+        };
+
+        let generation = self.upsert_planet(definition.clone())?;
+        if let Some(previous) = previous.filter(|planet_id| *planet_id != definition.planet_id) {
+            let has_other_owner = lock(&self.shared.state)
+                .component_sources
+                .iter()
+                .any(|(source, planet_id)| source != &source_key && *planet_id == previous);
+            if !has_other_owner {
+                self.remove_planet(previous)?;
+            }
+        }
+        lock(&self.shared.state)
+            .component_sources
+            .insert(source_key, definition.planet_id);
+        Ok(generation)
+    }
+
+    pub fn remove_component(&self, source_key: &str) -> Result<(), TerrainRuntimeError> {
+        let (planet_id, has_other_owner) = {
+            let mut state = lock(&self.shared.state);
+            let planet_id = state.component_sources.remove(source_key);
+            let has_other_owner = planet_id.is_some_and(|removed| {
+                state
+                    .component_sources
+                    .values()
+                    .any(|planet_id| *planet_id == removed)
+            });
+            (planet_id, has_other_owner)
+        };
+        if let Some(planet_id) = planet_id.filter(|_| !has_other_owner) {
+            self.remove_planet(planet_id)?;
+        }
+        Ok(())
+    }
+
+    pub fn append_edit(
+        &self,
+        planet_id: PlanetId,
+        operation: EditOp,
+    ) -> Result<(), TerrainRuntimeError> {
+        let mut state = lock(&self.shared.state);
+        if !state.running {
+            return Err(TerrainRuntimeError::NotRunning);
+        }
+        let planet = state
+            .planets
+            .get_mut(&planet_id)
+            .ok_or(TerrainRuntimeError::PlanetMissing(planet_id))?;
+        planet.core.append_edit(operation)?;
+        let bounds = operation.shape.bounds();
+        let mut affected = Vec::new();
+        for (key, generation) in &mut planet.page_generations {
+            if page_intersects(*key, bounds) {
+                *generation = generation
+                    .checked_add(1)
+                    .ok_or(TerrainRuntimeError::GenerationOverflow)?;
+                affected.push(*key);
+            }
+        }
+        if !affected.is_empty() {
+            let cancelled = self.shared.queue.cancel_where(|job| {
+                job.identity.planet_id == planet_id && affected.contains(&job.identity.page_key)
+            });
+            for job in cancelled {
+                state.cancel_active(job.identity);
+            }
+        }
+        state.refresh_resident_counters();
+        Ok(())
+    }
+
+    pub fn request_page(
+        &self,
+        planet_id: PlanetId,
+        page_key: PageKey,
+        class: TerrainRequestClass,
+        deadline_tick: u64,
+    ) -> Result<TerrainRequestOutcome, TerrainRuntimeError> {
+        let mut state = lock(&self.shared.state);
+        if !state.running {
+            return Err(TerrainRuntimeError::NotRunning);
+        }
+        let (planet_generation, page_generation) = {
+            let planet = state
+                .planets
+                .get(&planet_id)
+                .ok_or(TerrainRuntimeError::PlanetMissing(planet_id))?;
+            (
+                planet.generation,
+                planet.page_generations.get(&page_key).copied().unwrap_or(1),
+            )
+        };
+        let identity = RequestIdentity {
+            planet_id,
+            page_key,
+            planet_generation,
+            page_generation,
+        };
+        if state.active.contains_key(&identity) {
+            let upgraded = {
+                let active = state
+                    .active
+                    .get_mut(&identity)
+                    .expect("active request was checked above");
+                let upgraded = class.priority() > active.class.priority()
+                    || deadline_tick < active.deadline_tick;
+                if class.priority() > active.class.priority() {
+                    active.class = class;
+                }
+                active.deadline_tick = active.deadline_tick.min(deadline_tick);
+                upgraded
+            };
+            state.counters.coalesced = state.counters.coalesced.saturating_add(1);
+            if upgraded {
+                state.counters.priority_upgrades =
+                    state.counters.priority_upgrades.saturating_add(1);
+            }
+            self.shared.queue.upgrade(identity, class, deadline_tick);
+            return Ok(TerrainRequestOutcome::Coalesced {
+                planet_generation,
+                page_generation,
+                upgraded,
+            });
+        }
+
+        let (preparation, is_new_page, planet_resident, planet_resident_limit) = {
+            let planet = state
+                .planets
+                .get(&planet_id)
+                .expect("planet remains registered while state is locked");
+            (
+                planet.core.prepare_page_build(page_key)?,
+                planet.core.page(page_key).is_none(),
+                planet.core.memory_counters().resident_pages,
+                planet.definition.max_resident_pages,
+            )
+        };
+
+        let request = match preparation {
+            PageBuildPreparation::Current(record) => {
+                return Ok(TerrainRequestOutcome::Current {
+                    planet_generation,
+                    page_generation,
+                    record,
+                });
+            }
+            PageBuildPreparation::Build(request) => request,
+        };
+
+        if !class.is_critical() && state.events.len() >= self.shared.config.event_capacity {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(planet_id),
+                Some(page_key),
+                TerrainBackpressure::EventQueue,
+            );
+            return Err(TerrainRuntimeError::EventBackpressure {
+                capacity: self.shared.config.event_capacity,
+            });
+        }
+        if state.active.len() >= self.shared.config.completion_capacity {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(planet_id),
+                Some(page_key),
+                TerrainBackpressure::CompletionSlots,
+            );
+            return Err(TerrainRuntimeError::CompletionBackpressure {
+                capacity: self.shared.config.completion_capacity,
+            });
+        }
+        let noncritical_active = state
+            .active
+            .values()
+            .filter(|active| !active.class.is_critical())
+            .count();
+        let noncritical_limit = self
+            .shared
+            .config
+            .completion_capacity
+            .saturating_sub(self.shared.config.critical_request_reserve);
+        if !class.is_critical() && noncritical_active >= noncritical_limit {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(planet_id),
+                Some(page_key),
+                TerrainBackpressure::RequestQueue,
+            );
+            return Err(TerrainRuntimeError::RequestBackpressure { class });
+        }
+
+        let planet_reserved = state
+            .active
+            .iter()
+            .filter(|(identity, active)| {
+                identity.planet_id == planet_id && active.reserved_new_page
+            })
+            .count();
+        if is_new_page && planet_resident.saturating_add(planet_reserved) >= planet_resident_limit {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(planet_id),
+                Some(page_key),
+                TerrainBackpressure::ResidentPages,
+            );
+            return Err(TerrainRuntimeError::PlanetResidentPageBudget {
+                planet_id,
+                capacity: planet_resident_limit,
+            });
+        }
+        if is_new_page
+            && state
+                .counters
+                .resident_pages
+                .saturating_add(state.counters.reserved_new_pages)
+                >= self.shared.config.max_resident_pages
+        {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(planet_id),
+                Some(page_key),
+                TerrainBackpressure::ResidentPages,
+            );
+            return Err(TerrainRuntimeError::GlobalResidentPageBudget {
+                capacity: self.shared.config.max_resident_pages,
+            });
+        }
+        if state
+            .counters
+            .resident_dense_bytes
+            .saturating_add(state.counters.reserved_result_bytes)
+            .saturating_add(DENSE_PAGE_BYTES)
+            > self.shared.config.max_resident_dense_bytes
+        {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(planet_id),
+                Some(page_key),
+                TerrainBackpressure::ResidentBytes,
+            );
+            return Err(TerrainRuntimeError::ResidentByteBudget {
+                capacity: self.shared.config.max_resident_dense_bytes,
+            });
+        }
+
+        let order = state.next_job_order;
+        state.next_job_order = order
+            .checked_add(1)
+            .ok_or(TerrainRuntimeError::GenerationOverflow)?;
+        let job = WorkJob {
+            identity,
+            request,
+            class,
+            deadline_tick,
+            order,
+        };
+        if !self.shared.queue.try_push(job) {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(planet_id),
+                Some(page_key),
+                TerrainBackpressure::RequestQueue,
+            );
+            return Err(TerrainRuntimeError::RequestBackpressure { class });
+        }
+        state.active.insert(
+            identity,
+            ActiveRequest {
+                phase: RequestPhase::Queued,
+                class,
+                deadline_tick,
+                reserved_new_page: is_new_page,
+            },
+        );
+        state
+            .planets
+            .get_mut(&planet_id)
+            .expect("planet remains registered while state is locked")
+            .page_generations
+            .entry(page_key)
+            .or_insert(page_generation);
+        state.counters.queued = state.counters.queued.saturating_add(1);
+        state.counters.queue_high_water =
+            state.counters.queue_high_water.max(state.counters.queued);
+        state.counters.accepted = state.counters.accepted.saturating_add(1);
+        if is_new_page {
+            state.counters.reserved_new_pages = state.counters.reserved_new_pages.saturating_add(1);
+        }
+        state.counters.reserved_result_bytes = state
+            .counters
+            .reserved_result_bytes
+            .saturating_add(DENSE_PAGE_BYTES);
+        state.refresh_resident_counters();
+        Ok(TerrainRequestOutcome::Queued {
+            planet_generation,
+            page_generation,
+        })
+    }
+
+    pub fn pump(&self, max_completions: usize) -> usize {
+        let mut processed = 0;
+        while processed < max_completions {
+            let mut state = lock(&self.shared.state);
+            if state.events.len() >= self.shared.config.event_capacity {
+                break;
+            }
+            let completion = match self.shared.completion_rx.try_recv() {
+                Ok(completion) => completion,
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            };
+            self.publish_completion(&mut state, completion);
+            processed += 1;
+        }
+        processed
+    }
+
+    pub fn drain_events(&self, limit: usize) -> Vec<TerrainRuntimeEvent> {
+        let mut state = lock(&self.shared.state);
+        let count = limit.min(state.events.len());
+        let events = state.events.drain(..count).collect();
+        state.counters.events = state.events.len();
+        events
+    }
+
+    pub fn counters(&self) -> TerrainRuntimeCounters {
+        let mut state = lock(&self.shared.state);
+        state.refresh_resident_counters();
+        state.counters
+    }
+
+    pub fn page_snapshot(
+        &self,
+        planet_id: PlanetId,
+        page_key: PageKey,
+    ) -> Option<crate::VoxelPage> {
+        lock(&self.shared.state)
+            .planets
+            .get(&planet_id)
+            .and_then(|planet| planet.core.page(page_key))
+            .cloned()
+    }
+
+    fn publish_completion(&self, state: &mut RuntimeState, completion: WorkCompletion) {
+        let Some(active) = state.active.remove(&completion.identity) else {
+            return;
+        };
+        if active.phase == RequestPhase::Completed {
+            state.counters.completed = state.counters.completed.saturating_sub(1);
+        }
+        if active.reserved_new_page {
+            state.counters.reserved_new_pages = state.counters.reserved_new_pages.saturating_sub(1);
+        }
+        state.counters.reserved_result_bytes = state
+            .counters
+            .reserved_result_bytes
+            .saturating_sub(DENSE_PAGE_BYTES);
+
+        let identity = completion.identity;
+        let current = state
+            .planets
+            .get(&identity.planet_id)
+            .is_some_and(|planet| {
+                planet.generation == identity.planet_generation
+                    && planet.page_generations.get(&identity.page_key).copied()
+                        == Some(identity.page_generation)
+            });
+        let event = if !current || matches!(&completion.result, WorkerResult::Cancelled) {
+            state.counters.stale_rejected = state.counters.stale_rejected.saturating_add(1);
+            TerrainRuntimeEvent::StaleRejected {
+                planet_id: identity.planet_id,
+                page_key: identity.page_key,
+                planet_generation: identity.planet_generation,
+                page_generation: identity.page_generation,
+            }
+        } else {
+            match completion.result {
+                WorkerResult::Built(Ok(result)) => {
+                    let outcome = state
+                        .planets
+                        .get_mut(&identity.planet_id)
+                        .expect("current completion has a planet")
+                        .core
+                        .commit_page_build(result);
+                    match outcome {
+                        Ok(PageBuildCommitOutcome::Committed(record))
+                        | Ok(PageBuildCommitOutcome::Duplicate(record)) => {
+                            state.counters.published = state.counters.published.saturating_add(1);
+                            TerrainRuntimeEvent::PageReady {
+                                planet_id: identity.planet_id,
+                                page_key: identity.page_key,
+                                planet_generation: identity.planet_generation,
+                                page_generation: identity.page_generation,
+                                request_class: active.class,
+                                record,
+                            }
+                        }
+                        Ok(PageBuildCommitOutcome::Stale { .. }) => {
+                            state.counters.stale_rejected =
+                                state.counters.stale_rejected.saturating_add(1);
+                            TerrainRuntimeEvent::StaleRejected {
+                                planet_id: identity.planet_id,
+                                page_key: identity.page_key,
+                                planet_generation: identity.planet_generation,
+                                page_generation: identity.page_generation,
+                            }
+                        }
+                        Err(error) => {
+                            state.counters.errors = state.counters.errors.saturating_add(1);
+                            TerrainRuntimeEvent::Error {
+                                planet_id: identity.planet_id,
+                                page_key: identity.page_key,
+                                message: error.to_string(),
+                            }
+                        }
+                    }
+                }
+                WorkerResult::Built(Err(message)) => {
+                    state.counters.errors = state.counters.errors.saturating_add(1);
+                    TerrainRuntimeEvent::Error {
+                        planet_id: identity.planet_id,
+                        page_key: identity.page_key,
+                        message,
+                    }
+                }
+                WorkerResult::Cancelled => unreachable!("cancelled result handled above"),
+            }
+        };
+        let pushed = state.push_event(event, self.shared.config.event_capacity);
+        debug_assert!(
+            pushed,
+            "pump checks event capacity before receiving completion"
+        );
+        state.refresh_resident_counters();
+    }
+}
+
+pub struct TerrainSubsystem {
+    handle: TerrainRuntimeHandle,
+    workers: Vec<JoinHandle<()>>,
+}
+
+impl TerrainSubsystem {
+    pub fn new(config: TerrainRuntimeConfig) -> Result<Self, TerrainRuntimeError> {
+        config.validate()?;
+        let shared = Arc::new(RuntimeShared::new(config));
+        Ok(Self {
+            handle: TerrainRuntimeHandle { shared },
+            workers: Vec::new(),
+        })
+    }
+
+    pub fn runtime_handle(&self) -> TerrainRuntimeHandle {
+        self.handle.clone()
+    }
+
+    fn initialize(&mut self) -> Result<(), TerrainRuntimeError> {
+        {
+            let mut state = lock(&self.handle.shared.state);
+            if state.ever_initialized {
+                return Err(TerrainRuntimeError::AlreadyInitialized);
+            }
+            state.ever_initialized = true;
+            state.running = true;
+        }
+        for worker_index in 0..self.handle.shared.config.worker_count {
+            let shared = self.handle.shared.clone();
+            let handle = thread::Builder::new()
+                .name(format!("Pulsar-Terrain-{worker_index}"))
+                .spawn(move || worker_loop(shared))
+                .map_err(|_| {
+                    TerrainRuntimeError::InvalidConfig("failed to spawn terrain worker")
+                })?;
+            self.workers.push(handle);
+        }
+        Ok(())
+    }
+
+    fn shutdown_internal(&mut self) {
+        {
+            let mut state = lock(&self.handle.shared.state);
+            if !state.running {
+                return;
+            }
+            state.running = false;
+        }
+        let queued = self.handle.shared.queue.stop();
+        {
+            let mut state = lock(&self.handle.shared.state);
+            for job in queued {
+                state.cancel_active(job.identity);
+            }
+        }
+        for worker in self.workers.drain(..) {
+            let _ = worker.join();
+        }
+        while let Ok(completion) = self.handle.shared.completion_rx.try_recv() {
+            let mut state = lock(&self.handle.shared.state);
+            state.cancel_active(completion.identity);
+        }
+        let mut state = lock(&self.handle.shared.state);
+        let remaining: Vec<_> = state.active.keys().copied().collect();
+        for identity in remaining {
+            state.cancel_active(identity);
+        }
+        state.refresh_resident_counters();
+    }
+}
+
+impl Subsystem for TerrainSubsystem {
+    fn id(&self) -> SubsystemId {
+        TERRAIN_SUBSYSTEM_ID
+    }
+
+    fn dependencies(&self) -> Vec<SubsystemId> {
+        Vec::new()
+    }
+
+    fn init(&mut self, _context: &SubsystemContext) -> Result<(), SubsystemError> {
+        self.initialize()
+            .map_err(|error| SubsystemError::InitFailed(error.to_string()))
+    }
+
+    fn shutdown(&mut self) -> Result<(), SubsystemError> {
+        self.shutdown_internal();
+        Ok(())
+    }
+
+    fn on_frame(&mut self, _delta_time: f32) {
+        self.handle
+            .pump(self.handle.shared.config.max_completions_per_frame);
+    }
+}
+
+impl Drop for TerrainSubsystem {
+    fn drop(&mut self) {
+        self.shutdown_internal();
+    }
+}
+
+fn worker_loop(shared: Arc<RuntimeShared>) {
+    while let Some(job) = shared.queue.pop() {
+        let valid = shared.worker_started(job.identity);
+        let result = if valid {
+            WorkerResult::Built(job.request.execute().map_err(|error| error.to_string()))
+        } else {
+            WorkerResult::Cancelled
+        };
+        shared.publish_worker_completion(WorkCompletion {
+            identity: job.identity,
+            result,
+        });
+    }
+}
+
+fn validate_definition(
+    definition: &PlanetDefinition,
+    config: &TerrainRuntimeConfig,
+) -> Result<(), TerrainRuntimeError> {
+    if definition.radius_cells == 0
+        || definition.material == 0
+        || !(1..=62).contains(&definition.root_lod)
+        || definition.max_resident_pages == 0
+        || definition.max_resident_pages > config.max_resident_pages
+    {
+        return Err(TerrainRuntimeError::InvalidConfig(
+            "planet definition exceeds the runtime contract",
+        ));
+    }
+    Ok(())
+}
+
+fn page_intersects(key: PageKey, bounds: ([i64; 3], [i64; 3])) -> bool {
+    let Some(min) = key.lod0_cell_min() else {
+        return false;
+    };
+    let Some(span) = key.lod0_cell_span() else {
+        return false;
+    };
+    (0..3).all(|axis| min[axis] < bounds.1[axis] && min[axis].saturating_add(span) > bounds.0[axis])
+}
+
+fn record_backpressure(
+    state: &mut RuntimeState,
+    config: &TerrainRuntimeConfig,
+    planet_id: Option<PlanetId>,
+    page_key: Option<PageKey>,
+    kind: TerrainBackpressure,
+) {
+    state.counters.backpressured = state.counters.backpressured.saturating_add(1);
+    let _ = state.push_event(
+        TerrainRuntimeEvent::Backpressure {
+            planet_id,
+            page_key,
+            kind,
+        },
+        config.event_capacity,
+    );
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EditMode, EditShape};
+    use std::time::{Duration, Instant};
+
+    fn config(worker_count: usize) -> TerrainRuntimeConfig {
+        TerrainRuntimeConfig {
+            worker_count,
+            max_planets: 4,
+            max_component_sources: 8,
+            request_capacity: 8,
+            critical_request_reserve: 2,
+            completion_capacity: 8,
+            event_capacity: 16,
+            max_resident_pages: 8,
+            max_resident_dense_bytes: 8 * DENSE_PAGE_BYTES,
+            max_completions_per_frame: 8,
+        }
+    }
+
+    fn planet(id: u8) -> PlanetDefinition {
+        PlanetDefinition {
+            planet_id: PlanetId([id; 16]),
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: id.max(1),
+            root_lod: 12,
+            max_resident_pages: 8,
+        }
+    }
+
+    fn start(worker_count: usize) -> TerrainSubsystem {
+        let mut subsystem = TerrainSubsystem::new(config(worker_count)).unwrap();
+        subsystem.init(&SubsystemContext::new()).unwrap();
+        subsystem
+    }
+
+    fn wait_for_events(handle: &TerrainRuntimeHandle, count: usize) -> Vec<TerrainRuntimeEvent> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut events = Vec::new();
+        while events.len() < count && Instant::now() < deadline {
+            handle.pump(64);
+            events.extend(handle.drain_events(64));
+            if events.len() < count {
+                thread::yield_now();
+            }
+        }
+        assert!(
+            events.len() >= count,
+            "timed out waiting for terrain events"
+        );
+        events
+    }
+
+    #[test]
+    fn subsystem_lifecycle_joins_workers_and_accounts_for_every_job() {
+        let mut subsystem = start(2);
+        assert_eq!(subsystem.id(), TERRAIN_SUBSYSTEM_ID);
+        assert!(subsystem.dependencies().is_empty());
+        let handle = subsystem.runtime_handle();
+        let id = planet(1).planet_id;
+        handle.upsert_planet(planet(1)).unwrap();
+        for x in 0..4 {
+            handle
+                .request_page(
+                    id,
+                    PageKey::new(0, [x, 0, 0]),
+                    TerrainRequestClass::Visible,
+                    10,
+                )
+                .unwrap();
+        }
+        subsystem.shutdown().unwrap();
+        let counters = handle.counters();
+        assert!(!handle.is_running());
+        assert_eq!(counters.outstanding, 0);
+        assert_eq!(
+            counters.accepted,
+            counters.published + counters.stale_rejected + counters.cancelled + counters.errors
+        );
+    }
+
+    #[test]
+    fn saturated_prefetch_preserves_edit_and_collision_admission() {
+        let mut cfg = config(1);
+        cfg.request_capacity = 4;
+        cfg.completion_capacity = 4;
+        cfg.critical_request_reserve = 1;
+        let mut subsystem = TerrainSubsystem::new(cfg).unwrap();
+        subsystem.init(&SubsystemContext::new()).unwrap();
+        let handle = subsystem.runtime_handle();
+        let id = planet(2).planet_id;
+        handle.upsert_planet(planet(2)).unwrap();
+        for x in 0..3 {
+            handle
+                .request_page(
+                    id,
+                    PageKey::new(0, [x, 0, 0]),
+                    TerrainRequestClass::Prefetch,
+                    100,
+                )
+                .unwrap();
+        }
+        assert!(matches!(
+            handle.request_page(
+                id,
+                PageKey::new(0, [3, 0, 0]),
+                TerrainRequestClass::Prefetch,
+                100
+            ),
+            Err(TerrainRuntimeError::RequestBackpressure { .. })
+        ));
+        assert!(matches!(
+            handle.request_page(
+                id,
+                PageKey::new(0, [4, 0, 0]),
+                TerrainRequestClass::EditResponse,
+                1
+            ),
+            Ok(TerrainRequestOutcome::Queued { .. })
+        ));
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn duplicate_requests_coalesce_and_upgrade_without_duplicate_work() {
+        let mut subsystem = start(1);
+        let handle = subsystem.runtime_handle();
+        let id = planet(3).planet_id;
+        handle.upsert_planet(planet(3)).unwrap();
+        let key = PageKey::new(0, [-1, 2, -3]);
+        handle
+            .request_page(id, key, TerrainRequestClass::Prefetch, 100)
+            .unwrap();
+        assert!(matches!(
+            handle.request_page(id, key, TerrainRequestClass::Collision, 10),
+            Ok(TerrainRequestOutcome::Coalesced { upgraded: true, .. })
+        ));
+        let events = wait_for_events(&handle, 1);
+        assert!(matches!(
+            events[0],
+            TerrainRuntimeEvent::PageReady {
+                request_class: TerrainRequestClass::Collision,
+                ..
+            }
+        ));
+        assert_eq!(handle.counters().accepted, 1);
+        assert_eq!(handle.counters().coalesced, 1);
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn newer_edits_make_late_page_results_harmless() {
+        let mut subsystem = start(1);
+        let handle = subsystem.runtime_handle();
+        let id = planet(4).planet_id;
+        handle.upsert_planet(planet(4)).unwrap();
+        let key = PageKey::new(0, [0; 3]);
+        handle
+            .request_page(id, key, TerrainRequestClass::Visible, 10)
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while handle.counters().in_flight + handle.counters().completed == 0
+            && Instant::now() < deadline
+        {
+            thread::yield_now();
+        }
+        assert!(
+            handle.counters().in_flight + handle.counters().completed > 0,
+            "worker did not start the stale-result fixture"
+        );
+        handle
+            .append_edit(
+                id,
+                EditOp {
+                    sequence: 1,
+                    stable_id: [1; 16],
+                    shape: EditShape::Sphere {
+                        center_cell: [8; 3],
+                        radius_cells: 2,
+                    },
+                    mode: EditMode::Subtract,
+                    material: 0,
+                },
+            )
+            .unwrap();
+        let events = wait_for_events(&handle, 1);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            TerrainRuntimeEvent::StaleRejected { page_key, .. } if *page_key == key
+        )));
+        assert!(handle.page_snapshot(id, key).is_none());
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn signed_coordinates_and_planets_remain_distinct_across_worker_counts() {
+        fn run(worker_count: usize) -> BTreeMap<(PlanetId, PageKey), crate::PageId> {
+            let mut subsystem = start(worker_count);
+            let handle = subsystem.runtime_handle();
+            for id in [5_u8, 6_u8] {
+                handle.upsert_planet(planet(id)).unwrap();
+                for key in [PageKey::new(0, [-2, -1, 0]), PageKey::new(0, [2, 1, 0])] {
+                    handle
+                        .request_page(PlanetId([id; 16]), key, TerrainRequestClass::Visible, 10)
+                        .unwrap();
+                }
+            }
+            let events = wait_for_events(&handle, 4);
+            let records = events
+                .into_iter()
+                .filter_map(|event| match event {
+                    TerrainRuntimeEvent::PageReady {
+                        planet_id,
+                        page_key,
+                        record,
+                        ..
+                    } => Some(((planet_id, page_key), record.page_id)),
+                    _ => None,
+                })
+                .collect();
+            subsystem.shutdown().unwrap();
+            records
+        }
+
+        let single = run(1);
+        let parallel = run(4);
+        assert_eq!(single, parallel);
+        assert_eq!(single.len(), 4);
+    }
+
+    #[test]
+    fn a_full_event_queue_defers_completion_without_dropping_work() {
+        let mut cfg = config(1);
+        cfg.event_capacity = 1;
+        cfg.completion_capacity = 2;
+        cfg.request_capacity = 2;
+        cfg.critical_request_reserve = 1;
+        let mut subsystem = TerrainSubsystem::new(cfg).unwrap();
+        subsystem.init(&SubsystemContext::new()).unwrap();
+        let handle = subsystem.runtime_handle();
+        let mut definition = planet(8);
+        let id = definition.planet_id;
+        handle.upsert_planet(definition.clone()).unwrap();
+        definition.center_cell[0] = 1;
+        handle.upsert_planet(definition).unwrap();
+
+        handle
+            .request_page(
+                id,
+                PageKey::new(0, [0; 3]),
+                TerrainRequestClass::EditResponse,
+                1,
+            )
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while handle.counters().completed == 0 && Instant::now() < deadline {
+            thread::yield_now();
+        }
+        assert_eq!(handle.counters().completed, 1);
+        assert_eq!(handle.pump(1), 0);
+        assert_eq!(handle.counters().outstanding, 1);
+        assert!(matches!(
+            handle.drain_events(1).as_slice(),
+            [TerrainRuntimeEvent::EvictPlanet { .. }]
+        ));
+
+        assert_eq!(handle.pump(1), 1);
+        assert!(matches!(
+            handle.drain_events(1).as_slice(),
+            [TerrainRuntimeEvent::PageReady { .. }]
+        ));
+        let counters = handle.counters();
+        assert_eq!(counters.outstanding, 0);
+        assert_eq!(counters.accepted, 1);
+        assert_eq!(counters.published, 1);
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn component_sources_are_bounded_and_shared_planets_are_reference_counted() {
+        let mut cfg = config(1);
+        cfg.max_component_sources = 2;
+        let mut subsystem = TerrainSubsystem::new(cfg).unwrap();
+        subsystem.init(&SubsystemContext::new()).unwrap();
+        let handle = subsystem.runtime_handle();
+        let first = planet(9);
+        let first_id = first.planet_id;
+        handle
+            .upsert_component("first-a".to_owned(), first.clone())
+            .unwrap();
+        handle
+            .upsert_component("first-b".to_owned(), first)
+            .unwrap();
+        assert_eq!(handle.counters().planets, 1);
+
+        handle.remove_component("first-a").unwrap();
+        assert_eq!(handle.counters().planets, 1);
+        handle
+            .upsert_component("second".to_owned(), planet(10))
+            .unwrap();
+        assert!(matches!(
+            handle.upsert_component("overflow".to_owned(), planet(11)),
+            Err(TerrainRuntimeError::ComponentCapacity { capacity: 2 })
+        ));
+
+        handle.remove_component("first-b").unwrap();
+        assert_eq!(handle.counters().planets, 1);
+        assert!(matches!(
+            handle.request_page(
+                first_id,
+                PageKey::new(0, [0; 3]),
+                TerrainRequestClass::Visible,
+                1,
+            ),
+            Err(TerrainRuntimeError::PlanetMissing(id)) if id == first_id
+        ));
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn configured_resident_budgets_return_typed_backpressure() {
+        let mut cfg = config(1);
+        cfg.max_resident_pages = 1;
+        cfg.max_resident_dense_bytes = DENSE_PAGE_BYTES;
+        let mut definition = planet(7);
+        definition.max_resident_pages = 1;
+        let mut subsystem = TerrainSubsystem::new(cfg).unwrap();
+        subsystem.init(&SubsystemContext::new()).unwrap();
+        let handle = subsystem.runtime_handle();
+        let id = definition.planet_id;
+        handle.upsert_planet(definition).unwrap();
+        handle
+            .request_page(id, PageKey::new(0, [0; 3]), TerrainRequestClass::Visible, 1)
+            .unwrap();
+        assert!(matches!(
+            handle.request_page(
+                id,
+                PageKey::new(0, [1, 0, 0]),
+                TerrainRequestClass::Visible,
+                1
+            ),
+            Err(TerrainRuntimeError::PlanetResidentPageBudget { .. })
+                | Err(TerrainRuntimeError::ResidentByteBudget { .. })
+        ));
+        let counters = handle.counters();
+        assert!(counters.resident_pages + counters.reserved_new_pages <= 1);
+        assert!(counters.resident_dense_bytes + counters.reserved_result_bytes <= DENSE_PAGE_BYTES);
+        subsystem.shutdown().unwrap();
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/snapshot.rs
+++ b/crates/subsystems/pulsar_terrain/src/snapshot.rs
@@ -1,0 +1,207 @@
+use crate::{ContentHash, EditLog, PageId, PageKey, PlanetId, SparseBrickTree};
+use thiserror::Error;
+
+const SNAPSHOT_MAGIC: &[u8; 8] = b"PTSNAP01";
+const PAGE_RECORD_BYTES: usize = 72;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompactedPageRecord {
+    pub key: PageKey,
+    pub page_id: PageId,
+    pub compacted_through_sequence: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerrainSnapshot {
+    pub planet_id: PlanetId,
+    pub generator_hash: ContentHash,
+    pub hierarchy: SparseBrickTree,
+    pub edit_tail: EditLog,
+    pub compacted_pages: Vec<CompactedPageRecord>,
+}
+
+impl TerrainSnapshot {
+    pub fn encode(&self) -> Result<Vec<u8>, SnapshotCodecError> {
+        let mut compacted_pages = self.compacted_pages.clone();
+        compacted_pages.sort_unstable_by_key(|record| record.key);
+        if compacted_pages
+            .windows(2)
+            .any(|pair| pair[0].key == pair[1].key)
+        {
+            return Err(SnapshotCodecError::DuplicatePageKey);
+        }
+        let hierarchy = self.hierarchy.encode();
+        let edits = self.edit_tail.encode();
+        let mut output = Vec::with_capacity(
+            80 + hierarchy.len() + edits.len() + compacted_pages.len() * PAGE_RECORD_BYTES,
+        );
+        output.extend_from_slice(SNAPSHOT_MAGIC);
+        output.extend_from_slice(&self.planet_id.0);
+        output.extend_from_slice(&self.generator_hash.0);
+        output.extend_from_slice(&(hierarchy.len() as u64).to_le_bytes());
+        output.extend_from_slice(&(edits.len() as u64).to_le_bytes());
+        output.extend_from_slice(&(compacted_pages.len() as u32).to_le_bytes());
+        output.extend_from_slice(&[0; 4]);
+        output.extend_from_slice(&hierarchy);
+        output.extend_from_slice(&edits);
+        for record in compacted_pages {
+            output.push(record.key.lod);
+            output.extend_from_slice(&[0; 7]);
+            for axis in record.key.page_xyz {
+                output.extend_from_slice(&axis.to_le_bytes());
+            }
+            output.extend_from_slice(&record.page_id.0);
+            output.extend_from_slice(&record.compacted_through_sequence.to_le_bytes());
+        }
+        Ok(output)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, SnapshotCodecError> {
+        if bytes.len() < 80
+            || bytes.get(..8) != Some(SNAPSHOT_MAGIC)
+            || bytes.get(76..80) != Some(&[0; 4])
+        {
+            return Err(SnapshotCodecError::Codec);
+        }
+        let planet_id = PlanetId(read_array(bytes, 8)?);
+        let generator_hash = ContentHash(read_array(bytes, 24)?);
+        let hierarchy_len = read_u64(bytes, 56)? as usize;
+        let edits_len = read_u64(bytes, 64)? as usize;
+        let page_count = read_u32(bytes, 72)? as usize;
+        let hierarchy_end = 80_usize
+            .checked_add(hierarchy_len)
+            .ok_or(SnapshotCodecError::Codec)?;
+        let edits_end = hierarchy_end
+            .checked_add(edits_len)
+            .ok_or(SnapshotCodecError::Codec)?;
+        let expected_end = edits_end
+            .checked_add(
+                page_count
+                    .checked_mul(PAGE_RECORD_BYTES)
+                    .ok_or(SnapshotCodecError::Codec)?,
+            )
+            .ok_or(SnapshotCodecError::Codec)?;
+        if expected_end != bytes.len() {
+            return Err(SnapshotCodecError::Codec);
+        }
+        let hierarchy = SparseBrickTree::decode(&bytes[80..hierarchy_end])
+            .map_err(|_| SnapshotCodecError::Codec)?;
+        let edit_tail = EditLog::decode(&bytes[hierarchy_end..edits_end])
+            .map_err(|_| SnapshotCodecError::Codec)?;
+        let mut compacted_pages = Vec::with_capacity(page_count);
+        let mut cursor = edits_end;
+        for _ in 0..page_count {
+            let lod = bytes[cursor];
+            if bytes.get(cursor + 1..cursor + 8) != Some(&[0; 7]) {
+                return Err(SnapshotCodecError::Codec);
+            }
+            let page_xyz = [
+                read_i64(bytes, cursor + 8)?,
+                read_i64(bytes, cursor + 16)?,
+                read_i64(bytes, cursor + 24)?,
+            ];
+            compacted_pages.push(CompactedPageRecord {
+                key: PageKey::new(lod, page_xyz),
+                page_id: ContentHash(read_array(bytes, cursor + 32)?),
+                compacted_through_sequence: read_u64(bytes, cursor + 64)?,
+            });
+            cursor += PAGE_RECORD_BYTES;
+        }
+        if compacted_pages
+            .windows(2)
+            .any(|pair| pair[0].key >= pair[1].key)
+        {
+            return Err(SnapshotCodecError::DuplicatePageKey);
+        }
+        Ok(Self {
+            planet_id,
+            generator_hash,
+            hierarchy,
+            edit_tail,
+            compacted_pages,
+        })
+    }
+
+    pub fn content_hash(&self) -> Result<ContentHash, SnapshotCodecError> {
+        Ok(ContentHash::of(&self.encode()?))
+    }
+}
+
+fn read_array<const N: usize>(bytes: &[u8], offset: usize) -> Result<[u8; N], SnapshotCodecError> {
+    bytes
+        .get(offset..offset + N)
+        .ok_or(SnapshotCodecError::Codec)?
+        .try_into()
+        .map_err(|_| SnapshotCodecError::Codec)
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, SnapshotCodecError> {
+    Ok(u32::from_le_bytes(read_array(bytes, offset)?))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, SnapshotCodecError> {
+    Ok(u64::from_le_bytes(read_array(bytes, offset)?))
+}
+
+fn read_i64(bytes: &[u8], offset: usize) -> Result<i64, SnapshotCodecError> {
+    Ok(i64::from_le_bytes(read_array(bytes, offset)?))
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SnapshotCodecError {
+    #[error("invalid canonical terrain snapshot encoding")]
+    Codec,
+    #[error("terrain snapshot contains duplicate or unsorted page keys")]
+    DuplicatePageKey,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EditMode, EditOp, EditShape, NodeState};
+
+    #[test]
+    fn snapshot_round_trip_is_canonical_across_page_insertion_order() {
+        let generator_hash = ContentHash::of(b"generator");
+        let hierarchy =
+            SparseBrickTree::centered(16, NodeState::Procedural(generator_hash)).unwrap();
+        let mut edits = EditLog::default();
+        edits
+            .push(EditOp {
+                sequence: 3,
+                stable_id: [3; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [1, 2, 3],
+                    radius_cells: 5,
+                },
+                mode: EditMode::Subtract,
+                material: 0,
+            })
+            .unwrap();
+        let pages = vec![
+            CompactedPageRecord {
+                key: PageKey::new(0, [4, -1, 2]),
+                page_id: ContentHash::of(b"b"),
+                compacted_through_sequence: 3,
+            },
+            CompactedPageRecord {
+                key: PageKey::new(0, [-2, 7, 1]),
+                page_id: ContentHash::of(b"a"),
+                compacted_through_sequence: 3,
+            },
+        ];
+        let snapshot = TerrainSnapshot {
+            planet_id: PlanetId([7; 16]),
+            generator_hash,
+            hierarchy,
+            edit_tail: edits,
+            compacted_pages: pages,
+        };
+        let decoded = TerrainSnapshot::decode(&snapshot.encode().unwrap()).unwrap();
+        assert_eq!(
+            decoded.content_hash().unwrap(),
+            snapshot.content_hash().unwrap()
+        );
+        assert_eq!(decoded.compacted_pages[0].key.page_xyz, [-2, 7, 1]);
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/store.rs
+++ b/crates/subsystems/pulsar_terrain/src/store.rs
@@ -1,0 +1,213 @@
+use crate::{ContentHash, PageCodecError, PageId, VoxelPage};
+use engine_fs::virtual_fs;
+use std::path::PathBuf;
+use thiserror::Error;
+
+const MANIFEST_MAGIC: &[u8; 8] = b"PTRNRT01";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnapshotRecord {
+    pub generation: u64,
+    pub hash: ContentHash,
+    pub bytes: Vec<u8>,
+}
+
+/// Content-addressed terrain snapshots with atomic unique-name publication.
+/// A pending file is never considered a root; the preceding generation remains
+/// loadable until the provider's final rename succeeds.
+#[derive(Clone, Debug)]
+pub struct TerrainStore {
+    root: PathBuf,
+}
+
+impl TerrainStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn save(&self, snapshot: &[u8]) -> Result<SnapshotRecord, TerrainStoreError> {
+        let generation = self.latest_generation()?.unwrap_or(0).saturating_add(1);
+        let hash = self.store_object(snapshot)?;
+        virtual_fs::create_dir_all(&self.roots_dir()).map_err(TerrainStoreError::Io)?;
+
+        let manifest = encode_manifest(generation, hash);
+        let pending = self.roots_dir().join(format!("{generation:020}.pending"));
+        let published = self
+            .roots_dir()
+            .join(format!("{generation:020}-{}.root", hash.to_hex()));
+        virtual_fs::write_file(&pending, &manifest).map_err(TerrainStoreError::Io)?;
+        virtual_fs::rename(&pending, &published).map_err(TerrainStoreError::Io)?;
+
+        Ok(SnapshotRecord {
+            generation,
+            hash,
+            bytes: snapshot.to_vec(),
+        })
+    }
+
+    pub fn store_page(&self, page: &VoxelPage) -> Result<PageId, TerrainStoreError> {
+        self.store_object(&page.encode())
+    }
+
+    pub fn load_page(&self, page_id: PageId) -> Result<VoxelPage, TerrainStoreError> {
+        let bytes = virtual_fs::read_file(&self.objects_dir().join(page_id.to_hex()))
+            .map_err(TerrainStoreError::Io)?;
+        if ContentHash::of(&bytes) != page_id {
+            return Err(TerrainStoreError::ObjectHash);
+        }
+        VoxelPage::decode(&bytes).map_err(TerrainStoreError::Page)
+    }
+
+    pub fn load_latest(&self) -> Result<Option<SnapshotRecord>, TerrainStoreError> {
+        if !virtual_fs::exists(&self.roots_dir()).map_err(TerrainStoreError::Io)? {
+            return Ok(None);
+        }
+        let mut candidates = virtual_fs::list_dir(&self.roots_dir())
+            .map_err(TerrainStoreError::Io)?
+            .into_iter()
+            .filter(|entry| !entry.is_dir && entry.name.ends_with(".root"))
+            .filter_map(|entry| {
+                parse_generation(&entry.name).map(|generation| (generation, entry.name))
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_unstable_by_key(|candidate| std::cmp::Reverse(candidate.0));
+
+        for (filename_generation, filename) in candidates {
+            let manifest = match virtual_fs::read_file(&self.roots_dir().join(filename)) {
+                Ok(bytes) => bytes,
+                Err(_) => continue,
+            };
+            let Ok((generation, hash)) = decode_manifest(&manifest) else {
+                continue;
+            };
+            if generation != filename_generation {
+                continue;
+            }
+            let Ok(bytes) = virtual_fs::read_file(&self.objects_dir().join(hash.to_hex())) else {
+                continue;
+            };
+            if ContentHash::of(&bytes) != hash {
+                continue;
+            }
+            return Ok(Some(SnapshotRecord {
+                generation,
+                hash,
+                bytes,
+            }));
+        }
+        Ok(None)
+    }
+
+    fn latest_generation(&self) -> Result<Option<u64>, TerrainStoreError> {
+        Ok(self.load_latest()?.map(|record| record.generation))
+    }
+
+    fn store_object(&self, bytes: &[u8]) -> Result<ContentHash, TerrainStoreError> {
+        let hash = ContentHash::of(bytes);
+        virtual_fs::create_dir_all(&self.objects_dir()).map_err(TerrainStoreError::Io)?;
+        let object_path = self.objects_dir().join(hash.to_hex());
+        if !virtual_fs::exists(&object_path).map_err(TerrainStoreError::Io)? {
+            let pending = self
+                .objects_dir()
+                .join(format!("{}.pending", hash.to_hex()));
+            virtual_fs::write_file(&pending, bytes).map_err(TerrainStoreError::Io)?;
+            virtual_fs::rename(&pending, &object_path).map_err(TerrainStoreError::Io)?;
+        }
+        Ok(hash)
+    }
+
+    fn objects_dir(&self) -> PathBuf {
+        self.root.join("objects")
+    }
+
+    fn roots_dir(&self) -> PathBuf {
+        self.root.join("roots")
+    }
+
+    #[cfg(test)]
+    fn pending_root_path(&self, generation: u64) -> PathBuf {
+        self.roots_dir().join(format!("{generation:020}.pending"))
+    }
+}
+
+fn encode_manifest(generation: u64, hash: ContentHash) -> Vec<u8> {
+    let mut output = Vec::with_capacity(48);
+    output.extend_from_slice(MANIFEST_MAGIC);
+    output.extend_from_slice(&generation.to_le_bytes());
+    output.extend_from_slice(&hash.0);
+    output
+}
+
+fn decode_manifest(bytes: &[u8]) -> Result<(u64, ContentHash), TerrainStoreError> {
+    if bytes.len() != 48 || bytes.get(..8) != Some(MANIFEST_MAGIC) {
+        return Err(TerrainStoreError::Manifest);
+    }
+    let generation = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+    let hash = ContentHash(bytes[16..48].try_into().unwrap());
+    Ok((generation, hash))
+}
+
+fn parse_generation(filename: &str) -> Option<u64> {
+    filename.get(..20)?.parse().ok()
+}
+
+#[derive(Debug, Error)]
+pub enum TerrainStoreError {
+    #[error("terrain store I/O failed: {0}")]
+    Io(#[source] anyhow::Error),
+    #[error("invalid terrain root manifest")]
+    Manifest,
+    #[error("content-addressed terrain object hash mismatch")]
+    ObjectHash,
+    #[error("stored terrain page is invalid: {0}")]
+    Page(#[source] PageCodecError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interrupted_publish_keeps_the_previous_valid_root() {
+        virtual_fs::reset_to_local();
+        let temporary = tempfile::tempdir().unwrap();
+        let store = TerrainStore::new(temporary.path().join("terrain"));
+        let first = store.save(b"first canonical snapshot").unwrap();
+
+        virtual_fs::write_file(&store.pending_root_path(2), b"partial manifest").unwrap();
+        let recovered = store.load_latest().unwrap().unwrap();
+        assert_eq!(recovered, first);
+
+        virtual_fs::write_file(
+            &store.roots_dir().join(format!(
+                "{:020}-{}.root",
+                2,
+                ContentHash::default().to_hex()
+            )),
+            b"published but incomplete manifest",
+        )
+        .unwrap();
+        assert_eq!(store.load_latest().unwrap().unwrap(), first);
+
+        let second = store.save(b"second canonical snapshot").unwrap();
+        assert_eq!(second.generation, 2);
+        assert_eq!(store.load_latest().unwrap().unwrap(), second);
+    }
+
+    #[test]
+    fn pages_are_content_addressed_and_validated_on_load() {
+        virtual_fs::reset_to_local();
+        let temporary = tempfile::tempdir().unwrap();
+        let store = TerrainStore::new(temporary.path().join("terrain"));
+        let page = VoxelPage::constant(crate::CellWord::new(-1, 7, 0));
+        let page_id = store.store_page(&page).unwrap();
+        assert_eq!(page_id, page.page_id());
+        assert_eq!(store.load_page(page_id).unwrap(), page);
+
+        virtual_fs::write_file(&store.objects_dir().join(page_id.to_hex()), b"corrupt").unwrap();
+        assert!(matches!(
+            store.load_page(page_id),
+            Err(TerrainStoreError::ObjectHash)
+        ));
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/types.rs
+++ b/crates/subsystems/pulsar_terrain/src/types.rs
@@ -1,0 +1,618 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+pub type MaterialId = u8;
+pub const LOD0_CELL_SIZE_METERS: f64 = 0.1;
+pub const PAGE_EDGE_CELLS: i64 = 32;
+pub const MILLIMETER_INTERACTION_RADIUS_METERS: f64 = 8_192.0;
+
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub struct PlanetId(pub [u8; 16]);
+
+impl PlanetId {
+    pub fn from_stable_name(name: &str) -> Self {
+        let digest = Sha256::digest(name.as_bytes());
+        let mut id = [0_u8; 16];
+        id.copy_from_slice(&digest[..16]);
+        Self(id)
+    }
+
+    pub fn from_hex(value: &str) -> Result<Self, PlanetIdParseError> {
+        if value.len() != 32 {
+            return Err(PlanetIdParseError::Length(value.len()));
+        }
+        let mut id = [0_u8; 16];
+        for (index, output) in id.iter_mut().enumerate() {
+            let offset = index * 2;
+            *output = u8::from_str_radix(&value[offset..offset + 2], 16)
+                .map_err(|_| PlanetIdParseError::Hex { offset })?;
+        }
+        Ok(Self(id))
+    }
+
+    pub fn to_hex(self) -> String {
+        let mut output = String::with_capacity(32);
+        for byte in self.0 {
+            use std::fmt::Write as _;
+            write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+        }
+        output
+    }
+}
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum PlanetIdParseError {
+    #[error("planet id must contain exactly 32 hexadecimal characters, got {0}")]
+    Length(usize),
+    #[error("planet id contains invalid hexadecimal at byte offset {offset}")]
+    Hex { offset: usize },
+}
+
+/// Authoritative planet-space position at 10 cm LOD0 resolution.
+///
+/// `lod0_cell` is the persistent integer address. `subcell_m` is private and
+/// normalized to `[0, 0.1)` meters on every axis, including negative world
+/// coordinates. Serde deserialization runs the same validation as `new`.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "PlanetPositionWire", into = "PlanetPositionWire")]
+pub struct PlanetPosition {
+    lod0_cell: [i64; 3],
+    subcell_m: [f64; 3],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PlanetPositionWire {
+    lod0_cell: [i64; 3],
+    subcell_m: [f64; 3],
+}
+
+impl PlanetPosition {
+    pub fn new(lod0_cell: [i64; 3], mut subcell_m: [f64; 3]) -> Result<Self, PositionError> {
+        for value in &mut subcell_m {
+            if !value.is_finite() {
+                return Err(PositionError::NonFinite);
+            }
+            if !(0.0..LOD0_CELL_SIZE_METERS).contains(value) {
+                return Err(PositionError::SubcellOutOfRange);
+            }
+            if *value == -0.0 {
+                *value = 0.0;
+            }
+        }
+        Ok(Self {
+            lod0_cell,
+            subcell_m,
+        })
+    }
+
+    pub const fn from_lod0_cell(lod0_cell: [i64; 3]) -> Self {
+        Self {
+            lod0_cell,
+            subcell_m: [0.0; 3],
+        }
+    }
+
+    /// Convenience conversion for camera/input values. Terrain persistence and
+    /// replication should carry the canonical cell-plus-remainder form.
+    pub fn from_meters(meters: [f64; 3]) -> Result<Self, PositionError> {
+        let mut cells = [0_i64; 3];
+        let mut subcell_m = [0.0_f64; 3];
+        for axis in 0..3 {
+            let value = meters[axis];
+            if !value.is_finite() {
+                return Err(PositionError::NonFinite);
+            }
+            let cell = (value / LOD0_CELL_SIZE_METERS).floor();
+            if cell < i64::MIN as f64 || cell >= -(i64::MIN as f64) {
+                return Err(PositionError::CoordinateOverflow);
+            }
+            cells[axis] = cell as i64;
+            let mut remainder = value - cell * LOD0_CELL_SIZE_METERS;
+            if remainder < 0.0 {
+                cells[axis] = cells[axis]
+                    .checked_sub(1)
+                    .ok_or(PositionError::CoordinateOverflow)?;
+                remainder += LOD0_CELL_SIZE_METERS;
+            } else if remainder >= LOD0_CELL_SIZE_METERS {
+                cells[axis] = cells[axis]
+                    .checked_add(1)
+                    .ok_or(PositionError::CoordinateOverflow)?;
+                remainder -= LOD0_CELL_SIZE_METERS;
+            }
+            subcell_m[axis] = remainder;
+        }
+        Self::new(cells, subcell_m)
+    }
+
+    pub const fn lod0_cell(self) -> [i64; 3] {
+        self.lod0_cell
+    }
+
+    pub const fn subcell_m(self) -> [f64; 3] {
+        self.subcell_m
+    }
+
+    /// Computes `self - origin` before any conversion to floating point.
+    pub fn relative_meters(self, origin: Self) -> Result<[f64; 3], PositionError> {
+        let mut relative = [0.0_f64; 3];
+        for (axis, output) in relative.iter_mut().enumerate() {
+            let cell_delta = self.lod0_cell[axis]
+                .checked_sub(origin.lod0_cell[axis])
+                .ok_or(PositionError::CoordinateOverflow)?;
+            *output = cell_delta as f64 * LOD0_CELL_SIZE_METERS
+                + (self.subcell_m[axis] - origin.subcell_m[axis]);
+        }
+        Ok(relative)
+    }
+
+    pub fn relative_to_lod0_cell(
+        self,
+        origin_lod0_cell: [i64; 3],
+    ) -> Result<[f64; 3], PositionError> {
+        self.relative_meters(Self::from_lod0_cell(origin_lod0_cell))
+    }
+}
+
+impl Default for PlanetPosition {
+    fn default() -> Self {
+        Self::from_lod0_cell([0; 3])
+    }
+}
+
+impl TryFrom<PlanetPositionWire> for PlanetPosition {
+    type Error = PositionError;
+
+    fn try_from(value: PlanetPositionWire) -> Result<Self, Self::Error> {
+        Self::new(value.lod0_cell, value.subcell_m)
+    }
+}
+
+impl From<PlanetPosition> for PlanetPositionWire {
+    fn from(value: PlanetPosition) -> Self {
+        Self {
+            lod0_cell: value.lod0_cell,
+            subcell_m: value.subcell_m,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlanetFrame {
+    planet: PlanetId,
+    camera: PlanetPosition,
+    origin_lod0_cell: [i64; 3],
+    frame_index: u64,
+}
+
+impl PlanetFrame {
+    pub fn new(planet: PlanetId, camera: PlanetPosition, frame_index: u64) -> Self {
+        let origin_lod0_cell = camera
+            .lod0_cell
+            .map(|axis| axis.div_euclid(PAGE_EDGE_CELLS) * PAGE_EDGE_CELLS);
+        Self {
+            planet,
+            camera,
+            origin_lod0_cell,
+            frame_index,
+        }
+    }
+
+    pub const fn planet(self) -> PlanetId {
+        self.planet
+    }
+
+    pub const fn camera(self) -> PlanetPosition {
+        self.camera
+    }
+
+    pub const fn origin_lod0_cell(self) -> [i64; 3] {
+        self.origin_lod0_cell
+    }
+
+    pub const fn frame_index(self) -> u64 {
+        self.frame_index
+    }
+
+    pub fn camera_relative_m(self) -> [f64; 3] {
+        self.camera
+            .relative_to_lod0_cell(self.origin_lod0_cell)
+            .expect("a page-snapped camera origin cannot overflow")
+    }
+
+    pub fn camera_local_meters(self, position: PlanetPosition) -> Result<[f64; 3], PositionError> {
+        position.relative_meters(self.camera)
+    }
+
+    pub fn renderer_payload(self) -> PlanetFramePayload {
+        PlanetFramePayload {
+            planet_id_words: planet_words(self.planet),
+            origin_words: self.origin_lod0_cell.map(split_i64),
+            frame_index_words: split_u64(self.frame_index),
+            camera_relative_m: self.camera_relative_m().map(|value| value as f32),
+            lod0_cell_size_m: LOD0_CELL_SIZE_METERS as f32,
+            page_edge_cells: PAGE_EDGE_CELLS as u32,
+        }
+    }
+}
+
+/// Renderer-neutral payload matching Helio's planetary frame fields without a
+/// Helio dependency or revision pin in the authoritative terrain crate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlanetFramePayload {
+    planet_id_words: [u32; 4],
+    origin_words: [[u32; 2]; 3],
+    frame_index_words: [u32; 2],
+    camera_relative_m: [f32; 3],
+    lod0_cell_size_m: f32,
+    page_edge_cells: u32,
+}
+
+impl PlanetFramePayload {
+    pub const fn planet_id_words(self) -> [u32; 4] {
+        self.planet_id_words
+    }
+
+    pub fn planet_id(self) -> PlanetId {
+        let mut bytes = [0_u8; 16];
+        for (word, output) in self.planet_id_words.iter().zip(bytes.chunks_exact_mut(4)) {
+            output.copy_from_slice(&word.to_le_bytes());
+        }
+        PlanetId(bytes)
+    }
+
+    pub const fn origin_words(self) -> [[u32; 2]; 3] {
+        self.origin_words
+    }
+
+    pub const fn origin_lod0_cell(self) -> [i64; 3] {
+        [
+            join_i64(self.origin_words[0]),
+            join_i64(self.origin_words[1]),
+            join_i64(self.origin_words[2]),
+        ]
+    }
+
+    pub const fn frame_index_words(self) -> [u32; 2] {
+        self.frame_index_words
+    }
+
+    pub const fn frame_index(self) -> u64 {
+        join_u64(self.frame_index_words)
+    }
+
+    pub const fn camera_relative_m(self) -> [f32; 3] {
+        self.camera_relative_m
+    }
+
+    pub const fn lod0_cell_size_m(self) -> f32 {
+        self.lod0_cell_size_m
+    }
+
+    pub const fn page_edge_cells(self) -> u32 {
+        self.page_edge_cells
+    }
+}
+
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum PositionError {
+    #[error("planet position contains a non-finite value")]
+    NonFinite,
+    #[error("planet position sub-cell remainder must be in [0, 0.1) meters")]
+    SubcellOutOfRange,
+    #[error("planet position coordinate arithmetic overflowed")]
+    CoordinateOverflow,
+}
+
+const fn split_u64(value: u64) -> [u32; 2] {
+    [value as u32, (value >> 32) as u32]
+}
+
+const fn split_i64(value: i64) -> [u32; 2] {
+    split_u64(value as u64)
+}
+
+const fn join_u64(words: [u32; 2]) -> u64 {
+    (words[0] as u64) | ((words[1] as u64) << 32)
+}
+
+const fn join_i64(words: [u32; 2]) -> i64 {
+    join_u64(words) as i64
+}
+
+fn planet_words(planet: PlanetId) -> [u32; 4] {
+    let mut words = [0_u32; 4];
+    for (word, bytes) in words.iter_mut().zip(planet.0.chunks_exact(4)) {
+        *word = u32::from_le_bytes(bytes.try_into().expect("chunks_exact yields four bytes"));
+    }
+    words
+}
+
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub struct PageKey {
+    pub lod: u8,
+    pub page_xyz: [i64; 3],
+}
+
+impl PageKey {
+    pub const fn new(lod: u8, page_xyz: [i64; 3]) -> Self {
+        Self { lod, page_xyz }
+    }
+
+    pub fn parent(self) -> Option<Self> {
+        Some(Self {
+            lod: self.lod.checked_add(1)?,
+            page_xyz: self.page_xyz.map(|axis| axis.div_euclid(2)),
+        })
+    }
+
+    pub fn lod0_min(self) -> Option<[i64; 3]> {
+        let scale = 1_i64.checked_shl(u32::from(self.lod))?;
+        Some([
+            self.page_xyz[0].checked_mul(scale)?,
+            self.page_xyz[1].checked_mul(scale)?,
+            self.page_xyz[2].checked_mul(scale)?,
+        ])
+    }
+
+    /// Number of canonical LOD0 cells covered by one axis of this page.
+    pub fn lod0_cell_span(self) -> Option<i64> {
+        PAGE_EDGE_CELLS.checked_shl(u32::from(self.lod))
+    }
+
+    /// Canonical minimum LOD0-cell coordinate covered by this page.
+    pub fn lod0_cell_min(self) -> Option<[i64; 3]> {
+        let span = self.lod0_cell_span()?;
+        Some([
+            self.page_xyz[0].checked_mul(span)?,
+            self.page_xyz[1].checked_mul(span)?,
+            self.page_xyz[2].checked_mul(span)?,
+        ])
+    }
+
+    /// Convert a canonical LOD0-cell coordinate into a page and its 0..32
+    /// cell coordinate at the requested LOD. Euclidean division keeps the
+    /// mapping continuous and unambiguous across every negative-axis boundary.
+    pub fn address_lod0_cell(lod: u8, cell_xyz: [i64; 3]) -> Option<(Self, [u8; 3])> {
+        let scale = 1_i64.checked_shl(u32::from(lod))?;
+        let span = PAGE_EDGE_CELLS.checked_mul(scale)?;
+        let page_xyz = cell_xyz.map(|axis| axis.div_euclid(span));
+        let local = cell_xyz.map(|axis| (axis.rem_euclid(span) / scale) as u8);
+        Some((Self { lod, page_xyz }, local))
+    }
+}
+
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub struct ContentHash(pub [u8; 32]);
+
+impl ContentHash {
+    pub fn of(bytes: &[u8]) -> Self {
+        Self(Sha256::digest(bytes).into())
+    }
+
+    pub fn to_hex(self) -> String {
+        let mut output = String::with_capacity(64);
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        for byte in self.0 {
+            output.push(HEX[usize::from(byte >> 4)] as char);
+            output.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+        output
+    }
+}
+
+pub type PageId = ContentHash;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NodeState {
+    Air,
+    Solid(MaterialId),
+    Procedural(ContentHash),
+    Branch,
+    Page(PageId),
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CellWord(pub u32);
+
+impl CellWord {
+    pub const AIR: Self = Self::new(i16::MAX, 0, 0);
+
+    pub const fn new(density: i16, material: MaterialId, flags: u8) -> Self {
+        Self((density as u16 as u32) | ((material as u32) << 16) | ((flags as u32) << 24))
+    }
+
+    pub const fn density(self) -> i16 {
+        self.0 as u16 as i16
+    }
+
+    pub const fn material(self) -> MaterialId {
+        (self.0 >> 16) as u8
+    }
+
+    pub const fn flags(self) -> u8 {
+        (self.0 >> 24) as u8
+    }
+
+    pub const fn is_solid(self) -> bool {
+        self.density() <= 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signed_cell_to_page_conversion_is_exact_at_every_boundary() {
+        for lod in 0..=30 {
+            let scale = 1_i64 << lod;
+            let span = PAGE_EDGE_CELLS * scale;
+            let boundaries = [
+                -span - 1,
+                -span,
+                -span + 1,
+                -1,
+                0,
+                1,
+                span - 1,
+                span,
+                span + 1,
+            ];
+            for coordinate in boundaries {
+                let cell = [coordinate, -coordinate, coordinate.saturating_sub(1)];
+                let (key, local) = PageKey::address_lod0_cell(lod, cell).unwrap();
+                let page_min = key.lod0_cell_min().unwrap();
+                for axis in 0..3 {
+                    assert!(local[axis] < PAGE_EDGE_CELLS as u8);
+                    let reconstructed = page_min[axis] + i64::from(local[axis]) * scale;
+                    assert!(reconstructed <= cell[axis]);
+                    assert!(cell[axis] < reconstructed + scale);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn page_parent_uses_euclidean_division_on_negative_axes() {
+        assert_eq!(
+            PageKey::new(0, [-1, -2, -3]).parent(),
+            Some(PageKey::new(1, [-1, -1, -2]))
+        );
+    }
+
+    #[test]
+    fn planet_ids_round_trip_and_stable_names_are_deterministic() {
+        let id = PlanetId::from_stable_name("scene/earth:0");
+        assert_eq!(PlanetId::from_hex(&id.to_hex()).unwrap(), id);
+        assert_eq!(PlanetId::from_stable_name("scene/earth:0"), id);
+        assert_ne!(PlanetId::from_stable_name("scene/earth:1"), id);
+    }
+
+    #[test]
+    fn position_serde_is_canonical_and_rejects_invalid_payloads() {
+        let position = PlanetPosition::new([-63_710_001, 7, -1], [0.099, 0.0, -0.0]).unwrap();
+        let json = serde_json::to_string(&position).unwrap();
+        assert_eq!(
+            json,
+            r#"{"lod0_cell":[-63710001,7,-1],"subcell_m":[0.099,0.0,0.0]}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<PlanetPosition>(&json).unwrap(),
+            position
+        );
+        assert!(serde_json::from_str::<PlanetPosition>(
+            r#"{"lod0_cell":[0,0,0],"subcell_m":[0.1,0.0,0.0]}"#
+        )
+        .is_err());
+        assert!(serde_json::from_str::<PlanetPosition>(
+            r#"{"sector":[0,0,0],"offset_m":[0.0,0.0,0.0]}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn negative_meter_coordinates_use_euclidean_cells() {
+        let position = PlanetPosition::from_meters([-0.001, -0.1, -3.201]).unwrap();
+        assert_eq!(position.lod0_cell(), [-1, -1, -33]);
+        let expected = [0.099, 0.0, 0.099];
+        for (actual, expected) in position.subcell_m().into_iter().zip(expected) {
+            assert!((actual - expected).abs() < 1.0e-12);
+        }
+    }
+
+    #[test]
+    fn earth_ground_orbit_and_antipode_frames_stay_canonical() {
+        let earth_cells = 63_710_000_i64;
+        let ground = PlanetPosition::new([earth_cells, 0, 0], [0.001, 0.099, 0.05]).unwrap();
+        let orbit = PlanetPosition::new([67_710_000, 0, 0], [0.001, 0.099, 0.05]).unwrap();
+        let antipode = PlanetPosition::new([-earth_cells, 0, 0], [0.001, 0.099, 0.05]).unwrap();
+        assert_eq!(
+            orbit.relative_meters(ground).unwrap(),
+            [400_000.0, 0.0, 0.0]
+        );
+        assert_eq!(
+            ground.relative_meters(antipode).unwrap(),
+            [12_742_000.0, 0.0, 0.0]
+        );
+
+        let frame = PlanetFrame::new(PlanetId([4; 16]), ground, 17);
+        assert_eq!(frame.origin_lod0_cell(), [63_709_984, 0, 0]);
+        assert_eq!(frame.camera_relative_m(), [1.601, 0.099, 0.05]);
+        let payload = frame.renderer_payload();
+        assert_eq!(payload.planet_id(), PlanetId([4; 16]));
+        assert_eq!(payload.planet_id_words(), [0x0404_0404; 4]);
+        assert_eq!(payload.origin_lod0_cell(), frame.origin_lod0_cell());
+        assert_eq!(payload.frame_index(), 17);
+        assert_eq!(payload.lod0_cell_size_m(), 0.1_f32);
+        assert_eq!(payload.page_edge_cells(), 32);
+    }
+
+    #[test]
+    fn signed_origin_and_frame_words_round_trip_losslessly() {
+        for camera_cell in [
+            [i64::MIN, -1, 0],
+            [-63_710_017, 63_710_017, -32],
+            [i64::MAX, i64::MAX - 31, 31],
+        ] {
+            let frame = PlanetFrame::new(
+                PlanetId([8; 16]),
+                PlanetPosition::from_lod0_cell(camera_cell),
+                u64::MAX,
+            );
+            let payload = frame.renderer_payload();
+            assert_eq!(payload.origin_lod0_cell(), frame.origin_lod0_cell());
+            assert_eq!(payload.frame_index(), u64::MAX);
+        }
+    }
+
+    #[test]
+    fn renderer_payload_stays_within_one_millimeter_across_a_rebase() {
+        let earth_cells = 63_710_000_i64;
+        for camera_cell in [earth_cells + 31, earth_cells + 32] {
+            let camera = PlanetPosition::new([camera_cell, -1, 7], [0.037, 0.081, 0.019]).unwrap();
+            let point = PlanetPosition::new(
+                [
+                    camera_cell
+                        + (MILLIMETER_INTERACTION_RADIUS_METERS / LOD0_CELL_SIZE_METERS) as i64
+                        - 1,
+                    -4,
+                    9,
+                ],
+                [0.092, 0.006, 0.071],
+            )
+            .unwrap();
+            let frame = PlanetFrame::new(PlanetId([2; 16]), camera, 5);
+            let payload = frame.renderer_payload();
+            let expected = frame.camera_local_meters(point).unwrap();
+            let origin = payload.origin_lod0_cell();
+            let subcell = point.subcell_m();
+            let camera_relative = payload.camera_relative_m();
+            let reconstructed = [
+                ((point.lod0_cell()[0] - origin[0]) as f32
+                    + (subcell[0] / LOD0_CELL_SIZE_METERS) as f32)
+                    * payload.lod0_cell_size_m()
+                    - camera_relative[0],
+                ((point.lod0_cell()[1] - origin[1]) as f32
+                    + (subcell[1] / LOD0_CELL_SIZE_METERS) as f32)
+                    * payload.lod0_cell_size_m()
+                    - camera_relative[1],
+                ((point.lod0_cell()[2] - origin[2]) as f32
+                    + (subcell[2] / LOD0_CELL_SIZE_METERS) as f32)
+                    * payload.lod0_cell_size_m()
+                    - camera_relative[2],
+            ];
+            for (actual, expected) in reconstructed.into_iter().zip(expected) {
+                assert!((f64::from(actual) - expected).abs() <= 0.001);
+            }
+        }
+    }
+}

--- a/crates/subsystems/pulsar_terrain/tests/core_contract.rs
+++ b/crates/subsystems/pulsar_terrain/tests/core_contract.rs
@@ -1,0 +1,188 @@
+use pulsar_terrain::{
+    CellWord, DeterministicGenerator, EditLog, EditMode, EditOp, EditShape, FixedSphereGenerator,
+    NodeState, PageKey, PlanetId, SparseBrickTree, TerrainCore, VoxelPage,
+};
+
+fn sphere() -> FixedSphereGenerator {
+    FixedSphereGenerator {
+        center_cell: [0; 3],
+        radius_cells: 64,
+        material: 2,
+    }
+}
+
+#[test]
+fn edit_order_is_deterministic_and_changes_page_hash() {
+    let generator = sphere();
+    let key = PageKey::new(0, [-1, 0, 0]);
+    let base = VoxelPage::generate(key, &generator, &EditLog::default()).unwrap();
+    let operation = EditOp {
+        sequence: 1,
+        stable_id: [1; 16],
+        shape: EditShape::Sphere {
+            center_cell: [-8, 8, 8],
+            radius_cells: 6,
+        },
+        mode: EditMode::Subtract,
+        material: 0,
+    };
+    let mut edits = EditLog::default();
+    edits.push(operation).unwrap();
+    edits.push(operation).unwrap();
+    let edited_a = VoxelPage::generate(key, &generator, &edits).unwrap();
+    let edited_b = VoxelPage::generate(key, &generator, &edits).unwrap();
+    assert_ne!(base.page_id(), edited_a.page_id());
+    assert_eq!(edited_a.page_id(), edited_b.page_id());
+}
+
+#[test]
+fn identical_core_inputs_produce_identical_hierarchy_page_and_snapshot_hashes() {
+    let build = || {
+        let mut core = TerrainCore::new(PlanetId([7; 16]), 12, sphere()).unwrap();
+        for sequence in 1..=3_u64 {
+            core.append_edit(EditOp {
+                sequence,
+                stable_id: [sequence as u8; 16],
+                shape: EditShape::Sphere {
+                    center_cell: [sequence as i64 * 3, 8, -4],
+                    radius_cells: sequence as u32 + 1,
+                },
+                mode: EditMode::Subtract,
+                material: 0,
+            })
+            .unwrap();
+        }
+        let page = core.compact_page(PageKey::new(0, [0, 0, -1])).unwrap();
+        (
+            page.page_id,
+            core.hierarchy().content_hash(),
+            core.snapshot().content_hash().unwrap(),
+        )
+    };
+
+    assert_eq!(build(), build());
+}
+
+#[test]
+fn billion_cell_logical_region_cost_depends_on_touched_paths() {
+    let mut tree = SparseBrickTree::centered(24, NodeState::Procedural(sphere().hash())).unwrap();
+    for index in 0..128 {
+        tree.set(
+            PageKey::new(0, [index * 1024 - 65_536, -index * 37, index * 11]),
+            NodeState::Page(pulsar_terrain::ContentHash::of(&index.to_le_bytes())),
+        )
+        .unwrap();
+    }
+    assert!(tree.node_count() <= 1 + 128 * 8 * 24);
+    tree.set_root(NodeState::Air).unwrap();
+    assert_eq!(tree.node_count(), 1);
+}
+
+#[test]
+fn cell_word_layout_is_exactly_four_bytes() {
+    assert_eq!(std::mem::size_of::<CellWord>(), 4);
+    let word = CellWord::new(-123, 17, 9);
+    assert_eq!(
+        (word.density(), word.material(), word.flags()),
+        (-123, 17, 9)
+    );
+}
+
+fn next_random(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    *state
+}
+
+#[test]
+fn randomized_sparse_hierarchy_matches_a_dense_reference_fixture() {
+    const ROOT_LOD: u8 = 5;
+    const ROOT_EDGE: usize = 1 << ROOT_LOD;
+    const ROOT_MIN: i64 = -(ROOT_EDGE as i64 / 2);
+    let mut tree = SparseBrickTree::centered(ROOT_LOD, NodeState::Air).unwrap();
+    let mut dense = vec![NodeState::Air; ROOT_EDGE * ROOT_EDGE * ROOT_EDGE];
+    let mut random = 0x4d59_5df4_d0f3_3173_u64;
+
+    for operation in 0..512 {
+        let lod = (next_random(&mut random) % 4) as u8;
+        let half = 1_i64 << (ROOT_LOD - 1 - lod);
+        let coordinate = |random: &mut u64| (next_random(random) % (2 * half) as u64) as i64 - half;
+        let key = PageKey::new(
+            lod,
+            [
+                coordinate(&mut random),
+                coordinate(&mut random),
+                coordinate(&mut random),
+            ],
+        );
+        let state = if operation % 5 == 0 {
+            NodeState::Air
+        } else {
+            NodeState::Solid((operation % 13 + 1) as u8)
+        };
+        tree.set(key, state.clone()).unwrap();
+
+        let min = key.lod0_min().unwrap();
+        let edge = 1_i64 << lod;
+        for z in min[2]..min[2] + edge {
+            for y in min[1]..min[1] + edge {
+                for x in min[0]..min[0] + edge {
+                    let local = [x - ROOT_MIN, y - ROOT_MIN, z - ROOT_MIN];
+                    let index = local[0] as usize
+                        + ROOT_EDGE * (local[1] as usize + ROOT_EDGE * local[2] as usize);
+                    dense[index] = state.clone();
+                }
+            }
+        }
+    }
+
+    for z in ROOT_MIN..ROOT_MIN + ROOT_EDGE as i64 {
+        for y in ROOT_MIN..ROOT_MIN + ROOT_EDGE as i64 {
+            for x in ROOT_MIN..ROOT_MIN + ROOT_EDGE as i64 {
+                let local = [x - ROOT_MIN, y - ROOT_MIN, z - ROOT_MIN];
+                let index = local[0] as usize
+                    + ROOT_EDGE * (local[1] as usize + ROOT_EDGE * local[2] as usize);
+                assert_eq!(
+                    tree.resolve(PageKey::new(0, [x, y, z])).unwrap(),
+                    dense[index],
+                    "sparse mismatch at [{x}, {y}, {z}]"
+                );
+            }
+        }
+    }
+
+    let decoded = SparseBrickTree::decode(&tree.encode()).unwrap();
+    assert_eq!(decoded, tree);
+    tree.set_root(NodeState::Solid(9)).unwrap();
+    assert_eq!(tree.node_count(), 1);
+    assert_eq!(
+        tree.resolve(PageKey::new(0, [-16; 3])).unwrap(),
+        NodeState::Solid(9)
+    );
+}
+
+#[test]
+fn randomized_page_codecs_are_canonical_and_deterministic() {
+    let mut random = 0xa076_1d64_78bd_642f_u64;
+    for fixture in 0..32 {
+        let mut cells = Vec::with_capacity(pulsar_terrain::CELL_COUNT);
+        let mut current = CellWord::AIR;
+        for index in 0..pulsar_terrain::CELL_COUNT {
+            if index == 0 || next_random(&mut random) % 19 == 0 {
+                current = CellWord::new(
+                    next_random(&mut random) as i16,
+                    next_random(&mut random) as u8,
+                    fixture,
+                );
+            }
+            cells.push(current);
+        }
+        let page = VoxelPage::from_cells(cells).unwrap();
+        let encoded = page.encode();
+        let decoded = VoxelPage::decode(&encoded).unwrap();
+        assert_eq!(decoded, page);
+        assert_eq!(decoded.encode(), encoded);
+        assert_eq!(decoded.page_id(), page.page_id());
+    }
+}

--- a/docs/planetary-voxel-terrain.md
+++ b/docs/planetary-voxel-terrain.md
@@ -1,0 +1,330 @@
+# Planetary voxel terrain goal and architecture
+
+Status: research-backed implementation plan, 2026-07-13
+
+## Goal
+
+Build a new production terrain path for a real-scale spherical planet with a true volumetric source representation, approximately 10 cm maximum local resolution, arbitrary digging/building/material edits, persistence, and the semantic ability to remove every part of the planet.
+
+This is a new subsystem. It does not replace Helio's existing `voxel_demo` or `voxel_demo_raymarch`; those remain examples and regression baselines.
+
+The target is not a heightmap, a thin shell presented as a volume, a pre-cut destruction mesh, or a dense grid hidden behind a smaller render distance. Far geometry must be derived from the same volumetric field as near geometry. Rasterized meshes are allowed only as a transient render/collision cache generated from that field.
+
+## Feasibility boundary
+
+For an Earth-radius body (`R = 6,371 km`) and 10 cm cells:
+
+- One surface-cell layer contains about `5.10e16` cells.
+- One bit per surface cell would require about `6.38 PB`.
+- Four bytes per surface cell would require about `204 PB`.
+- A dense full sphere contains about `1.08e24` cells, or `4.33 YB` at four bytes per cell.
+
+Therefore, "10 cm planet" can only mean an exact virtual address space with 10 cm finest resolution. Uniform air, uniform solid regions, untouched procedural regions, and coarse distant regions must remain hierarchical descriptions. Finest pages are materialized only where observation, editing, physics, or authored data requires them.
+
+Destroying the whole planet is still exact: setting the root override to `Air` changes the canonical terrain state without iterating over `1.08e24` cells. It does not imply simulating `1.08e24` independent rigid bodies. Detached-body simulation is a separately budgeted system.
+
+## Architectural decision
+
+Use a Virtual Sparse Brick Tree (VSBT):
+
+1. A VDB-like mutable hierarchy is the canonical spatial index.
+2. Uniform nodes encode `Air` or `Solid(material)` without children.
+3. Untouched nodes reference a deterministic procedural field instead of materialized voxels.
+4. Edited/detail leaves reference fixed-size voxel pages.
+5. A bounded CPU page cache owns decompressed working data.
+6. A bounded GPU hash/page table maps active page keys into large shared brick buffers.
+7. View-driven LOD requests pages; every LOD is sampled from the same volumetric field.
+8. GPU compute incrementally extracts terrain meshlets for normal raster rendering.
+
+The hierarchy, edit log, and persisted pages are authoritative. GPU voxel pages and meshes are disposable caches.
+
+### Why this combination
+
+| Candidate | Strength | Rejection or role |
+|---|---|---|
+| Dense grid | Simple indexing and edits | Physically impossible at planetary scale |
+| One global sparse voxel octree | Compresses uniform space and supplies LOD | Pointer traversal and mutation are too expensive for the resident hot path; retained as the conceptual hierarchy only |
+| Sparse voxel DAG | Exceptional static repetition compression | Shared subtrees amplify mutation and copy-on-write cost; optional immutable archive compression, never the mutable canonical store |
+| OpenVDB/NanoVDB as-is | Proven sparse hierarchy and GPU traversal | OpenVDB is C++/CPU-oriented; NanoVDB has static topology and is read-only for structural edits; use the data-layout lessons, not a drop-in dependency |
+| Flat hashed brick map | Fast random access and dynamic GPU updates | Cannot alone represent global LOD, deep uniform solid space, or root-scale edits; use it as the resident GPU cache |
+| Cubed-sphere surface shell | Efficient for conventional planet surfaces | Introduces face seams and special central/deep topology, and makes arbitrary full-volume destruction harder |
+| VSBT plus resident brick cache | Mutable hierarchy, exact large edits, bounded residency, GPU-friendly pages | Chosen |
+
+## Canonical data model
+
+### Addressing
+
+```text
+PlanetId
+PlanetPosition { lod0_cell: [i64; 3], subcell_m: [f64; 3] }
+PageKey { lod: u8, page_xyz: [i64; 3] }
+NodeState = Air | Solid(material) | Procedural(source) | Branch | Page(PageId)
+```
+
+Do not use one 64-bit Morton key for the full address. About 27 binary levels are required to span an Earth diameter down to 10 cm, which exceeds 64 bits when three coordinate bits are interleaved at every level. Keep level and signed axes explicit on CPU and serialize them canonically.
+
+`PlanetPosition.lod0_cell` is the signed authoritative 10 cm address.
+`subcell_m` is normalized to the half-open interval `[0, 0.1)` on every axis;
+negative positions use Euclidean cell decomposition. Invalid or non-finite
+remainders are rejected during construction and deserialization. Large
+absolute coordinates are never collapsed into one floating-point value before
+the active frame origin is subtracted.
+
+GPU page addresses are camera-relative 32-bit values plus a per-frame origin. WGSL has no concrete 64-bit integer type, and absolute planet coordinates must never reach shader arithmetic as one `f32`.
+
+### Page layout
+
+Initial measurement candidate:
+
+- Logical page: `32^3` cells (3.2 m at LOD0).
+- Dirty/dispatch unit: `8^3` microbrick.
+- Cell word: signed 16-bit density/distance, 8-bit material palette index, 8-bit flags.
+- One-voxel halo is generated or fetched for meshing but is not duplicated in persistence.
+- Uniform channels use a constant representation and allocate no dense array.
+
+The 32-bit cell word is deliberately aligned for Rust, storage buffers, atomics/copies, and WGSL. Smaller encodings may be added only after profiling demonstrates that bandwidth dominates and decode cost is acceptable.
+
+### Procedural base plus edits
+
+The base planet is a deterministic fixed-point function returning density and material. It may call authored data sources, but identical inputs must return identical values independent of view LOD.
+
+Every terrain mutation is an ordered operation:
+
+```text
+EditOp {
+    sequence,
+    shape,
+    mode: Union | Subtract | Replace | Paint,
+    material,
+    planet_space_bounds,
+}
+```
+
+Small edits materialize affected LOD0 pages. Large edits attach high in the hierarchy and are evaluated lazily by descendants. Background compaction folds operation tails into versioned pages and collapses newly uniform subtrees. The edit kernel uses deterministic integer/fixed-point math so persistence, multiplayer, CPU generation, and GPU previews cannot silently disagree.
+
+## Coordinates and large-world behavior
+
+Pulsar owns canonical planet-space coordinates. Helio and Rapier consume a camera/simulation-local frame:
+
+```text
+canonical planet position (i64/f64)
+        -> subtract active frame origin
+        -> local f32 transform for rendering/physics
+```
+
+The active origin snaps to a stable LOD0 page boundary. Rebasing changes derived transforms and cache keys, not canonical object or terrain positions.
+
+This avoids an engine-wide conversion of existing scene components, Helio camera buffers, mesh transforms, and Rapier APIs from `f32`. Existing objects remain valid. New large-world objects opt into a `LargeWorldTransform`/planet-frame component, while legacy transforms remain local-world components.
+
+## Streaming and LOD
+
+- Maintain a 2:1-balanced active hierarchy: adjacent rendered leaves differ by at most one LOD.
+- LOD0 starts at 10 cm inside a measured interaction radius (initial target: 64 m), then cell size doubles by level.
+- Requests are driven by projected error, camera motion prediction, edit bounds, physics bubbles, and shadow visibility—not distance alone.
+- Page generation, disk/network reads, decompression, meshing, and collision cooking use separate queues with deadlines and cancellation.
+- A request scheduler reserves capacity for edits and collision so fast camera movement cannot starve gameplay.
+- Pages transition through explicit states: `Absent -> Requested -> CPUReady -> GPUResident -> Meshed`, each carrying a generation number to reject stale jobs.
+- GPU data uses a few large suballocated buffers. Never allocate one wgpu buffer per terrain page.
+- Coarse pages use conservative filtering so thin solid features do not disappear or flip topology unpredictably.
+
+The planet seen from orbit is coarse voxel geometry from the same field, not a heightmap proxy. Atmosphere and oceans may be separate render systems, but they do not replace terrain geometry.
+
+## Rendering decision
+
+The production path is GPU-extracted meshlets rendered through Helio's normal depth, G-buffer, shadow, lighting, Hi-Z, and temporal passes. Per-pixel voxel ray marching remains useful for validation and picking experiments, but is not the primary planetary renderer because surface-dominant scenes pay traversal cost at every shaded pixel.
+
+Helio's existing meshlet/virtual-geometry implementation is a prerequisite to audit, not a trusted dependency. The current implementation uses compute culling plus classic indexed indirect draws, duplicates all LOD meshlets per instance, labels rather than measures LOD error, selects LOD from cluster-local projected radius, and performs position-only welding that can destroy vertex-attribute seams. The planetary path may share it only after Helio's dedicated meshlet correctness, bounded-rebuild, caller-compatibility, and performance gates pass. Otherwise the planet pass will use a terrain-specialized publisher behind the same descriptor/draw contract while the generic path is repaired independently.
+
+Two extraction algorithms must be measured on the same page format:
+
+1. GPU Transvoxel: proven crack stitching and predictable lookup-table work.
+2. Feature-preserving manifold dual contouring: fewer vertices and better sharp-feature retention, with a more expensive Hermite/QEF pipeline.
+
+The production choice is a benchmark gate, not a preference. Dual contouring is promoted if it remains within 25% of Transvoxel's dirty-page generation time while materially reducing mesh size or geometric error and passing manifold/crack tests. Otherwise Transvoxel is promoted. Both use the same authoritative voxels; there will not be two terrain systems.
+
+Mesh generation stages are classify, compact active cells, solve/emit vertices, emit topology/LOD transitions, build meshlets and bounds, and publish an indirect-draw range. Old meshlets remain visible until the replacement generation is complete.
+
+## Destruction and detached matter
+
+- Subtract/add/paint/replace edits operate at 10 cm inside the high-resolution interaction region.
+- Dirty propagation touches affected microbricks, neighbor halos, coarse ancestors, render meshlets, collision pages, navigation, and persistence versions.
+- A root or high-level uniform override supports exact continental or whole-planet removal without leaf expansion.
+- Structural separation is evaluated around edited regions with a sparse connectivity job. Supported terrain remains in the planet tree; bounded detached islands become `VoxelBody` entities.
+- Detached bodies have explicit voxel, volume, and active-body budgets. Beyond the budget, the terrain state is still exact, but debris simulation is aggregated or deferred. The engine must report that degradation rather than silently dropping terrain edits.
+
+## Physics
+
+Rapier remains local `f32` physics. Switching the whole engine to `rapier3d-f64` would touch every collider, rigid body, query, and component caller and still would not solve GPU precision.
+
+The terrain subsystem provides:
+
+- Exact voxel-field ray/sweep queries for tools, digging, and surface sampling.
+- Incremental triangle colliders cooked from active near-field pages for general rigid bodies.
+- A command queue into `PhysicsEngine` for add/replace/remove terrain colliders; the physics thread remains the sole owner of Rapier mutation.
+- Planet-frame gravity direction and magnitude supplied to simulation bubbles.
+- Generation IDs so an old collider result cannot replace newer terrain.
+
+## Persistence and multiplayer
+
+- Base data: generator/version/content hashes.
+- Mutable data: hierarchical overrides, content-addressed compressed pages, and an ordered edit tail.
+- Storage: only through `engine_fs::virtual_fs`, preserving Pulsar's local/remote/P2P providers.
+- Save snapshots publish a new root atomically; interrupted writes cannot corrupt the previous root.
+- Multiplayer is server-authoritative. Edits carry stable IDs and sequence numbers.
+- Interest management operates on `PageKey` ranges and simulation bubbles.
+- Join-in-progress transfers root metadata, requested page hashes/pages, then the edit tail—not an entire planet save through one RPC.
+- Page hashes and deterministic replay are verified in tests across thread counts and supported platforms.
+
+## Ownership in the repositories
+
+### Pulsar
+
+Create `crates/subsystems/pulsar_terrain` as the authoritative runtime crate. It owns planet definitions, coordinates, hierarchy, generation, edit scheduling, persistence, streaming, collision requests, and replication-facing data.
+
+Create `PlanetTerrainComponent` in that runtime crate. Do not repurpose the current editor-only `TerrainComponent` or `ProceduralTerrainComponent` during the prototype. Their runtime methods are empty today, and retaining them avoids a scene-format migration while the new contract is validated.
+
+`pulsar_rendering` consumes immutable render deltas/page uploads from `pulsar_terrain`; it does not own terrain state. `engine_backend` registers the terrain subsystem through the existing subsystem/plugin injection path. The level editor provides inspectors and debug views for the runtime component.
+
+### Helio
+
+Create new crates:
+
+- `helio-planet-voxel-core`: GPU POD layouts, page/upload protocol, limits, and validation helpers.
+- `helio-pass-planetary-voxel`: resident page pool, compute extraction, meshlet culling/draw, G-buffer/shadow integration, and profiling.
+- A new `planet_voxel_demo` example for isolated validation.
+
+The pass owns independent buffers. It must not reuse or resize `GpuScene::voxel_brick_pool`, `voxel_data_pool`, `VoxelTerrain`, `VoxelMeshPass`, or `VoxelRayMarchPass`.
+
+Helio's locked default graph needs an additive graph-extension/build hook at the geometry stage. With no extension supplied, the pass list and behavior must be byte-for-byte/API-equivalent to today. Pulsar opts into the planetary pass explicitly.
+
+## Compatibility audit before engine changes
+
+| Proposed change | Known users | Compatibility requirement |
+|---|---|---|
+| New Helio planet crates/pass | No existing callers | Additive; current voxel crates and demos unchanged |
+| Helio meshlet repair/replacement | `libhelio`, virtual-mesh upload/rebuild, `helio-pass-virtual-geometry`, default graphs, VG examples/debug views, voxel mesh pass terminology | Preserve public callers and default graph behavior; add real geometry/GPU tests; no mandatory mesh-shader feature |
+| Default-graph geometry extension hook | All `Renderer` constructors and examples through `helio-default-graphs` | Disabled by default; existing pass order snapshot and examples must remain unchanged |
+| Pulsar Helio dependency update | `engine_backend`, `pulsar_game`, `pulsar_rendering`, reflection primitives, asset thumbnails | First isolate current-Helio API adaptation; run targeted checks before terrain work |
+| Planet-local render frame | Pulsar scene sync, editor camera, picking/gizmos | Opt-in path; legacy f32 scene objects keep current semantics |
+| Terrain subsystem registration | `EngineBackend` subsystem/plugin injection and generated games | Explicit dependency ID; clean init/shutdown; no editor dependency in shipped runtime |
+| Terrain collider command queue | `PhysicsEngine`, `PhysicsQueryService`, physics components | Additive API; physics thread remains sole mutator; existing queries unchanged |
+| Persistent page store | `engine_fs` local/remote/P2P providers | No direct `std::fs`; atomic root and versioned format tests |
+
+Pulsar currently pins Helio commit `b88e366d`, while the retained voxel baselines are at Helio `3210590`. The pin cannot simply be changed: the current Pulsar call to `Renderer::new_with_external_device` uses an older constructor surface. Compatibility milestone 0 must adapt and verify the two direct constructor paths (`engine_backend` and `pulsar_game`) before the planet pass is introduced.
+
+## Provisional performance and quality gates
+
+Baseline target: desktop, 1440p, 60 Hz, 6-core CPU, 16 GB system RAM, 8 GB VRAM, commodity NVMe, and a WebGPU-class discrete GPU. These are goals to measure, not current claims.
+
+| Metric | Promotion gate |
+|---|---|
+| Steady terrain GPU time | <= 4.0 ms p95 at the reference traversal scenes |
+| Main/render-thread terrain CPU | <= 0.5 ms p95; no synchronous generation or save I/O |
+| Terrain-caused frame spike | No p99 frame above 25 ms in the fly/teleport/edit traces |
+| GPU terrain memory | <= 2 GB configurable budget, including pages, meshes, tables, and staging |
+| CPU terrain memory | <= 3 GB configurable budget |
+| Small edit (<= 1 m radius) | Replacement mesh visible within 2 frames p95 |
+| Medium edit (<= 10 m radius) | First visible response <= 100 ms, completed near field <= 500 ms p95 |
+| Root-scale delete | Canonical state update <= 10 ms and visible invalidation within 2 frames; refinement remains asynchronous |
+| Ground-to-orbit precision | <= 1 mm local jitter/error inside the interaction bubble |
+| LOD quality | No holes/T-junction cracks in adversarial 2:1 boundaries; manifold gate for dual contouring |
+| Persistence | Save/load/replay produces identical root/page hashes |
+| Regression | Both existing Helio voxel demos still compile and run their automated smoke path |
+
+Reference traces must include ground walking, supersonic surface flight, ground-to-orbit travel, teleport, cave traversal, repeated drilling, 10 m explosion, kilometer-scale subtraction, whole-root deletion, and save/reload during background work.
+
+## Execution plan
+
+### Milestone 0: compatibility baseline
+
+- Record pass-order, compile, and smoke baselines for Helio's two existing voxel demos.
+- Adapt Pulsar to current Helio behind a focused compatibility change.
+- Audit both Pulsar renderer constructor paths and component/runtime registrations.
+- Gate: both repositories cleanly build targeted crates; no planet code yet.
+
+### Milestone 1: sparse terrain core
+
+- Add `pulsar_terrain` with page keys, node states, deterministic generator interface, edit log, compaction, page codec, and `engine_fs` store.
+- Add property/fuzz tests for hierarchy collapse, edit ordering, negative coordinates, LOD reduction, interrupted saves, and deterministic hashes.
+- Add dense-vs-sparse and edit-amplification benchmarks.
+- Gate: billion-cell logical test regions remain bounded by touched surface/pages; no O(world volume) operation.
+
+### Meshlet prerequisite gate
+
+- Audit all Helio meshlet construction, LOD, buffer rebuild, compute culling, indirect draw, shader, graph, debug, and example callers.
+- Validate against meshoptimizer, Microsoft DirectX meshlet samples, NVIDIA task-culling guidance, and AMD cross-vendor sizing/profiling guidance.
+- Fix attribute-safe indexing, real simplification error/ranges, object/region-consistent LOD coverage, exact cone tests, immutable descriptor instancing, bounded generation-tagged dynamic ranges, and overflow handling.
+- Benchmark static assets and generated voxel surfaces against conventional indexed rendering.
+- Gate: zero correctness false-rejects, no per-instance duplication of immutable descriptors, bounded dynamic rebuilds, measured win or justified parity, and no caller/default-graph regressions before shared use by planetary terrain.
+
+### Milestone 2: Helio resident page cache
+
+- Add the new core/pass crates and a standalone planet demo.
+- Implement bounded shared buffers, page generations, uploads/evictions, neighbor halos, GPU profiling, and validation readbacks.
+- Gate: no per-page GPU allocations, stale-job rejection passes, memory never exceeds configured budget.
+
+### Milestone 3: extraction bake-off
+
+- Implement Transvoxel and manifold dual-contouring prototypes over the same pages.
+- Test cracks, topology, feature error, triangles, generation latency, and total frame time.
+- Select one production extractor by the stated gate; remove the losing production path after retaining benchmark evidence.
+
+### Milestone 4: real-radius coordinates and streaming
+
+- Add planet-frame positions and camera-relative rendering.
+- Implement 2:1 LOD requests from 10 cm near field through orbital scale.
+- Add predictive scheduling, cancellation, and ground/orbit/teleport traces.
+- Gate: precision, no cracks, bounded residency, and frame-time targets pass.
+
+### Milestone 5: destruction and persistence
+
+- Apply deterministic edits, dirty propagation, coarse rebuilds, background compaction, and atomic saves.
+- Validate complete root removal and restore from a prior snapshot.
+- Gate: edit latency, exact hashes, and crash-recovery tests pass.
+
+### Milestone 6: Pulsar component and editor integration
+
+- Register `PlanetTerrainComponent` and terrain subsystem.
+- Bridge render deltas into the new Helio pass.
+- Add editor diagnostics for page state, LOD, queue latency, memory, and edit bounds.
+- Gate: standalone generated game does not link editor crates; legacy terrain components/scenes remain loadable.
+
+### Milestone 7: physics and detached bodies
+
+- Add voxel queries, local collider cooking, physics command queue, radial gravity, connectivity analysis, and bounded `VoxelBody` extraction.
+- Gate: no stale colliders, no physics-thread ownership violation, and edit/collision convergence tests pass.
+
+### Milestone 8: replication and production hardening
+
+- Add authoritative edit sequencing, interest-based pages, snapshots, join-in-progress, corruption detection, budgets, and telemetry.
+- Run all reference traces on minimum and target hardware.
+- Promote only if every performance, quality, persistence, compatibility, and regression gate passes.
+
+## Stop and redesign conditions
+
+Do not continue adding features if any of these persist after focused optimization:
+
+- 10 cm interaction pages cannot meet the edit-latency budget without unbounded mesh backlog.
+- Coarse LOD cannot conserve topology/material well enough to avoid visible holes or destructive edit disagreement.
+- Resident working-set growth is proportional to planet size rather than active views/edits.
+- Persistence or multiplayer requires replaying the entire historical edit log for an active page.
+- The new pass requires changing default Helio behavior or broadening mandatory GPU features for all users.
+- Large-world support requires silently changing existing Pulsar transform semantics.
+
+## Research basis
+
+- [GigaVoxels: Ray-Guided Streaming for Efficient and Detailed Voxel Rendering](https://doi.org/10.1145/1507149.1507152): view/visibility-driven production and streaming of datasets beyond GPU memory, demonstrated at several billion voxels.
+- [Efficient Sparse Voxel Octrees](https://research.nvidia.com/publication/2010-02_efficient-sparse-voxel-octrees) and the [extended technical report](https://research.nvidia.com/sites/default/files/pubs/2010-02_Efficient-Sparse-Voxel/laine2010tr1_paper.pdf): compact hierarchical traversal, contour data, filtering, and explicit storage-resolution tradeoffs.
+- [High Resolution Sparse Voxel DAGs](https://icg.gwu.edu/sites/g/files/zaxdzs6126/files/downloads/highResolutionSparseVoxelDAGs.pdf): 19 billion static voxels in 945 MB, showing the value and mutation cost risk of shared-subtree compression.
+- [VDB: High-Resolution Sparse Volumes with Dynamic Topology](https://museth.org/Ken/Publications_files/Museth_TOG13.pdf) and [OpenVDB overview](https://www.openvdb.org/documentation/doxygen/overview.html): effectively unbounded integer index space, dynamic sparse topology, fast access, and CSG-oriented hierarchy.
+- [NanoVDB documentation](https://www.openvdb.org/documentation/doxygen/NanoVDB_8h.html): compact GPU-friendly VDB traversal, but explicitly read-only/static-topology for structural changes.
+- [Real-time 3D Reconstruction at Scale using Voxel Hashing](https://www.graphics.stanford.edu/~niessner/niessner2013hashing.html): dynamic GPU-friendly hashed blocks, streaming, and storage only where surface data is observed.
+- [Dual Contouring of Hermite Data](https://people.engr.tamu.edu/schaefer/research/dualcontour.pdf) and [Manifold Dual Contouring](https://doi.org/10.1109/TVCG.2007.1012): adaptive, crack-free, feature-preserving surface extraction and topology-preserving simplification.
+- [The Transvoxel Algorithm](https://transvoxel.org/) and [Voxel-Based Terrain for Real-Time Virtual Simulations](https://transvoxel.org/Lengyel-VoxelTerrain.pdf): practical transition cells for seamless multiresolution volumetric terrain.
+- [Voxel Tools for Godot](https://github.com/Zylann/godot_voxel), its [performance notes](https://voxel-tools.readthedocs.io/en/latest/performance/), and [streaming/persistence design](https://voxel-tools.readthedocs.io/en/latest/streams/): open-source evidence for chunk paging, asynchronous generation, Transvoxel LOD, modified-block persistence, collision updates, and the cost of many small GPU resources.
+- [Voxel Plugin runtime edits](https://docs.voxelplugin.com/knowledgebase/blueprints/runtime-edits-and-sculpting): production-oriented evidence that large edits, sculpt accumulation, asynchronous work, persistence, physics, and replication must be designed as separate costs.
+- [Unreal Engine large-world rendering](https://dev.epicgames.com/documentation/unreal-engine/large-world-coordinates-rendering-in-unreal-engine-5) and the [WGSL specification](https://www.w3.org/TR/WGSL/): use canonical high precision plus translated camera-local GPU space instead of absolute planet coordinates in shaders.
+- [Atomontage Virtual Matter](https://www.atomontage.com/) and [Voxel Farm](https://voxelfarm.com/gaming.html): commercial evidence that progressively streamed microvoxels and mutable massive worlds are viable product directions, but their implementation claims are proprietary and are not treated as reproducible design evidence.
+- [meshoptimizer clusterization](https://github.com/zeux/meshoptimizer#clusterization): production meshlet construction, bounds, cone-culling formulas, spatial splitting, compression, and cross-vendor cluster-size caveats.
+- [Microsoft Direct3D 12 mesh shader samples](https://learn.microsoft.com/en-us/samples/microsoft/directx-graphics-samples/d3d12-mesh-shader-samples-win32/): reference conversion, culling, instancing, and object-level dynamic LOD organization.
+- [NVIDIA mesh-shader introduction](https://developer.nvidia.com/blog/introduction-turing-mesh-shaders/) and [AMD optimization guidance](https://gpuopen.com/learn/mesh_shaders/mesh_shaders-optimization_and_best_practices/): primary vendor evidence for cluster-level early rejection, occupancy, and hardware-sensitive meshlet sizing.


### PR DESCRIPTION
## Summary
- restore the already-merged `pulsar_terrain` subsystem and planetary terrain design document that PR #250's SceneDB merge dropped from its first parent
- restore the workspace dependency and lockfile entry on the post-SceneDB tree
- keep the consolidated editor terrain and SceneDB architecture unchanged
- do not reintroduce `pulsar_ecs` or any legacy editor terrain implementation

## Root cause
Merge commit `a5ad7f8e` contains the planetary work in first parent `1b16e11b`, but the merge result deletes the full terrain crate and document. This also causes delete/modify conflicts for the next planet-only PR (#339).

## Validation on current main
- `cargo check -p pulsar_terrain`
- `cargo test -p pulsar_terrain` — 46 passed
- `cargo clippy -p pulsar_terrain --all-targets --no-deps -- -D warnings`
- `cargo check -p engine_backend -p pulsar_rendering -p pulsar_game -p ui_level_editor` — all passed
- `git diff --cached --check`

The unrestricted dependency-wide Clippy invocation exposes existing warnings in the new SceneDB-era reflection/WGPUI dependencies; this PR does not broaden into that unrelated cleanup.

## Review boundary
This restores shared engine state and therefore requires maintainer review before merge. The planet-only planner PR #339 should be rebased after this lands.

Closes #340