### PR TITLE
Add bounded planetary residency reconciliation

### DIFF
--- a/crates/subsystems/pulsar_terrain/src/core.rs
+++ b/crates/subsystems/pulsar_terrain/src/core.rs
@@ -29,6 +29,7 @@ pub struct TerrainWorkCounters {
     pub cells_generated: u64,
     pub cells_replayed: u64,
     pub edit_candidates_replayed: u64,
+    pub pages_rehydrated: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -178,23 +179,26 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
                 if self.pages.contains_key(&key) {
                     return Ok(PageBuildPreparation::Current(*record));
                 }
-                return Err(TerrainCoreError::BasePageUnavailable(key));
             }
         }
 
+        let base_page = self.pages.get(&key).cloned();
+        // Dense pages are a disposable cache. If one was evicted, rebuild it
+        // from the deterministic source and full relevant edit prefix.
+        let replay_from_sequence = if base_page.is_some() {
+            previous_sequence
+        } else {
+            0
+        };
         let relevant = self
             .edit_index
-            .operations_for_page(&self.edits, key, previous_sequence);
-        let base_page = self.pages.get(&key).cloned();
-        if previous_sequence != 0 && base_page.is_none() {
-            return Err(TerrainCoreError::BasePageUnavailable(key));
-        }
+            .operations_for_page(&self.edits, key, replay_from_sequence);
         Ok(PageBuildPreparation::Build(PageBuildRequest {
             key,
             generator: self.generator.clone(),
             base_page_id: base_page.as_ref().map(VoxelPage::page_id),
             base_page,
-            previous_sequence,
+            previous_sequence: replay_from_sequence,
             target_sequence: latest_sequence,
             operations: relevant,
         }))
@@ -211,17 +215,40 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             });
         }
         if let Some(current) = self.compacted.get(&result.key).copied() {
-            if current.compacted_through_sequence == result.target_sequence
-                && self.pages.contains_key(&result.key)
-            {
-                return Ok(PageBuildCommitOutcome::Duplicate(current));
-            }
-            if current.compacted_through_sequence != result.previous_sequence
-                || self.pages.get(&result.key).map(VoxelPage::page_id) != result.base_page_id
-            {
-                return Ok(PageBuildCommitOutcome::Stale {
-                    newest_sequence: current.compacted_through_sequence.max(latest_sequence),
-                });
+            if !self.pages.contains_key(&result.key) && result.previous_sequence == 0 {
+                let rebuilt_page_id = result.page.page_id();
+                if current.compacted_through_sequence == result.target_sequence {
+                    if current.page_id != rebuilt_page_id {
+                        return Err(TerrainCoreError::RehydratedPageMismatch(result.key));
+                    }
+                    self.pages.insert(result.key, result.page);
+                    self.work.pages_rehydrated = self.work.pages_rehydrated.saturating_add(1);
+                    self.work.cells_generated = self
+                        .work
+                        .cells_generated
+                        .saturating_add(crate::CELL_COUNT as u64);
+                    self.work.edit_candidates_replayed = self
+                        .work
+                        .edit_candidates_replayed
+                        .saturating_add(result.replayed_operations as u64);
+                    return Ok(PageBuildCommitOutcome::Duplicate(current));
+                }
+                // This resident cache was evicted before newer edits arrived.
+                // The full replay below safely replaces the older compacted
+                // record because target_sequence was checked above.
+            } else {
+                if current.compacted_through_sequence == result.target_sequence
+                    && self.pages.contains_key(&result.key)
+                {
+                    return Ok(PageBuildCommitOutcome::Duplicate(current));
+                }
+                if current.compacted_through_sequence != result.previous_sequence
+                    || self.pages.get(&result.key).map(VoxelPage::page_id) != result.base_page_id
+                {
+                    return Ok(PageBuildCommitOutcome::Stale {
+                        newest_sequence: current.compacted_through_sequence.max(latest_sequence),
+                    });
+                }
             }
         } else if result.previous_sequence != 0 || result.base_page_id.is_some() {
             return Ok(PageBuildCommitOutcome::Stale {
@@ -295,6 +322,13 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
         self.pages.keys().copied()
     }
 
+    /// Drop one decompressed page while retaining its authoritative compacted
+    /// record and hierarchy entry. A later request rehydrates the exact bytes
+    /// from the deterministic generator and ordered edit prefix.
+    pub fn evict_resident_page(&mut self, key: PageKey) -> bool {
+        self.pages.remove(&key).is_some()
+    }
+
     /// Exact whole-root replacement. Resident pages remain disposable caches;
     /// the root state is immediately authoritative without iterating over them.
     pub fn set_root(&mut self, state: NodeState) -> Result<(), TerrainCoreError> {
@@ -355,10 +389,8 @@ pub enum TerrainCoreError {
     Edit(#[from] EditError),
     #[error(transparent)]
     Page(#[from] PageCodecError),
-    #[error(
-        "compacted page {0:?} is not resident; reload it from the content store before replay"
-    )]
-    BasePageUnavailable(PageKey),
+    #[error("rehydrated page {0:?} does not match its authoritative content hash")]
+    RehydratedPageMismatch(PageKey),
 }
 
 #[cfg(test)]
@@ -576,5 +608,69 @@ mod tests {
         );
         assert_eq!(core.work_counters().pages_compacted, 1);
         assert_eq!(core.memory_counters().compacted_page_records, 1);
+    }
+
+    #[test]
+    fn evicted_dense_page_rehydrates_to_the_authoritative_hash() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([6; 16]), 12, generator).unwrap();
+        let key = PageKey::new(0, [0; 3]);
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [7; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8; 3],
+                radius_cells: 3,
+            },
+            mode: EditMode::Paint,
+            material: 12,
+        })
+        .unwrap();
+        let original = core.compact_page(key).unwrap();
+        let snapshot_before = core.snapshot();
+
+        assert!(core.evict_resident_page(key));
+        assert!(!core.evict_resident_page(key));
+        assert!(core.page(key).is_none());
+        assert_eq!(core.snapshot(), snapshot_before);
+
+        let rehydrated = core.compact_page(key).unwrap();
+        assert_eq!(rehydrated, original);
+        assert_eq!(core.page(key).unwrap().page_id(), original.page_id);
+        assert_eq!(core.work_counters().pages_rehydrated, 1);
+        assert_eq!(core.work_counters().pages_compacted, 1);
+    }
+
+    #[test]
+    fn evicted_page_full_replay_includes_edits_added_while_absent() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([7; 16]), 12, generator).unwrap();
+        let key = PageKey::new(0, [0; 3]);
+        core.compact_page(key).unwrap();
+        assert!(core.evict_resident_page(key));
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [8; 16],
+            shape: EditShape::Sphere {
+                center_cell: [8; 3],
+                radius_cells: 2,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        })
+        .unwrap();
+
+        let updated = core.compact_page(key).unwrap();
+        assert_eq!(updated.compacted_through_sequence, 1);
+        assert_eq!(core.work_counters().pages_compacted, 2);
+        assert_eq!(core.work_counters().edit_candidates_replayed, 1);
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/lib.rs
+++ b/crates/subsystems/pulsar_terrain/src/lib.rs
@@ -11,6 +11,7 @@ mod edit;
 mod generator;
 mod hierarchy;
 mod page;
+mod residency;
 mod runtime;
 mod snapshot;
 mod store;
@@ -30,6 +31,10 @@ pub use hierarchy::{HierarchyError, SparseBrickTree};
 pub use page::{
     PageCodecError, VoxelPage, CELL_COUNT, MICROBRICKS_PER_AXIS, MICROBRICK_COUNT, MICROBRICK_EDGE,
     PAGE_EDGE,
+};
+pub use residency::{
+    TerrainResidencyConfig, TerrainResidencyCounters, TerrainResidencyError,
+    TerrainResidencyReport, TerrainResidencySession,
 };
 pub use runtime::{
     TerrainBackpressure, TerrainRequestClass, TerrainRequestOutcome, TerrainRuntimeConfig,

--- a/crates/subsystems/pulsar_terrain/src/residency.rs
+++ b/crates/subsystems/pulsar_terrain/src/residency.rs
@@ -1,0 +1,570 @@
+use crate::{
+    PageDemand, PageKey, PlanetId, TerrainRequestClass, TerrainRequestOutcome, TerrainRuntimeError,
+    TerrainRuntimeHandle, TerrainStreamingPlan,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use thiserror::Error;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TerrainResidencyConfig {
+    /// Maximum number of pages in one stable visible/prefetch set.
+    pub max_active_pages: usize,
+    /// Maximum union of the committed and replacement sets during handoff.
+    pub max_transition_pages: usize,
+    /// Maximum runtime submissions performed by one reconcile call.
+    pub max_requests_per_reconcile: usize,
+    pub visible_deadline_ticks: u64,
+    pub prefetch_deadline_ticks: u64,
+}
+
+impl Default for TerrainResidencyConfig {
+    fn default() -> Self {
+        Self {
+            max_active_pages: 2_048,
+            max_transition_pages: 4_096,
+            max_requests_per_reconcile: 64,
+            visible_deadline_ticks: 1,
+            prefetch_deadline_ticks: 8,
+        }
+    }
+}
+
+impl TerrainResidencyConfig {
+    fn validate(self) -> Result<Self, TerrainResidencyError> {
+        if self.max_active_pages == 0 {
+            return Err(TerrainResidencyError::InvalidConfig(
+                "max_active_pages must be non-zero",
+            ));
+        }
+        if self.max_transition_pages < self.max_active_pages {
+            return Err(TerrainResidencyError::InvalidConfig(
+                "max_transition_pages must cover max_active_pages",
+            ));
+        }
+        if self.max_requests_per_reconcile == 0 {
+            return Err(TerrainResidencyError::InvalidConfig(
+                "max_requests_per_reconcile must be non-zero",
+            ));
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerrainResidencyCounters {
+    pub plans_seen: u64,
+    pub plans_superseded: u64,
+    pub requests_queued: u64,
+    pub requests_coalesced: u64,
+    pub pages_current: u64,
+    pub requests_deferred: u64,
+    pub pages_evicted: u64,
+    pub handoffs_committed: u64,
+    pub active_page_high_water: usize,
+    pub transition_page_high_water: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerrainResidencyReport {
+    pub submitted: usize,
+    pub queued: usize,
+    pub coalesced: usize,
+    pub current: usize,
+    pub deferred: usize,
+    pub evicted: usize,
+    pub ready_pages: usize,
+    pub desired_pages: usize,
+    pub committed_pages: usize,
+    pub handoff_committed: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum TerrainResidencyError {
+    #[error("invalid terrain residency configuration: {0}")]
+    InvalidConfig(&'static str),
+    #[error("residency session belongs to planet {session:?}, not plan planet {plan:?}")]
+    PlanetMismatch { session: PlanetId, plan: PlanetId },
+    #[error("plan contains {pages} pages but the active-page budget is {capacity}")]
+    ActivePageBudget { pages: usize, capacity: usize },
+    #[error("handoff requires {pages} pages but the transition budget is {capacity}")]
+    TransitionPageBudget { pages: usize, capacity: usize },
+    #[error(transparent)]
+    Runtime(#[from] TerrainRuntimeError),
+}
+
+#[derive(Clone, Debug)]
+struct PendingPlan {
+    demands: Vec<PageDemand>,
+    keys: BTreeSet<PageKey>,
+}
+
+/// Reconciles complete deterministic demand plans with the asynchronous page
+/// runtime. The previously committed set remains resident until every page in
+/// its replacement is ready, preventing a camera teleport from exposing a
+/// partially materialized LOD set.
+pub struct TerrainResidencySession {
+    planet_id: PlanetId,
+    config: TerrainResidencyConfig,
+    committed: BTreeMap<PageKey, TerrainRequestClass>,
+    pending: Option<PendingPlan>,
+    counters: TerrainResidencyCounters,
+}
+
+impl TerrainResidencySession {
+    pub fn new(
+        planet_id: PlanetId,
+        config: TerrainResidencyConfig,
+    ) -> Result<Self, TerrainResidencyError> {
+        Ok(Self {
+            planet_id,
+            config: config.validate()?,
+            committed: BTreeMap::new(),
+            pending: None,
+            counters: TerrainResidencyCounters::default(),
+        })
+    }
+
+    pub fn planet_id(&self) -> PlanetId {
+        self.planet_id
+    }
+
+    pub fn committed_pages(&self) -> impl ExactSizeIterator<Item = PageKey> + '_ {
+        self.committed.keys().copied()
+    }
+
+    pub fn pending_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
+        self.pending
+            .as_ref()
+            .into_iter()
+            .flat_map(|pending| pending.keys.iter().copied())
+    }
+
+    pub fn counters(&self) -> TerrainResidencyCounters {
+        self.counters
+    }
+
+    pub fn reconcile(
+        &mut self,
+        runtime: &TerrainRuntimeHandle,
+        plan: &TerrainStreamingPlan,
+        tick: u64,
+    ) -> Result<TerrainResidencyReport, TerrainResidencyError> {
+        if plan.planet_id() != self.planet_id {
+            return Err(TerrainResidencyError::PlanetMismatch {
+                session: self.planet_id,
+                plan: plan.planet_id(),
+            });
+        }
+        if plan.demands().len() > self.config.max_active_pages {
+            return Err(TerrainResidencyError::ActivePageBudget {
+                pages: plan.demands().len(),
+                capacity: self.config.max_active_pages,
+            });
+        }
+        let desired_keys = plan
+            .demands()
+            .iter()
+            .map(|demand| demand.page_key())
+            .collect::<BTreeSet<_>>();
+        let transition_pages = self
+            .committed
+            .keys()
+            .copied()
+            .chain(desired_keys.iter().copied())
+            .collect::<BTreeSet<_>>()
+            .len();
+        if transition_pages > self.config.max_transition_pages {
+            return Err(TerrainResidencyError::TransitionPageBudget {
+                pages: transition_pages,
+                capacity: self.config.max_transition_pages,
+            });
+        }
+
+        let is_new_plan = self
+            .pending
+            .as_ref()
+            .is_none_or(|pending| pending.demands != plan.demands());
+        let mut report = TerrainResidencyReport {
+            desired_pages: desired_keys.len(),
+            committed_pages: self.committed.len(),
+            ..TerrainResidencyReport::default()
+        };
+        let committed_matches = self.committed.len() == plan.demands().len()
+            && plan.demands().iter().all(|demand| {
+                self.committed.get(&demand.page_key()) == Some(&demand.request_class())
+            });
+        if self.pending.is_none() && committed_matches {
+            report.ready_pages = desired_keys.len();
+            return Ok(report);
+        }
+        if is_new_plan {
+            self.counters.plans_seen = self.counters.plans_seen.saturating_add(1);
+            if let Some(previous) = self.pending.take() {
+                self.counters.plans_superseded = self.counters.plans_superseded.saturating_add(1);
+                for key in previous.keys.difference(&desired_keys).copied() {
+                    if !self.committed.contains_key(&key)
+                        && runtime.evict_page(self.planet_id, key)?
+                    {
+                        report.evicted += 1;
+                    }
+                }
+            }
+            self.pending = Some(PendingPlan {
+                demands: plan.demands().to_vec(),
+                keys: desired_keys.clone(),
+            });
+        }
+
+        self.counters.active_page_high_water =
+            self.counters.active_page_high_water.max(desired_keys.len());
+        self.counters.transition_page_high_water = self
+            .counters
+            .transition_page_high_water
+            .max(transition_pages);
+
+        let resident_before = runtime
+            .resident_page_keys(self.planet_id)?
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let pending_demands = self
+            .pending
+            .as_ref()
+            .expect("a valid plan always establishes pending demand")
+            .demands
+            .clone();
+        for demand in pending_demands
+            .iter()
+            .filter(|demand| !resident_before.contains(&demand.page_key()))
+            .take(self.config.max_requests_per_reconcile)
+        {
+            let deadline_offset = match demand.request_class() {
+                TerrainRequestClass::Prefetch => self.config.prefetch_deadline_ticks,
+                TerrainRequestClass::Visible
+                | TerrainRequestClass::Collision
+                | TerrainRequestClass::EditResponse => self.config.visible_deadline_ticks,
+            };
+            report.submitted += 1;
+            match runtime.request_page(
+                self.planet_id,
+                demand.page_key(),
+                demand.request_class(),
+                tick.saturating_add(deadline_offset),
+            ) {
+                Ok(TerrainRequestOutcome::Queued { .. }) => {
+                    report.queued += 1;
+                    self.counters.requests_queued = self.counters.requests_queued.saturating_add(1);
+                }
+                Ok(TerrainRequestOutcome::Coalesced { .. }) => {
+                    report.coalesced += 1;
+                    self.counters.requests_coalesced =
+                        self.counters.requests_coalesced.saturating_add(1);
+                }
+                Ok(TerrainRequestOutcome::Current { .. }) => {
+                    report.current += 1;
+                    self.counters.pages_current = self.counters.pages_current.saturating_add(1);
+                }
+                Err(error) if is_backpressure(&error) => {
+                    report.deferred += 1;
+                    self.counters.requests_deferred =
+                        self.counters.requests_deferred.saturating_add(1);
+                    break;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        let resident_after = runtime
+            .resident_page_keys(self.planet_id)?
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        report.ready_pages = desired_keys.intersection(&resident_after).count();
+        if report.ready_pages == desired_keys.len() {
+            let obsolete = self
+                .committed
+                .keys()
+                .copied()
+                .filter(|key| !desired_keys.contains(key))
+                .collect::<Vec<_>>();
+            for key in obsolete {
+                if runtime.evict_page(self.planet_id, key)? {
+                    report.evicted += 1;
+                }
+            }
+            self.committed = plan
+                .demands()
+                .iter()
+                .map(|demand| (demand.page_key(), demand.request_class()))
+                .collect();
+            self.pending = None;
+            report.committed_pages = self.committed.len();
+            report.handoff_committed = true;
+            self.counters.handoffs_committed = self.counters.handoffs_committed.saturating_add(1);
+        }
+        self.counters.pages_evicted = self
+            .counters
+            .pages_evicted
+            .saturating_add(report.evicted as u64);
+        Ok(report)
+    }
+}
+
+fn is_backpressure(error: &TerrainRuntimeError) -> bool {
+    matches!(
+        error,
+        TerrainRuntimeError::RequestBackpressure { .. }
+            | TerrainRuntimeError::CompletionBackpressure { .. }
+            | TerrainRuntimeError::EventBackpressure { .. }
+            | TerrainRuntimeError::PlanetResidentPageBudget { .. }
+            | TerrainRuntimeError::GlobalResidentPageBudget { .. }
+            | TerrainRuntimeError::ResidentByteBudget { .. }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PageDemand, PlanetDefinition, TerrainRuntimeConfig, TerrainSubsystem, CELL_COUNT};
+    use engine_subsystems::{Subsystem, SubsystemContext};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    const DENSE_PAGE_BYTES: usize = CELL_COUNT * std::mem::size_of::<crate::CellWord>();
+
+    fn start() -> TerrainSubsystem {
+        let mut subsystem = TerrainSubsystem::new(TerrainRuntimeConfig {
+            worker_count: 1,
+            max_planets: 1,
+            max_component_sources: 1,
+            request_capacity: 16,
+            critical_request_reserve: 2,
+            completion_capacity: 16,
+            event_capacity: 64,
+            max_resident_pages: 8,
+            max_resident_dense_bytes: 8 * DENSE_PAGE_BYTES,
+            max_completions_per_frame: 16,
+        })
+        .unwrap();
+        subsystem.init(&SubsystemContext::new()).unwrap();
+        subsystem
+    }
+
+    fn definition() -> PlanetDefinition {
+        PlanetDefinition {
+            planet_id: PlanetId([42; 16]),
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 2,
+            root_lod: 12,
+            max_resident_pages: 8,
+        }
+    }
+
+    fn plan(keys: &[(PageKey, TerrainRequestClass)]) -> TerrainStreamingPlan {
+        TerrainStreamingPlan::for_test(
+            definition().planet_id,
+            keys.iter()
+                .map(|(key, class)| PageDemand::for_test(*key, *class))
+                .collect(),
+        )
+    }
+
+    fn settle(
+        session: &mut TerrainResidencySession,
+        handle: &TerrainRuntimeHandle,
+        plan: &TerrainStreamingPlan,
+    ) -> TerrainResidencyReport {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            handle.pump(16);
+            handle.drain_events(64);
+            let report = session.reconcile(handle, plan, 1).unwrap();
+            if report.handoff_committed {
+                return report;
+            }
+            assert!(Instant::now() < deadline, "residency handoff timed out");
+            thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn replacement_set_commits_only_after_every_page_is_ready() {
+        let mut subsystem = start();
+        let handle = subsystem.runtime_handle();
+        handle.upsert_planet(definition()).unwrap();
+        let mut session = TerrainResidencySession::new(
+            definition().planet_id,
+            TerrainResidencyConfig {
+                max_active_pages: 2,
+                max_transition_pages: 4,
+                max_requests_per_reconcile: 2,
+                ..TerrainResidencyConfig::default()
+            },
+        )
+        .unwrap();
+        let first = plan(&[
+            (PageKey::new(0, [0, 0, 0]), TerrainRequestClass::Visible),
+            (PageKey::new(0, [1, 0, 0]), TerrainRequestClass::Visible),
+        ]);
+        settle(&mut session, &handle, &first);
+
+        let second = plan(&[
+            (PageKey::new(0, [4, 0, 0]), TerrainRequestClass::Visible),
+            (PageKey::new(0, [5, 0, 0]), TerrainRequestClass::Visible),
+        ]);
+        let initial = session.reconcile(&handle, &second, 2).unwrap();
+        assert!(!initial.handoff_committed);
+        assert_eq!(
+            session.committed_pages().collect::<Vec<_>>(),
+            first
+                .demands()
+                .iter()
+                .map(|d| d.page_key())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            handle
+                .resident_page_keys(definition().planet_id)
+                .unwrap()
+                .len()
+                <= 4
+        );
+
+        let committed = settle(&mut session, &handle, &second);
+        assert!(committed.handoff_committed);
+        assert_eq!(committed.evicted, 2);
+        assert_eq!(
+            handle
+                .resident_page_keys(definition().planet_id)
+                .unwrap()
+                .len(),
+            2
+        );
+        let stable = session.reconcile(&handle, &second, 3).unwrap();
+        assert!(!stable.handoff_committed);
+        assert_eq!(stable.submitted, 0);
+        assert_eq!(session.counters().handoffs_committed, 2);
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn superseded_teleport_cancels_uncommitted_work_and_stays_bounded() {
+        let mut subsystem = start();
+        let handle = subsystem.runtime_handle();
+        handle.upsert_planet(definition()).unwrap();
+        let mut session = TerrainResidencySession::new(
+            definition().planet_id,
+            TerrainResidencyConfig {
+                max_active_pages: 2,
+                max_transition_pages: 4,
+                max_requests_per_reconcile: 1,
+                ..TerrainResidencyConfig::default()
+            },
+        )
+        .unwrap();
+        let origin = plan(&[(PageKey::new(0, [0, 0, 0]), TerrainRequestClass::Visible)]);
+        settle(&mut session, &handle, &origin);
+        let abandoned = plan(&[
+            (PageKey::new(0, [10, 0, 0]), TerrainRequestClass::Visible),
+            (PageKey::new(0, [11, 0, 0]), TerrainRequestClass::Prefetch),
+        ]);
+        session.reconcile(&handle, &abandoned, 2).unwrap();
+        let destination = plan(&[(PageKey::new(0, [-10, 0, 0]), TerrainRequestClass::Visible)]);
+        session.reconcile(&handle, &destination, 3).unwrap();
+        settle(&mut session, &handle, &destination);
+
+        assert_eq!(
+            session.committed_pages().collect::<Vec<_>>(),
+            vec![PageKey::new(0, [-10, 0, 0])]
+        );
+        assert!(session.counters().plans_superseded >= 1);
+        assert!(session.counters().transition_page_high_water <= 4);
+        assert!(handle.counters().cancelled + handle.counters().stale_rejected >= 1);
+        assert!(
+            handle
+                .resident_page_keys(definition().planet_id)
+                .unwrap()
+                .len()
+                <= 2
+        );
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn transition_budget_rejects_a_handoff_without_mutating_committed_state() {
+        let mut subsystem = start();
+        let handle = subsystem.runtime_handle();
+        handle.upsert_planet(definition()).unwrap();
+        let mut session = TerrainResidencySession::new(
+            definition().planet_id,
+            TerrainResidencyConfig {
+                max_active_pages: 2,
+                max_transition_pages: 2,
+                max_requests_per_reconcile: 2,
+                ..TerrainResidencyConfig::default()
+            },
+        )
+        .unwrap();
+        let first = plan(&[
+            (PageKey::new(0, [0, 0, 0]), TerrainRequestClass::Visible),
+            (PageKey::new(0, [1, 0, 0]), TerrainRequestClass::Visible),
+        ]);
+        settle(&mut session, &handle, &first);
+        let replacement = plan(&[
+            (PageKey::new(0, [2, 0, 0]), TerrainRequestClass::Visible),
+            (PageKey::new(0, [3, 0, 0]), TerrainRequestClass::Visible),
+        ]);
+        assert!(matches!(
+            session.reconcile(&handle, &replacement, 2),
+            Err(TerrainResidencyError::TransitionPageBudget {
+                pages: 4,
+                capacity: 2
+            })
+        ));
+        assert_eq!(session.committed_pages().count(), 2);
+        assert_eq!(
+            handle
+                .resident_page_keys(definition().planet_id)
+                .unwrap()
+                .len(),
+            2
+        );
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn repeated_teleports_do_not_accumulate_resident_pages() {
+        let mut subsystem = start();
+        let handle = subsystem.runtime_handle();
+        handle.upsert_planet(definition()).unwrap();
+        let mut session = TerrainResidencySession::new(
+            definition().planet_id,
+            TerrainResidencyConfig {
+                max_active_pages: 1,
+                max_transition_pages: 2,
+                max_requests_per_reconcile: 1,
+                ..TerrainResidencyConfig::default()
+            },
+        )
+        .unwrap();
+
+        for x in -16..16 {
+            let destination =
+                plan(&[(PageKey::new(0, [x * 8, 0, 0]), TerrainRequestClass::Visible)]);
+            settle(&mut session, &handle, &destination);
+            assert_eq!(
+                handle
+                    .resident_page_keys(definition().planet_id)
+                    .unwrap()
+                    .len(),
+                1
+            );
+        }
+
+        let counters = session.counters();
+        assert_eq!(counters.handoffs_committed, 32);
+        assert_eq!(counters.active_page_high_water, 1);
+        assert_eq!(counters.transition_page_high_water, 2);
+        assert_eq!(handle.counters().resident_page_high_water, 2);
+        subsystem.shutdown().unwrap();
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/runtime.rs
+++ b/crates/subsystems/pulsar_terrain/src/runtime.rs
@@ -147,6 +147,12 @@ pub enum TerrainRuntimeEvent {
         planet_id: PlanetId,
         retired_generation: u64,
     },
+    EvictPage {
+        planet_id: PlanetId,
+        page_key: PageKey,
+        planet_generation: u64,
+        retired_page_generation: u64,
+    },
     StaleRejected {
         planet_id: PlanetId,
         page_key: PageKey,
@@ -187,6 +193,7 @@ pub struct TerrainRuntimeCounters {
     pub coalesced: u64,
     pub priority_upgrades: u64,
     pub cancelled: u64,
+    pub evicted: u64,
     pub stale_rejected: u64,
     pub backpressured: u64,
     pub published: u64,
@@ -1016,6 +1023,95 @@ impl TerrainRuntimeHandle {
         })
     }
 
+    /// Retire one disposable resident page and all work targeting its current
+    /// generation. The compacted content hash remains authoritative, so a
+    /// later request can deterministically rehydrate the same page.
+    pub fn evict_page(
+        &self,
+        planet_id: PlanetId,
+        page_key: PageKey,
+    ) -> Result<bool, TerrainRuntimeError> {
+        let mut state = lock(&self.shared.state);
+        if !state.running {
+            return Err(TerrainRuntimeError::NotRunning);
+        }
+        let Some((planet_generation, page_generation, is_resident)) =
+            state.planets.get(&planet_id).map(|planet| {
+                (
+                    planet.generation,
+                    planet.page_generations.get(&page_key).copied().unwrap_or(1),
+                    planet.core.page(page_key).is_some(),
+                )
+            })
+        else {
+            return Err(TerrainRuntimeError::PlanetMissing(planet_id));
+        };
+        let has_active = state
+            .active
+            .keys()
+            .any(|identity| identity.planet_id == planet_id && identity.page_key == page_key);
+        if !is_resident && !has_active {
+            return Ok(false);
+        }
+        if state.events.len() >= self.shared.config.event_capacity {
+            record_backpressure(
+                &mut state,
+                &self.shared.config,
+                Some(planet_id),
+                Some(page_key),
+                TerrainBackpressure::EventQueue,
+            );
+            return Err(TerrainRuntimeError::EventBackpressure {
+                capacity: self.shared.config.event_capacity,
+            });
+        }
+
+        let cancelled = self.shared.queue.cancel_where(|job| {
+            job.identity.planet_id == planet_id && job.identity.page_key == page_key
+        });
+        for job in cancelled {
+            state.cancel_active(job.identity);
+        }
+        let remaining = state
+            .active
+            .iter()
+            .filter_map(|(identity, active)| {
+                (identity.planet_id == planet_id
+                    && identity.page_key == page_key
+                    && active.phase != RequestPhase::Completed)
+                    .then_some(*identity)
+            })
+            .collect::<Vec<_>>();
+        for identity in remaining {
+            state.cancel_active(identity);
+        }
+
+        let next_page_generation = page_generation
+            .checked_add(1)
+            .ok_or(TerrainRuntimeError::GenerationOverflow)?;
+        let planet = state
+            .planets
+            .get_mut(&planet_id)
+            .expect("planet remains registered while state is locked");
+        planet
+            .page_generations
+            .insert(page_key, next_page_generation);
+        planet.core.evict_resident_page(page_key);
+        state.counters.evicted = state.counters.evicted.saturating_add(1);
+        let pushed = state.push_event(
+            TerrainRuntimeEvent::EvictPage {
+                planet_id,
+                page_key,
+                planet_generation,
+                retired_page_generation: page_generation,
+            },
+            self.shared.config.event_capacity,
+        );
+        debug_assert!(pushed, "event capacity was checked before page eviction");
+        state.refresh_resident_counters();
+        Ok(true)
+    }
+
     pub fn pump(&self, max_completions: usize) -> usize {
         let mut processed = 0;
         while processed < max_completions {
@@ -1057,6 +1153,18 @@ impl TerrainRuntimeHandle {
             .get(&planet_id)
             .and_then(|planet| planet.core.page(page_key))
             .cloned()
+    }
+
+    pub fn resident_page_keys(
+        &self,
+        planet_id: PlanetId,
+    ) -> Result<Vec<PageKey>, TerrainRuntimeError> {
+        let state = lock(&self.shared.state);
+        let planet = state
+            .planets
+            .get(&planet_id)
+            .ok_or(TerrainRuntimeError::PlanetMissing(planet_id))?;
+        Ok(planet.core.resident_page_keys().collect())
     }
 
     fn publish_completion(&self, state: &mut RuntimeState, completion: WorkCompletion) {
@@ -1529,6 +1637,47 @@ mod tests {
             TerrainRuntimeEvent::StaleRejected { page_key, .. } if *page_key == key
         )));
         assert!(handle.page_snapshot(id, key).is_none());
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn eviction_retires_active_generation_and_allows_exact_rehydration() {
+        let mut subsystem = start(1);
+        let handle = subsystem.runtime_handle();
+        let id = planet(12).planet_id;
+        handle.upsert_planet(planet(12)).unwrap();
+        let key = PageKey::new(0, [0; 3]);
+        handle
+            .request_page(id, key, TerrainRequestClass::Visible, 1)
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while handle.counters().in_flight + handle.counters().completed == 0
+            && Instant::now() < deadline
+        {
+            thread::yield_now();
+        }
+        assert!(handle.evict_page(id, key).unwrap());
+        assert!(matches!(
+            handle.drain_events(1).as_slice(),
+            [TerrainRuntimeEvent::EvictPage { page_key, .. }] if *page_key == key
+        ));
+        handle.pump(8);
+        assert!(handle.page_snapshot(id, key).is_none());
+        assert_eq!(handle.counters().outstanding, 0);
+
+        handle
+            .request_page(id, key, TerrainRequestClass::Visible, 2)
+            .unwrap();
+        let events = wait_for_events(&handle, 1);
+        let page_id = events.iter().find_map(|event| match event {
+            TerrainRuntimeEvent::PageReady { record, .. } => Some(record.page_id),
+            _ => None,
+        });
+        assert_eq!(
+            page_id,
+            handle.page_snapshot(id, key).map(|page| page.page_id())
+        );
+        assert_eq!(handle.counters().evicted, 1);
         subsystem.shutdown().unwrap();
     }
 

--- a/crates/subsystems/pulsar_terrain/src/streaming.rs
+++ b/crates/subsystems/pulsar_terrain/src/streaming.rs
@@ -212,6 +212,16 @@ pub struct PageDemand {
 }
 
 impl PageDemand {
+    #[cfg(test)]
+    pub(crate) const fn for_test(page_key: PageKey, request_class: TerrainRequestClass) -> Self {
+        Self {
+            page_key,
+            request_class,
+            projected_error_px: 0.0,
+            distance_m: 0.0,
+        }
+    }
+
     pub const fn page_key(self) -> PageKey {
         self.page_key
     }
@@ -253,6 +263,19 @@ pub struct TerrainStreamingPlan {
 }
 
 impl TerrainStreamingPlan {
+    #[cfg(test)]
+    pub(crate) fn for_test(planet_id: PlanetId, demands: Vec<PageDemand>) -> Self {
+        Self {
+            planet_id,
+            counters: TerrainStreamingCounters {
+                page_high_water: demands.len(),
+                ..TerrainStreamingCounters::default()
+            },
+            demands,
+            limits: Vec::new(),
+        }
+    }
+
     pub const fn planet_id(&self) -> PlanetId {
         self.planet_id
     }

--- a/docs/planetary-voxel-terrain.md
+++ b/docs/planetary-voxel-terrain.md
@@ -127,6 +127,17 @@ This avoids an engine-wide conversion of existing scene components, Helio camera
 - GPU data uses a few large suballocated buffers. Never allocate one wgpu buffer per terrain page.
 - Coarse pages use conservative filtering so thin solid features do not disappear or flip topology unpredictably.
 
+Successive complete demand plans use a bounded two-set handoff. The currently
+committed visible/prefetch set remains resident while its replacement is
+materialized. The handoff commits, and obsolete pages become evictable, only
+after every replacement page is CPU-ready. The union of both sets has its own
+explicit transition-page budget; a plan that cannot fit is rejected without
+mutating the committed set. A newer camera plan cancels uncommitted obsolete
+work, and page-generation retirement prevents a late result from republishing
+an evicted page. Dense CPU pages may then be dropped while their compacted
+content hash and hierarchy record remain authoritative; rehydration must
+reproduce that hash from the deterministic generator and ordered edit prefix.
+
 The planet seen from orbit is coarse voxel geometry from the same field, not a heightmap proxy. Atmosphere and oceans may be separate render systems, but they do not replace terrain geometry.
 
 ## Rendering decision


### PR DESCRIPTION
Closes #342.

## Summary
- add a bounded residency session that reconciles complete deterministic demand plans into the asynchronous terrain runtime
- retain the committed page set until every replacement page is CPU-ready, then atomically hand off and evict obsolete pages
- cancel superseded queued/running work while keeping completed results capacity-accounted until the runtime drains and generation-rejects them
- add explicit active-set and transition-set budgets, bounded per-call submissions, typed failures, and high-water counters
- make dense CPU pages disposable while retaining authoritative compacted hashes and hierarchy records
- require deterministic rehydration to reproduce the authoritative page hash, including edits added while the page was absent

## Dependency
Stacked on planet planner PR #339, which is stacked on shared-engine recovery PR #341. Retarget to main in that order after the maintainer merges #341.

## Validation
- cargo test -p pulsar_terrain --no-fail-fast — 58 unit tests and 6 contract tests passed
- cargo clippy -p pulsar_terrain --all-targets --no-deps -- -D warnings
- cargo check -p engine_backend -p pulsar_rendering -p pulsar_game -p ui_level_editor — all passed on the post-SceneDB stacked tree
- repeated 32-teleport stress fixture keeps one stable page, a two-page transition high-water mark, and no resident accumulation
- stale completion, exact rehydration, edit-while-absent, steady-state, supersession, and transition-budget tests passed
- git diff --check

## Scope boundary
Planetary subsystem only. This completes CPU demand reconciliation and dense-page residency handoff; GPU upload/mesh readiness still needs its own later state transition before milestone 4 can be called complete.