### PR TITLE
fix(pulsar_game): finish the wgpu 30 surface migration — unbreak main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9103,6 +9103,7 @@ dependencies = [
  "engine_state",
  "glam 0.33.2",
  "helio 0.18.0",
+ "helio-default-graphs",
  "pbgc",
  "pollster 1.0.1",
  "profiling 0.1.0",

--- a/crates/core/pulsar_game/Cargo.toml
+++ b/crates/core/pulsar_game/Cargo.toml
@@ -27,6 +27,7 @@ pulsar_reflection = { workspace = true }
 
 # Windowed rendering (Helio + winit + wgpu)
 helio   = { workspace = true }
+helio-default-graphs = { workspace = true }
 winit   = { workspace = true }
 wgpu    = { workspace = true }
 glam    = { workspace = true }

--- a/crates/core/pulsar_game/src/tests.rs
+++ b/crates/core/pulsar_game/src/tests.rs
@@ -101,7 +101,13 @@ mod actors {
         fn begin_play(&mut self, _e: Entity, _w: &mut World) {
             self.0.lock().unwrap().push("begin");
         }
-        fn tick(&mut self, _e: Entity, _w: &mut World, _t: GameTime) {
+        // NOTE: `Actor::tick` (from `pulsar_scenedb`) requires
+        // `pulsar_scenedb::GameTime`, not the `GameTime` re-exported by this
+        // crate's prelude (which is `pulsar_core::GameTime`). The two are
+        // structurally identical but nominally distinct types — a leftover
+        // of the SceneDB extraction. Using the fully-qualified path here
+        // rather than the prelude import.
+        fn tick(&mut self, _e: Entity, _w: &mut World, _t: pulsar_scenedb::GameTime) {
             self.0.lock().unwrap().push("tick");
         }
         fn end_play(&mut self, _e: Entity, _w: &mut World) {
@@ -149,7 +155,10 @@ mod schedule_tests {
             o2.lock().unwrap().push(2);
         });
 
-        let time = GameTime {
+        // `Schedule::run` (from `pulsar_scenedb`) requires
+        // `pulsar_scenedb::GameTime`, not the prelude's `pulsar_core::GameTime`
+        // — see note in the `actors` test module above.
+        let time = pulsar_scenedb::GameTime {
             elapsed: std::time::Duration::ZERO,
             delta: std::time::Duration::from_millis(16),
             tick: 0,

--- a/crates/core/pulsar_game/src/tick.rs
+++ b/crates/core/pulsar_game/src/tick.rs
@@ -82,8 +82,20 @@ impl TickLoop {
         };
 
         profiling::profile_scope!("TickLoop::tick");
-        self.schedule.run(&mut self.world, time);
-        self.actors.tick_all(&mut self.world, time);
+        // `pulsar_core::GameTime` and `pulsar_scenedb::GameTime` are two
+        // independent, structurally-identical types — a byproduct of the
+        // SceneDB extraction (pulsar_scenedb now lives in its own repo and
+        // carries its own copy of `GameTime` rather than depending on
+        // pulsar_core). This is a type-identity artifact, not a wgpu 30
+        // change; converting at this single call site is the minimal fix
+        // that avoids touching either crate's source.
+        let scenedb_time = pulsar_scenedb::GameTime {
+            elapsed: time.elapsed,
+            delta: time.delta,
+            tick: time.tick,
+        };
+        self.schedule.run(&mut self.world, scenedb_time);
+        self.actors.tick_all(&mut self.world, scenedb_time);
 
         // Drive runtime blueprint lifecycle + tick events after ECS + actor
         // updates. `begin_play` for newly-registered instances is deferred to

--- a/crates/core/pulsar_game/src/windowed_app.rs
+++ b/crates/core/pulsar_game/src/windowed_app.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use winit::{
@@ -18,7 +18,10 @@ use winit::{
     window::{CursorGrabMode, Window, WindowId},
 };
 
-use helio::{required_wgpu_features, required_wgpu_limits, Camera, Renderer, RendererConfig};
+use helio::{
+    required_wgpu_features, required_wgpu_limits, Camera, DebugDrawState, Renderer,
+    RendererConfig, Scene,
+};
 
 use crate::freecam::FreeCam;
 use crate::window::{RenderCamera, WindowBridge, WindowCommand, WindowDescriptor, WindowHandle};
@@ -31,6 +34,8 @@ struct GameWindow {
     surface: wgpu::Surface<'static>,
     surface_config: wgpu::SurfaceConfiguration,
     device: Arc<wgpu::Device>,
+    /// wgpu 30 moved `SurfaceTexture::present()` to `Queue::present()`.
+    queue: Arc<wgpu::Queue>,
     renderer: Renderer,
     /// Built-in free-look camera — active when no ECS camera has been set.
     freecam: FreeCam,
@@ -69,13 +74,55 @@ impl GameWindow {
             alpha_mode: caps.alpha_modes[0],
             view_formats: vec![],
             desired_maximum_frame_latency: 2,
+            color_space: wgpu::SurfaceColorSpace::Auto,
         };
         surface.configure(&device, &surface_config);
+
+        // Build the Helio renderer. `pulsar_game` owns its device (unlike the
+        // editor's wgpui-hosted viewport, which shares GPUI's device via
+        // `Renderer::new_with_external_device`), so we use the plain `new`
+        // constructor and build the default render graph ourselves — mirrors
+        // `engine_backend::subsystems::render::helio_renderer`.
+        let render_config =
+            RendererConfig::new(surface_config.width, surface_config.height, surface_format);
+        let scene = Scene::new(device.clone(), queue.clone());
+        let debug_camera_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Pulsar Game Debug Camera Buffer"),
+            size: 64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let cull_stats_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Pulsar Game Cull Stats Buffer"),
+            size: 64,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let debug_state = Arc::new(Mutex::new(DebugDrawState::default()));
+        let graph = helio_default_graphs::build_default_graph_external(
+            &device,
+            &queue,
+            &scene,
+            render_config,
+            debug_state.clone(),
+            &debug_camera_buffer,
+            &cull_stats_buffer,
+            None,
+        );
 
         let mut renderer = Renderer::new(
             device.clone(),
             queue.clone(),
-            RendererConfig::new(surface_config.width, surface_config.height, surface_format),
+            surface_format,
+            surface_config.width,
+            surface_config.height,
+            render_config.render_scale,
+            render_config,
+            scene,
+            graph,
+            debug_state,
+            debug_camera_buffer,
+            cull_stats_buffer,
         );
         // Kill the default helio ambient ([0.05, 0.05, 0.08] @ 1.0).
         // All illumination comes from lights in the scene file — same as editor.
@@ -88,6 +135,7 @@ impl GameWindow {
             surface,
             surface_config,
             device,
+            queue,
             renderer,
             freecam: FreeCam::default(),
         }
@@ -105,11 +153,12 @@ impl GameWindow {
 
     fn acquire_after_surface_recovery(&self) -> Option<wgpu::SurfaceTexture> {
         match self.surface.get_current_texture() {
-            Ok(texture) => Some(texture),
-            Err(error) => {
+            wgpu::CurrentSurfaceTexture::Success(t)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(t) => Some(t),
+            other => {
                 tracing::warn!(
                     window = self.handle.id(),
-                    ?error,
+                    ?other,
                     "Skipping frame after surface recovery"
                 );
                 None
@@ -137,9 +186,17 @@ impl GameWindow {
             cam.far,
         );
 
+        // wgpu 30 replaced `Result<SurfaceTexture, SurfaceError>` with the
+        // `CurrentSurfaceTexture` enum (see wgpui's
+        // `platform/cross/renderer.rs` for the template this mirrors).
+        // `Suboptimal` is treated the same as `Success` — matching wgpui's
+        // choice — rather than forcing a reconfigure after every present;
+        // an actually-outdated surface will surface as `Outdated` on the
+        // next frame's acquire and get reconfigured then.
         let output = match self.surface.get_current_texture() {
-            Ok(texture) => texture,
-            Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => {
+            wgpu::CurrentSurfaceTexture::Success(t)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(t) => t,
+            wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
                 // The surface no longer matches its last known configuration.
                 // Reconfigure once and retry rather than dropping every later
                 // frame after a resize or compositor transition.
@@ -149,29 +206,28 @@ impl GameWindow {
                 };
                 texture
             }
-            Err(wgpu::SurfaceError::Timeout) => {
+            wgpu::CurrentSurfaceTexture::Timeout => {
                 tracing::warn!(
                     window = self.handle.id(),
                     "Skipping frame after surface acquisition timeout"
                 );
                 return;
             }
-            Err(wgpu::SurfaceError::OutOfMemory) => {
-                tracing::error!(
+            wgpu::CurrentSurfaceTexture::Occluded => {
+                tracing::warn!(
                     window = self.handle.id(),
-                    "Surface acquisition ran out of memory"
+                    "Skipping frame: window occluded"
                 );
                 return;
             }
-            Err(wgpu::SurfaceError::Other) => {
+            wgpu::CurrentSurfaceTexture::Validation => {
                 tracing::warn!(
                     window = self.handle.id(),
-                    "Skipping frame after surface error"
+                    "Skipping frame after surface validation error"
                 );
                 return;
             }
         };
-        let reconfigure_after_present = output.suboptimal;
         let view = output
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
@@ -180,11 +236,7 @@ impl GameWindow {
             tracing::error!(window = self.handle.id(), "Render error: {:?}", e);
         }
 
-        output.present();
-
-        if reconfigure_after_present {
-            self.surface.configure(&self.device, &self.surface_config);
-        }
+        self.queue.present(output);
     }
 }
 
@@ -204,7 +256,7 @@ impl GpuContext {
                 wgpu::InstanceDescriptor {
                     backends: wgpu::Backends::all(),
                     flags: wgpu::InstanceFlags::empty(),
-                    ..Default::default()
+                    ..wgpu::InstanceDescriptor::new_without_display_handle()
                 }
                 .with_display_handle(Box::new(display)),
             ),
@@ -224,6 +276,7 @@ impl GpuContext {
                 power_preference: wgpu::PowerPreference::HighPerformance,
                 compatible_surface: Some(surface),
                 force_fallback_adapter: false,
+                apply_limit_buckets: false,
             }))
             .expect("No suitable GPU adapter found");
 


### PR DESCRIPTION
## What & why

`main` does not currently compile: `pulsar_game` was left with unfinished wgpu-30 surface-API drift after the workspace migration (#337). `cargo check -p pulsar_game --lib` fails with 19 errors (`wgpu::SurfaceError` removed, `SurfaceConfiguration.color_space` now required, a changed constructor arity, type mismatches). Since `pulsar_game` owns one of the engine's two wgpu device roots, the game runtime is broken on `main`. This finishes the migration.

## Approach

Every fix **mirrors the already-merged, working migration in `crates/ui/wgpui`** (the other device root) — nothing invented:
- `SurfaceConfiguration` gains the required `color_space`.
- `wgpu::SurfaceError` → the `CurrentSurfaceTexture` enum (7 sites); adopted wgpui's choice of treating `Suboptimal` as success (no forced post-present reconfigure).
- `SurfaceTexture::present()` → `Queue::present()` (added a `queue` field to `GameWindow`).
- `InstanceDescriptor` lost `Default` → `new_without_display_handle().with_display_handle(..)`.
- `RequestAdapterOptions` gains `apply_limit_buckets: false`.

**One error was not wgpu drift:** `Renderer::new`'s "12 args but 3 supplied" is Helio's own API evolution — resolved by building the missing `Scene`/`RenderGraph`/buffers via `helio_default_graphs::build_default_graph_external`, following `engine_backend`'s existing call site.

**`GameTime`:** converted at the `tick.rs`/`tests.rs` call sites (`pulsar_core::GameTime` ↔ `pulsar_scenedb::GameTime` are structurally identical but nominally distinct after the SceneDB extraction). **Open question, deliberately not decided here:** `pulsar_game`'s prelude still re-exports `pulsar_core::GameTime`, so downstream `Actor` impls will hit the same wall — whether the prelude should re-export `pulsar_scenedb::GameTime` (i.e. where `Actor` should own time) is a design call for a separate change.

## Verification

- `cargo check -p pulsar_game --lib` → 0 errors.
- `cargo check --workspace` → **0 errors** (was 19).
- Nothing stubbed, `todo!()`'d, or `#[allow]`'d to force green.

## Scope

This is **only** the build fix. It does **not** touch the Helio submodule gitlink, the pinned SceneDB rev, or the `GameTime`/`Actor` ownership question — those are separate coordination decisions.

Pre-existing `--all-targets` failures in vendored submodule test/bench/example targets (`wgpui-component`'s `ui`, a `blueprint_editor` example, `gpui-ce` examples, `graphy` benches) are unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)