### PR TITLE
Fix native bundle cache and dependency boundary

### DIFF
--- a/crates/core/engine_fs/Cargo.toml
+++ b/crates/core/engine_fs/Cargo.toml
@@ -3,30 +3,50 @@ name = "engine_fs"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["editor", "remote", "p2p"]
+editor = [
+    "dep:ui_types_common",
+    "dep:pulsar_reflection",
+    "dep:uuid",
+    "dep:dashmap",
+    "dep:plugin_manager",
+    "dep:plugin_editor_api",
+    "dep:serde_json",
+    "dep:notify",
+    "dep:walkdir",
+    "dep:profiling",
+    "dep:image",
+    "dep:tool_registry",
+    "dep:tool_registry_macros",
+]
+remote = ["dep:ureq", "dep:urlencoding", "dep:base64"]
+p2p = ["dep:futures", "dep:pulsar-multiplayer-core"]
+
 [dependencies]
-ui_types_common = { workspace = true }
-pulsar_reflection = { workspace = true }
-uuid = { workspace = true }
-dashmap = { workspace = true }
-plugin_manager = { workspace = true }
-plugin_editor_api = { workspace = true }
+ui_types_common = { workspace = true, optional = true }
+pulsar_reflection = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
+dashmap = { workspace = true, optional = true }
+plugin_manager = { workspace = true, optional = true }
+plugin_editor_api = { workspace = true, optional = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
-notify = { workspace = true }
-walkdir = { workspace = true }
-profiling = { workspace = true }
-image = { workspace = true }
+serde_json = { workspace = true, optional = true }
+notify = { workspace = true, optional = true }
+walkdir = { workspace = true, optional = true }
+profiling = { workspace = true, optional = true }
+image = { workspace = true, optional = true }
 parking_lot = { workspace = true }
-urlencoding = { workspace = true }
-ureq = { version = "3.0", features = ["json"] }
-base64 = { workspace = true }
-tool_registry = { workspace = true }
-tool_registry_macros = { workspace = true }
+urlencoding = { workspace = true, optional = true }
+ureq = { version = "3.0", features = ["json"], optional = true }
+base64 = { workspace = true, optional = true }
+tool_registry = { workspace = true, optional = true }
+tool_registry_macros = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync"] }
-futures = { workspace = true }
-pulsar-multiplayer-core = { path = "../pulsar-multiplayer-core" }
+futures = { workspace = true, optional = true }
+pulsar-multiplayer-core = { path = "../pulsar-multiplayer-core", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/core/engine_fs/src/lib.rs
+++ b/crates/core/engine_fs/src/lib.rs
@@ -23,40 +23,56 @@
 //! will automatically target the right backend.
 
 // Module declarations
+#[cfg(feature = "editor")]
 pub mod asset_index;
+#[cfg(feature = "editor")]
 mod engine_fs;
 pub mod events;
+#[cfg(feature = "editor")]
 pub mod operations;
 pub mod providers;
+#[cfg(feature = "editor")]
 mod scanner;
+#[cfg(feature = "editor")]
 pub mod templates;
+#[cfg(feature = "editor")]
 pub mod thumbnails;
+#[cfg(feature = "editor")]
 pub mod tooling;
+#[cfg(feature = "editor")]
 pub mod user_types;
 pub mod virtual_fs;
+#[cfg(feature = "editor")]
 pub mod watchers;
 
 // Re-export main types
+#[cfg(feature = "editor")]
 pub use asset_index::{AssetIndex, AssetInfo};
+#[cfg(feature = "editor")]
 pub use engine_fs::EngineFs;
+#[cfg(feature = "editor")]
 pub use user_types::{UserTypeInfo, UserTypeRegistry};
 
 // Re-export provider types
-pub use providers::{
-    FsEntry, FsMetadata, FsProvider, LocalFsProvider, ManifestEntry, RemoteConfig, RemoteFsProvider,
-};
+#[cfg(feature = "p2p")]
+pub use providers::P2pFsProvider;
+pub use providers::{FsEntry, FsMetadata, FsProvider, LocalFsProvider, ManifestEntry};
+#[cfg(feature = "remote")]
+pub use providers::{RemoteConfig, RemoteFsProvider};
 
 // Re-export operations
 pub use events::{emit, subscribe, FsChangeKind, FsEvent};
+#[cfg(feature = "editor")]
 pub use operations::AssetOperations;
 
 // Re-export template types
+#[cfg(feature = "editor")]
 pub use templates::{AssetCategory, AssetKind};
 
 // Re-export commonly used virtual_fs functions
 pub use virtual_fs::{cloud_join, is_cloud_path};
 
-#[cfg(test)]
+#[cfg(all(test, feature = "editor"))]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/core/engine_fs/src/providers/mod.rs
+++ b/crates/core/engine_fs/src/providers/mod.rs
@@ -4,12 +4,16 @@
 //! for both local disk and remote (HTTP-based) filesystems.
 
 mod local;
+#[cfg(feature = "p2p")]
 pub mod p2p;
 mod provider_trait;
+#[cfg(feature = "remote")]
 mod remote;
 
 // Re-export all public types
 pub use local::LocalFsProvider;
+#[cfg(feature = "p2p")]
 pub use p2p::P2pFsProvider;
 pub use provider_trait::{FsEntry, FsMetadata, FsProvider, ManifestEntry};
+#[cfg(feature = "remote")]
 pub use remote::{RemoteConfig, RemoteFsProvider};

--- a/crates/core/pulsar_std/Cargo.toml
+++ b/crates/core/pulsar_std/Cargo.toml
@@ -17,7 +17,7 @@ native = ["dep:rlua", "dep:linkme"]
 [dependencies]
 pulsar_macros = { workspace = true }
 pulsar_reflection = { workspace = true }
-engine_fs = { workspace = true }
+engine_fs = { path = "../engine_fs", default-features = false }
 linkme         = { workspace = true, optional = true }
 tracing        = { workspace = true }
 rand           = { workspace = true, features = [] }

--- a/crates/core/pulsar_std_bundle/build.rs
+++ b/crates/core/pulsar_std_bundle/build.rs
@@ -3,17 +3,25 @@
 /// Compiles `pulsar_std` as a native cdylib and embeds the bytes.
 /// Uses an isolated CARGO_TARGET_DIR so the subprocess never contends
 /// the parent cargo's file lock.
-use std::path::PathBuf;
+#[path = "src/build_cache.rs"]
+mod build_cache;
+
+use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
 
 fn main() {
     println!("cargo:rerun-if-changed=../pulsar_std/src");
     println!("cargo:rerun-if-changed=../pulsar_std/Cargo.toml");
+    println!("cargo:rerun-if-changed=../pulsar_macros/src");
+    println!("cargo:rerun-if-changed=../pulsar_macros/Cargo.toml");
+    println!("cargo:rerun-if-changed=../engine_fs/src");
+    println!("cargo:rerun-if-changed=../engine_fs/Cargo.toml");
+    println!("cargo:rerun-if-changed=../../../Cargo.lock");
     println!("cargo:rerun-if-env-changed=PULSAR_SKIP_NATIVE_BUILD");
+    println!("cargo:rerun-if-env-changed=PULSAR_STD_NATIVE_TARGET_DIR");
+    println!("cargo:rerun-if-env-changed=CARGO_TARGET_DIR");
+    println!("cargo:rerun-if-env-changed=RUSTFLAGS");
+    println!("cargo:rerun-if-env-changed=CARGO_ENCODED_RUSTFLAGS");
 
     let ext = std::env::consts::DLL_EXTENSION;
     let prefix = if cfg!(target_os = "windows") {
@@ -34,20 +42,27 @@ fn main() {
         return;
     }
 
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let pulsar_std_manifest = PathBuf::from(&manifest_dir)
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let workspace_root = manifest_dir
+        .ancestors()
+        .nth(3)
+        .expect("pulsar_std_bundle must live under crates/core")
+        .to_path_buf();
+    let pulsar_std_manifest = manifest_dir
         .parent()
         .unwrap()
         .join("pulsar_std")
         .join("Cargo.toml");
 
-    // Build into an isolated target dir outside the workspace target tree.
-    // This avoids file-lock contention with the parent cargo invocation.
-    let mut hasher = DefaultHasher::new();
-    out_dir.hash(&mut hasher);
-    let isolated_target =
-        std::env::temp_dir().join(format!("pulsar_std_cdylib_target_{}", hasher.finish()));
-    std::fs::create_dir_all(&isolated_target).ok();
+    // Use a stable target below the outer target root. It is isolated from the
+    // parent Cargo lock, but unlike the previous OUT_DIR hash it survives build
+    // script fingerprint changes and can reuse Cargo's dependency cache.
+    let native_target = build_cache::native_target_dir(
+        &workspace_root,
+        std::env::var_os("PULSAR_STD_NATIVE_TARGET_DIR"),
+        std::env::var_os("CARGO_TARGET_DIR"),
+    );
+    std::fs::create_dir_all(&native_target).expect("create native bundle target directory");
 
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
 
@@ -59,8 +74,9 @@ fn main() {
         "--features",
         "native",
         "--no-default-features",
+        "--locked",
     ])
-    .env("CARGO_TARGET_DIR", &isolated_target)
+    .env("CARGO_TARGET_DIR", &native_target)
     // Avoid inheriting Cargo's jobserver env from the parent build.
     // Child cargo gets its own scheduler and won't block waiting on parent tokens.
     .env_remove("CARGO_MAKEFLAGS")
@@ -68,15 +84,22 @@ fn main() {
     .env_remove("MFLAGS")
     .env_remove("NUM_JOBS");
 
-    let built_profile_dir = if profile == "release" {
+    let built_profile = if profile == "release" {
         cmd.arg("--release");
-        "release".to_string()
+        "release"
     } else if profile == "debug" {
-        "debug".to_string()
+        "debug"
     } else {
         cmd.args(["--profile", &profile]);
-        profile.clone()
+        &profile
     };
+
+    let target = std::env::var("TARGET").expect("Cargo must set TARGET for build scripts");
+    let host = std::env::var("HOST").expect("Cargo must set HOST for build scripts");
+    let cross_target = (target != host).then_some(target.as_str());
+    if let Some(target) = cross_target {
+        cmd.args(["--target", target]);
+    }
 
     let status = cmd.status().expect("failed to invoke cargo");
 
@@ -84,9 +107,8 @@ fn main() {
         panic!("pulsar_std native build failed");
     }
 
-    let built = isolated_target
-        .join(&built_profile_dir)
-        .join(format!("{}pulsar_std.{}", prefix, ext));
+    let built =
+        build_cache::native_artifact_path(&native_target, cross_target, built_profile, prefix, ext);
 
     if !built.exists() {
         panic!("Expected dylib at {} — not found", built.display());
@@ -96,7 +118,13 @@ fn main() {
     let bytes = std::fs::metadata(&dest).map(|m| m.len()).unwrap_or(0);
     println!("cargo:rustc-env=PULSAR_STD_LIB_PATH={}", dest.display());
     println!(
-        "cargo:warning=pulsar_std native lib: {} bytes ({})",
-        bytes, ext
+        "cargo:warning=pulsar_std native lib: {} bytes ({}) from {}",
+        bytes,
+        ext,
+        display_path(&native_target)
     );
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
 }

--- a/crates/core/pulsar_std_bundle/src/build_cache.rs
+++ b/crates/core/pulsar_std_bundle/src/build_cache.rs
@@ -1,0 +1,96 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+const CACHE_DIR: &str = "pulsar-std-native";
+
+pub(crate) fn native_target_dir(
+    workspace_root: &Path,
+    explicit_native_target: Option<OsString>,
+    cargo_target_dir: Option<OsString>,
+) -> PathBuf {
+    if let Some(path) = explicit_native_target {
+        return absolute_from(workspace_root, PathBuf::from(path));
+    }
+
+    let outer_target = cargo_target_dir
+        .map(PathBuf::from)
+        .map(|path| absolute_from(workspace_root, path))
+        .unwrap_or_else(|| workspace_root.join("target"));
+    outer_target.join(CACHE_DIR)
+}
+
+pub(crate) fn native_artifact_path(
+    target_dir: &Path,
+    cross_target: Option<&str>,
+    profile: &str,
+    prefix: &str,
+    extension: &str,
+) -> PathBuf {
+    let mut path = target_dir.to_path_buf();
+    if let Some(target) = cross_target {
+        path.push(target);
+    }
+    path.join(profile)
+        .join(format!("{prefix}pulsar_std.{extension}"))
+}
+
+fn absolute_from(workspace_root: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        workspace_root.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_cache_is_stable_below_the_workspace_target() {
+        let root = Path::new("workspace");
+        assert_eq!(
+            native_target_dir(root, None, None),
+            root.join("target").join(CACHE_DIR)
+        );
+    }
+
+    #[test]
+    fn configured_outer_target_gets_an_isolated_stable_child() {
+        let root = Path::new("workspace");
+        assert_eq!(
+            native_target_dir(root, None, Some(OsString::from("shared-target"))),
+            root.join("shared-target").join(CACHE_DIR)
+        );
+    }
+
+    #[test]
+    fn explicit_native_target_is_used_without_an_extra_suffix() {
+        let root = Path::new("workspace");
+        assert_eq!(
+            native_target_dir(
+                root,
+                Some(OsString::from("native-cache")),
+                Some(OsString::from("ignored")),
+            ),
+            root.join("native-cache")
+        );
+    }
+
+    #[test]
+    fn cross_compiled_artifact_includes_the_target_triple() {
+        assert_eq!(
+            native_artifact_path(
+                Path::new("cache"),
+                Some("aarch64-apple-darwin"),
+                "release",
+                "lib",
+                "dylib",
+            ),
+            Path::new("cache")
+                .join("aarch64-apple-darwin")
+                .join("release")
+                .join("libpulsar_std.dylib")
+        );
+    }
+}

--- a/crates/core/pulsar_std_bundle/src/lib.rs
+++ b/crates/core/pulsar_std_bundle/src/lib.rs
@@ -15,6 +15,9 @@
 /// ```
 pub const PULSAR_STD_LIB_BYTES: &[u8] = include_bytes!(env!("PULSAR_STD_LIB_PATH"));
 
+#[cfg(test)]
+mod build_cache;
+
 /// Return the expected SHA-256 digest of the embedded `pulsar_std` library.
 ///
 /// This is computed lazily from the embeded bytes and cached for the


### PR DESCRIPTION
Closes #362

## What changed
- reuse a stable isolated Cargo target for the nested `pulsar_std` native build instead of hashing Cargo's ephemeral `OUT_DIR`
- track the actual native bundle inputs and toolchain flags that invalidate the build
- support custom profiles and cross-target artifact paths
- split `engine_fs` into editor, remote, and p2p features while keeping the existing full feature set as the default
- build `pulsar_std` against only the local VFS core, avoiding GPUI/editor/plugin dependencies in the gameplay DLL
- add focused cache-path and artifact-path tests

## Measured result
- cold native bundle test: 9m40s
- identical warm rerun: 9.42s
- about 62x faster for the repeated native-bundle step
- output DLL unchanged in location/contract and 2,904,064 bytes in both runs

## Validation
- `cargo check -p engine_fs --no-default-features --offline`
- `cargo test -p pulsar_std_bundle build_cache --lib` (cold and warm; 4/4)
- `cargo check -p engine_fs --all-features`
- targeted rustfmt
- `git diff --check`

The full-feature check confirms editor/default consumers retain the existing engine filesystem surface. This is an engine/shared change and should be reviewed and merged by Tuafo.