### PR TITLE
Materialize bounded coarse planetary terrain pages

### DIFF
--- a/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
+++ b/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
@@ -50,6 +50,33 @@ fn main() {
     let compacted = core.compact_page(PageKey::new(0, [0; 3])).unwrap();
     let edit_time = edit_started.elapsed();
 
+    let mut coarse_core = TerrainCore::new(
+        PlanetId([3; 16]),
+        24,
+        FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 63_710_000,
+            material: 1,
+        },
+    )
+    .unwrap();
+    coarse_core
+        .append_edit(EditOp {
+            sequence: 1,
+            stable_id: [2; 16],
+            shape: EditShape::Sphere {
+                center_cell: [0; 3],
+                radius_cells: 10,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        })
+        .unwrap();
+    let coarse_started = Instant::now();
+    coarse_core.compact_page(PageKey::new(12, [0; 3])).unwrap();
+    let coarse_time = coarse_started.elapsed();
+    let coarse_work = coarse_core.work_counters();
+
     let delete_started = Instant::now();
     core.set_root(NodeState::Air).unwrap();
     let delete_time = delete_started.elapsed();
@@ -134,7 +161,7 @@ fn main() {
     // A billion logical cells are represented by the root without allocation.
     let logical_dense_bytes = 1_000_000_000_u64 * 4;
     println!(
-        "terrain_core sparse_touches={TOUCHES} nodes={} sparse_ms={:.3} dense_sample_cells={} dense_sample_bytes={} dense_fill_ms={:.3} billion_dense_equivalent_bytes={logical_dense_bytes} edited_page_bytes={} resident_dense_bytes={} generated_cells={} edit_attachment_regions={} edit_attachment_refs={} edit_candidates_replayed={} edit_compact_ms={:.3} edit_radius_cells=[1,10,100,1000] edit_aabb_pages={edit_amplification:?} root_delete_us={:.3} orbit_plan_pages={} orbit_plan_nodes={} orbit_plan_p95_ms={:.3} orbit_plan_limits={:?} ground_plan_pages={} ground_plan_nodes={} ground_plan_p95_ms={:.3} ground_plan_limits={:?}",
+        "terrain_core sparse_touches={TOUCHES} nodes={} sparse_ms={:.3} dense_sample_cells={} dense_sample_bytes={} dense_fill_ms={:.3} billion_dense_equivalent_bytes={logical_dense_bytes} edited_page_bytes={} resident_dense_bytes={} generated_cells={} edit_attachment_regions={} edit_attachment_refs={} edit_candidates_replayed={} edit_compact_ms={:.3} coarse_lod=12 coarse_generated_cells={} coarse_edit_candidates={} coarse_compact_ms={:.3} edit_radius_cells=[1,10,100,1000] edit_aabb_pages={edit_amplification:?} root_delete_us={:.3} orbit_plan_pages={} orbit_plan_nodes={} orbit_plan_p95_ms={:.3} orbit_plan_limits={:?} ground_plan_pages={} ground_plan_nodes={} ground_plan_p95_ms={:.3} ground_plan_limits={:?}",
         sparse.node_count(),
         sparse_time.as_secs_f64() * 1_000.0,
         dense.len(),
@@ -147,6 +174,9 @@ fn main() {
         memory.edit_attachment_references,
         work.edit_candidates_replayed,
         edit_time.as_secs_f64() * 1_000.0,
+        coarse_work.cells_generated,
+        coarse_work.edit_candidates_replayed,
+        coarse_time.as_secs_f64() * 1_000.0,
         delete_time.as_secs_f64() * 1_000_000.0,
         latest_plan.demands().len(),
         latest_plan.counters().traversed_nodes,

--- a/crates/subsystems/pulsar_terrain/src/core.rs
+++ b/crates/subsystems/pulsar_terrain/src/core.rs
@@ -294,8 +294,8 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
         Ok(PageBuildCommitOutcome::Committed(record))
     }
 
-    /// Fold the current ordered edit prefix into one content-addressed LOD0
-    /// page and publish that page into the canonical hierarchy.
+    /// Fold the current ordered edit prefix into one content-addressed page at
+    /// its requested LOD and publish it into the canonical hierarchy.
     pub fn compact_page(&mut self, key: PageKey) -> Result<CompactedPageRecord, TerrainCoreError>
     where
         G: Clone,
@@ -672,5 +672,33 @@ mod tests {
         assert_eq!(updated.compacted_through_sequence, 1);
         assert_eq!(core.work_counters().pages_compacted, 2);
         assert_eq!(core.work_counters().edit_candidates_replayed, 1);
+    }
+
+    #[test]
+    fn coarse_compaction_replays_edits_attached_to_fine_descendants() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 10_000,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([9; 16]), 12, generator).unwrap();
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [1; 16],
+            shape: EditShape::Sphere {
+                center_cell: [16; 3],
+                radius_cells: 1,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        })
+        .unwrap();
+
+        let key = PageKey::new(2, [0; 3]);
+        core.compact_page(key).unwrap();
+        let edited_sample = core.page(key).unwrap().get([4; 3]).unwrap();
+        assert!(!edited_sample.is_solid());
+        assert_eq!(core.work_counters().edit_candidates_replayed, 1);
+        assert_eq!(core.memory_counters().resident_pages, 1);
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/edit.rs
+++ b/crates/subsystems/pulsar_terrain/src/edit.rs
@@ -1,5 +1,5 @@
 use crate::{CellWord, ContentHash, MaterialId, PageKey};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
 
 const EDIT_LOG_MAGIC: &[u8; 8] = b"PTEDIT01";
@@ -161,14 +161,19 @@ enum EditAttachment {
 /// Derived sparse spatial index for the canonical edit log.
 ///
 /// Every edit contributes exactly one reference, either at the root or at its
-/// smallest covering hierarchy region. Page replay walks only the page's
-/// ancestor chain, so work is proportional to relevant candidates rather than
-/// the total logical volume or the total global edit count.
+/// smallest covering hierarchy region. Fine-page replay walks its ancestor
+/// chain. Coarse-page replay additionally follows occupancy-only hierarchy
+/// branches to relevant descendant attachments, so it sees every edit inside
+/// its volume without scanning the total logical volume or global edit log.
 #[derive(Clone, Debug)]
 pub(crate) struct EditIndex {
     root_lod: u8,
     root: Vec<usize>,
     regions: BTreeMap<PageKey, Vec<usize>>,
+    /// Hierarchy nodes that contain one or more region attachments. Edit
+    /// payloads remain stored exactly once in `regions`; these occupancy marks
+    /// let a coarse-page query descend only into relevant branches.
+    occupied_subtrees: BTreeSet<PageKey>,
 }
 
 impl EditIndex {
@@ -177,6 +182,7 @@ impl EditIndex {
             root_lod,
             root: Vec::new(),
             regions: BTreeMap::new(),
+            occupied_subtrees: BTreeSet::new(),
         }
     }
 
@@ -185,6 +191,11 @@ impl EditIndex {
             EditAttachment::Root => self.root.push(operation_index),
             EditAttachment::Region(key) => {
                 self.regions.entry(key).or_default().push(operation_index);
+                let mut ancestor = Some(key);
+                while let Some(node) = ancestor.filter(|node| node.lod < self.root_lod) {
+                    self.occupied_subtrees.insert(node);
+                    ancestor = node.parent();
+                }
             }
         }
     }
@@ -203,12 +214,50 @@ impl EditIndex {
             }
             ancestor = key.parent();
         }
+        self.collect_descendant_indices(key, &mut indices);
         indices.sort_unstable();
+        indices.dedup();
         indices
             .into_iter()
             .filter_map(|index| log.operations().get(index).copied())
             .filter(|operation| operation.sequence > after_sequence)
             .collect()
+    }
+
+    fn collect_descendant_indices(&self, parent: PageKey, indices: &mut Vec<usize>) {
+        let Some(child_lod) = parent.lod.checked_sub(1) else {
+            return;
+        };
+        for z in 0..2_i64 {
+            for y in 0..2_i64 {
+                for x in 0..2_i64 {
+                    let offsets = [x, y, z];
+                    let mut page_xyz = [0_i64; 3];
+                    let mut valid = true;
+                    for axis in 0..3 {
+                        let Some(coordinate) = parent.page_xyz[axis]
+                            .checked_mul(2)
+                            .and_then(|coordinate| coordinate.checked_add(offsets[axis]))
+                        else {
+                            valid = false;
+                            break;
+                        };
+                        page_xyz[axis] = coordinate;
+                    }
+                    if !valid {
+                        continue;
+                    }
+                    let child = PageKey::new(child_lod, page_xyz);
+                    if !self.occupied_subtrees.contains(&child) {
+                        continue;
+                    }
+                    if let Some(attached) = self.regions.get(&child) {
+                        indices.extend_from_slice(attached);
+                    }
+                    self.collect_descendant_indices(child, indices);
+                }
+            }
+        }
     }
 
     pub(crate) fn region_count(&self) -> usize {
@@ -575,5 +624,43 @@ mod tests {
         );
         assert_eq!(index.region_count(), 3);
         assert_eq!(index.reference_count(), operations.len());
+    }
+
+    #[test]
+    fn coarse_page_queries_descend_only_into_occupied_edit_branches() {
+        let inside = EditOp {
+            sequence: 1,
+            stable_id: [1; 16],
+            shape: EditShape::Sphere {
+                center_cell: [3_208, 3_208, 3_208],
+                radius_cells: 1,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        };
+        let outside = EditOp {
+            sequence: 2,
+            stable_id: [2; 16],
+            shape: EditShape::Sphere {
+                center_cell: [6_400, 3_208, 3_208],
+                radius_cells: 1,
+            },
+            mode: EditMode::Union,
+            material: 5,
+        };
+        let mut log = EditLog::default();
+        let mut index = EditIndex::new(12);
+        for operation in [inside, outside] {
+            let operation_index = log.operations().len();
+            log.push(operation).unwrap();
+            index.insert(operation_index, operation);
+        }
+
+        let first_region = index.operations_for_page(&log, PageKey::new(7, [0, 0, 0]), 0);
+        assert_eq!(first_region, vec![inside]);
+        let second_region = index.operations_for_page(&log, PageKey::new(7, [1, 0, 0]), 0);
+        assert_eq!(second_region, vec![outside]);
+        assert_eq!(index.reference_count(), 2);
+        assert!(index.occupied_subtrees.len() <= 2 * 12);
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/page.rs
+++ b/crates/subsystems/pulsar_terrain/src/page.rs
@@ -65,17 +65,20 @@ impl VoxelPage {
         generator: &dyn DeterministicGenerator,
         operations: &[EditOp],
     ) -> Result<Self, PageCodecError> {
-        if key.lod != 0 {
+        if key.lod > 57 {
             return Err(PageCodecError::UnsupportedLod(key.lod));
         }
         let origin = key
             .lod0_cell_min()
             .ok_or(PageCodecError::CoordinateOverflow)?;
+        let scale = 1_i64
+            .checked_shl(u32::from(key.lod))
+            .ok_or(PageCodecError::CoordinateOverflow)?;
         let mut cells = Vec::with_capacity(CELL_COUNT);
         for z in 0..PAGE_EDGE as i64 {
             for y in 0..PAGE_EDGE as i64 {
                 for x in 0..PAGE_EDGE as i64 {
-                    let coordinate = [origin[0] + x, origin[1] + y, origin[2] + z];
+                    let coordinate = sample_coordinate(origin, scale, [x, y, z])?;
                     let mut cell = generator.sample_cell(coordinate);
                     for operation in operations {
                         let (min, max) = operation.shape.bounds();
@@ -99,17 +102,20 @@ impl VoxelPage {
         key: PageKey,
         operations: &[EditOp],
     ) -> Result<Self, PageCodecError> {
-        if key.lod != 0 {
+        if key.lod > 57 {
             return Err(PageCodecError::UnsupportedLod(key.lod));
         }
         let origin = key
             .lod0_cell_min()
             .ok_or(PageCodecError::CoordinateOverflow)?;
+        let scale = 1_i64
+            .checked_shl(u32::from(key.lod))
+            .ok_or(PageCodecError::CoordinateOverflow)?;
         let mut cells = Vec::with_capacity(CELL_COUNT);
         for z in 0..PAGE_EDGE as i64 {
             for y in 0..PAGE_EDGE as i64 {
                 for x in 0..PAGE_EDGE as i64 {
-                    let coordinate = [origin[0] + x, origin[1] + y, origin[2] + z];
+                    let coordinate = sample_coordinate(origin, scale, [x, y, z])?;
                     let mut cell = self.get([x as usize, y as usize, z as usize]).unwrap();
                     for operation in operations {
                         let (min, max) = operation.shape.bounds();
@@ -261,6 +267,21 @@ impl VoxelPage {
     }
 }
 
+fn sample_coordinate(
+    origin: [i64; 3],
+    scale: i64,
+    local: [i64; 3],
+) -> Result<[i64; 3], PageCodecError> {
+    let mut coordinate = [0_i64; 3];
+    for axis in 0..3 {
+        coordinate[axis] = local[axis]
+            .checked_mul(scale)
+            .and_then(|offset| origin[axis].checked_add(offset))
+            .ok_or(PageCodecError::CoordinateOverflow)?;
+    }
+    Ok(coordinate)
+}
+
 fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, PageCodecError> {
     let value = bytes
         .get(offset..offset + 4)
@@ -280,7 +301,7 @@ pub enum PageCodecError {
     TruncatedOrTrailing,
     #[error("terrain page uses a non-canonical run encoding")]
     NonCanonical,
-    #[error("materialized pages currently require LOD0, received LOD{0}")]
+    #[error("terrain page LOD{0} exceeds the supported materialized range")]
     UnsupportedLod(u8),
     #[error("terrain page coordinate overflow")]
     CoordinateOverflow,
@@ -407,13 +428,71 @@ mod tests {
             mode: EditMode::Union,
             material: 9,
         };
-        let key = PageKey::new(0, [0; 3]);
         let prefix = EditLog::from_scheduled(vec![first]).unwrap();
         let complete = EditLog::from_scheduled(vec![second, first]).unwrap();
-        let prefix_page = VoxelPage::generate(key, &generator, &prefix).unwrap();
-        let incremental = prefix_page.apply_edit_tail(key, &[second]).unwrap();
-        let replayed = VoxelPage::generate(key, &generator, &complete).unwrap();
-        assert_eq!(incremental, replayed);
-        assert_eq!(incremental.page_id(), replayed.page_id());
+        for key in [PageKey::new(0, [0; 3]), PageKey::new(4, [0; 3])] {
+            let prefix_page = VoxelPage::generate(key, &generator, &prefix).unwrap();
+            let incremental = prefix_page.apply_edit_tail(key, &[second]).unwrap();
+            let replayed = VoxelPage::generate(key, &generator, &complete).unwrap();
+            assert_eq!(incremental, replayed, "LOD{}", key.lod);
+            assert_eq!(incremental.page_id(), replayed.page_id(), "LOD{}", key.lod);
+        }
+    }
+
+    #[test]
+    fn coarse_pages_sample_the_same_canonical_field_in_fixed_work() {
+        let generator = FixedSphereGenerator {
+            center_cell: [-40, 17, 9],
+            radius_cells: 180,
+            material: 6,
+        };
+        let edit = EditOp {
+            sequence: 1,
+            stable_id: [3; 16],
+            shape: EditShape::Sphere {
+                center_cell: [-32, 32, 0],
+                radius_cells: 24,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        };
+        let edits = EditLog::from_scheduled(vec![edit]).unwrap();
+        let key = PageKey::new(3, [-1, 0, -1]);
+        let page = VoxelPage::generate(key, &generator, &edits).unwrap();
+        assert_eq!(page.cells().len(), CELL_COUNT);
+        let origin = key.lod0_cell_min().unwrap();
+        let scale = 1_i64 << key.lod;
+        for local in [[0, 0, 0], [1, 7, 13], [16, 16, 16], [31, 31, 31]] {
+            let coordinate = std::array::from_fn(|axis| {
+                origin[axis] + i64::try_from(local[axis]).unwrap() * scale
+            });
+            let expected = edits.apply(coordinate, generator.sample_cell(coordinate));
+            assert_eq!(page.get(local), Some(expected));
+        }
+    }
+
+    #[test]
+    fn coincident_samples_match_across_lods_and_negative_page_boundaries() {
+        let generator = FixedSphereGenerator {
+            center_cell: [-20, 10, 5],
+            radius_cells: 90,
+            material: 4,
+        };
+        let edits = EditLog::default();
+        let coarse_key = PageKey::new(1, [-1, 0, 0]);
+        let fine_key = PageKey::new(0, [-2, 0, 0]);
+        let coarse = VoxelPage::generate(coarse_key, &generator, &edits).unwrap();
+        let fine = VoxelPage::generate(fine_key, &generator, &edits).unwrap();
+        for z in 0..16 {
+            for y in 0..16 {
+                for x in 0..16 {
+                    assert_eq!(
+                        coarse.get([x, y, z]),
+                        fine.get([x * 2, y * 2, z * 2]),
+                        "coincident sample at {x},{y},{z}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/residency.rs
+++ b/crates/subsystems/pulsar_terrain/src/residency.rs
@@ -323,7 +323,10 @@ fn is_backpressure(error: &TerrainRuntimeError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{PageDemand, PlanetDefinition, TerrainRuntimeConfig, TerrainSubsystem, CELL_COUNT};
+    use crate::{
+        PageDemand, PlanetDefinition, PlanetPosition, PlanetView, TerrainRuntimeConfig,
+        TerrainStreamingConfig, TerrainStreamingPlanner, TerrainSubsystem, CELL_COUNT,
+    };
     use engine_subsystems::{Subsystem, SubsystemContext};
     use std::thread;
     use std::time::{Duration, Instant};
@@ -565,6 +568,80 @@ mod tests {
         assert_eq!(counters.active_page_high_water, 1);
         assert_eq!(counters.transition_page_high_water, 2);
         assert_eq!(handle.counters().resident_page_high_water, 2);
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
+    fn mixed_lod_plan_materializes_and_commits_end_to_end() {
+        let max_pages = 64;
+        let mut subsystem = TerrainSubsystem::new(TerrainRuntimeConfig {
+            worker_count: 4,
+            max_planets: 1,
+            max_component_sources: 1,
+            request_capacity: max_pages,
+            critical_request_reserve: 4,
+            completion_capacity: max_pages,
+            event_capacity: max_pages * 2,
+            max_resident_pages: max_pages,
+            max_resident_dense_bytes: max_pages * DENSE_PAGE_BYTES,
+            max_completions_per_frame: max_pages,
+        })
+        .unwrap();
+        subsystem.init(&SubsystemContext::new()).unwrap();
+        let handle = subsystem.runtime_handle();
+        let mut planet = definition();
+        planet.radius_cells = 1_000;
+        planet.root_lod = 6;
+        planet.max_resident_pages = max_pages;
+        handle.upsert_planet(planet.clone()).unwrap();
+        let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
+            interaction_radius_m: 8.0,
+            target_projected_error_px: 2.0,
+            prediction_seconds: 0.0,
+            max_pages,
+            max_traversal_nodes: 4_096,
+        })
+        .unwrap();
+        let view = PlanetView::new(
+            PlanetPosition::from_lod0_cell([1_000, 0, 0]),
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            60_f64.to_radians(),
+            [1280, 720],
+            0.1,
+            20_000_000.0,
+            [0.0; 3],
+        )
+        .unwrap();
+        let plan = planner.plan_fixed_sphere(&planet, view).unwrap();
+        assert!(plan
+            .demands()
+            .iter()
+            .any(|demand| demand.page_key().lod == 0));
+        assert!(plan
+            .demands()
+            .iter()
+            .any(|demand| demand.page_key().lod > 0));
+        assert!(plan.is_face_balanced());
+        assert!(plan.demands().len() <= max_pages);
+
+        let mut session = TerrainResidencySession::new(
+            planet.planet_id,
+            TerrainResidencyConfig {
+                max_active_pages: max_pages,
+                max_transition_pages: max_pages * 2,
+                max_requests_per_reconcile: max_pages,
+                ..TerrainResidencyConfig::default()
+            },
+        )
+        .unwrap();
+        let report = settle(&mut session, &handle, &plan);
+        assert!(report.handoff_committed);
+        assert_eq!(report.committed_pages, plan.demands().len());
+        assert_eq!(
+            handle.resident_page_keys(planet.planet_id).unwrap().len(),
+            plan.demands().len()
+        );
         subsystem.shutdown().unwrap();
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/runtime.rs
+++ b/crates/subsystems/pulsar_terrain/src/runtime.rs
@@ -1682,6 +1682,61 @@ mod tests {
     }
 
     #[test]
+    fn coarse_page_publishes_and_rehydrates_with_a_new_generation() {
+        let mut subsystem = start(1);
+        let handle = subsystem.runtime_handle();
+        let id = planet(13).planet_id;
+        handle.upsert_planet(planet(13)).unwrap();
+        let key = PageKey::new(5, [-1, 0, 0]);
+        handle
+            .request_page(id, key, TerrainRequestClass::Visible, 1)
+            .unwrap();
+        let first = wait_for_events(&handle, 1)
+            .into_iter()
+            .find_map(|event| match event {
+                TerrainRuntimeEvent::PageReady {
+                    page_key,
+                    page_generation,
+                    record,
+                    ..
+                } if page_key == key => Some((page_generation, record.page_id)),
+                _ => None,
+            })
+            .expect("coarse page must publish");
+        assert_eq!(first.0, 1);
+        assert_eq!(handle.page_snapshot(id, key).unwrap().page_id(), first.1);
+
+        assert!(handle.evict_page(id, key).unwrap());
+        assert!(matches!(
+            handle.drain_events(1).as_slice(),
+            [TerrainRuntimeEvent::EvictPage {
+                page_key,
+                retired_page_generation: 1,
+                ..
+            }] if *page_key == key
+        ));
+        handle
+            .request_page(id, key, TerrainRequestClass::Visible, 2)
+            .unwrap();
+        let second = wait_for_events(&handle, 1)
+            .into_iter()
+            .find_map(|event| match event {
+                TerrainRuntimeEvent::PageReady {
+                    page_key,
+                    page_generation,
+                    record,
+                    ..
+                } if page_key == key => Some((page_generation, record.page_id)),
+                _ => None,
+            })
+            .expect("coarse page must rehydrate");
+        assert_eq!(second.0, 2);
+        assert_eq!(second.1, first.1);
+        assert_eq!(handle.page_snapshot(id, key).unwrap().page_id(), first.1);
+        subsystem.shutdown().unwrap();
+    }
+
+    #[test]
     fn signed_coordinates_and_planets_remain_distinct_across_worker_counts() {
         fn run(worker_count: usize) -> BTreeMap<(PlanetId, PageKey), crate::PageId> {
             let mut subsystem = start(worker_count);


### PR DESCRIPTION
Closes #344.

## What changed

- materialize coarse terrain pages at LOD 0 through 57 with the same fixed 32^3 work per page
- sample every LOD from canonical LOD0 coordinates with checked arithmetic, including negative page boundaries
- extend sparse edit lookup so coarse pages see edits attached to occupied fine descendants without scanning the global edit log
- support deterministic coarse-page edit-tail replay, eviction, and rehydration
- add a real mixed-LOD planner-to-runtime-to-residency integration test
- report coarse-page generated-cell and edit-candidate work in the terrain benchmark

## Why

The streaming planner already emitted mixed-LOD page demands, but page generation and edit-tail replay rejected every LOD above zero. Coarse pages also could not see edits indexed beneath them, so orbital/coarse plans could not become correct committed resident sets.

## Scope

This is planet-system-only work inside `pulsar_terrain`. It does not change Helio, legacy voxel demos, renderer APIs, or other engine crates.

## Validation

- `cargo test -p pulsar_terrain --no-fail-fast` — 64 unit tests and 6 contract tests passed
- `cargo clippy -p pulsar_terrain --all-targets --no-deps -- -D warnings` — passed
- `cargo check -p engine_backend -p pulsar_rendering -p pulsar_game -p ui_level_editor` — passed on current `main` after #345
- `git diff --check` — passed

Workspace dependency warnings are pre-existing and outside `pulsar_terrain`.
