### PR TITLE
perf(editor): skip unchanged scene synchronization

### DIFF
--- a/crates/core/engine_backend/src/scene/mod.rs
+++ b/crates/core/engine_backend/src/scene/mod.rs
@@ -39,8 +39,8 @@ use glam::{Mat4, Vec3};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -206,10 +206,12 @@ impl SceneEntry {
     }
 
     #[inline]
-    pub fn set_position(&self, v: [f32; 3]) {
-        self.position[0].store(v[0].to_bits(), Ordering::Relaxed);
-        self.position[1].store(v[1].to_bits(), Ordering::Relaxed);
-        self.position[2].store(v[2].to_bits(), Ordering::Relaxed);
+    pub fn set_position(&self, v: [f32; 3]) -> bool {
+        let bits = v.map(f32::to_bits);
+        let x = self.position[0].swap(bits[0], Ordering::Relaxed) != bits[0];
+        let y = self.position[1].swap(bits[1], Ordering::Relaxed) != bits[1];
+        let z = self.position[2].swap(bits[2], Ordering::Relaxed) != bits[2];
+        x || y || z
     }
 
     #[inline]
@@ -222,10 +224,12 @@ impl SceneEntry {
     }
 
     #[inline]
-    pub fn set_rotation(&self, v: [f32; 3]) {
-        self.rotation[0].store(v[0].to_bits(), Ordering::Relaxed);
-        self.rotation[1].store(v[1].to_bits(), Ordering::Relaxed);
-        self.rotation[2].store(v[2].to_bits(), Ordering::Relaxed);
+    pub fn set_rotation(&self, v: [f32; 3]) -> bool {
+        let bits = v.map(f32::to_bits);
+        let x = self.rotation[0].swap(bits[0], Ordering::Relaxed) != bits[0];
+        let y = self.rotation[1].swap(bits[1], Ordering::Relaxed) != bits[1];
+        let z = self.rotation[2].swap(bits[2], Ordering::Relaxed) != bits[2];
+        x || y || z
     }
 
     #[inline]
@@ -238,10 +242,12 @@ impl SceneEntry {
     }
 
     #[inline]
-    pub fn set_scale(&self, v: [f32; 3]) {
-        self.scale[0].store(v[0].to_bits(), Ordering::Relaxed);
-        self.scale[1].store(v[1].to_bits(), Ordering::Relaxed);
-        self.scale[2].store(v[2].to_bits(), Ordering::Relaxed);
+    pub fn set_scale(&self, v: [f32; 3]) -> bool {
+        let bits = v.map(f32::to_bits);
+        let x = self.scale[0].swap(bits[0], Ordering::Relaxed) != bits[0];
+        let y = self.scale[1].swap(bits[1], Ordering::Relaxed) != bits[1];
+        let z = self.scale[2].swap(bits[2], Ordering::Relaxed) != bits[2];
+        x || y || z
     }
 
     #[inline]
@@ -250,8 +256,8 @@ impl SceneEntry {
     }
 
     #[inline]
-    pub fn set_visible(&self, v: bool) {
-        self.visible.store(v, Ordering::Relaxed);
+    pub fn set_visible(&self, v: bool) -> bool {
+        self.visible.swap(v, Ordering::Relaxed) != v
     }
 
     #[inline]
@@ -260,8 +266,8 @@ impl SceneEntry {
     }
 
     #[inline]
-    pub fn set_locked(&self, v: bool) {
-        self.locked.store(v, Ordering::Relaxed);
+    pub fn set_locked(&self, v: bool) -> bool {
+        self.locked.swap(v, Ordering::Relaxed) != v
     }
 
     /// Build a world-space Mat4 from the current atomic transform.
@@ -346,6 +352,9 @@ struct SceneDbInner {
     children_map: RwLock<HashMap<String, Vec<ObjectId>>>,
     /// Auto-incrementing id counter.
     next_id: AtomicU64,
+    /// Monotonic generation for data consumed by the renderer. A release bump
+    /// publishes the preceding atomic/cold-data writes to the render thread.
+    render_revision: AtomicU64,
     /// Currently selected object id.
     selected: RwLock<Option<ObjectId>>,
     /// Gizmo state for the level editor
@@ -365,6 +374,7 @@ impl SceneDb {
                 objects: DashMap::new(),
                 children_map: RwLock::new(HashMap::new()),
                 next_id: AtomicU64::new(1),
+                render_revision: AtomicU64::new(1),
                 selected: RwLock::new(None),
                 gizmo_state: RwLock::new(GizmoState::default()),
             }),
@@ -415,6 +425,7 @@ impl SceneDb {
         self.inner
             .objects
             .insert(id.clone(), Arc::new(SceneEntry::new(&snap)));
+        self.bump_render_revision();
         id
     }
 
@@ -446,6 +457,7 @@ impl SceneDb {
             if sel.as_deref() == Some(id) {
                 *sel = None;
             }
+            self.bump_render_revision();
             true
         } else {
             false
@@ -493,6 +505,12 @@ impl SceneDb {
         self.collect_dfs(None)
     }
 
+    /// Current generation of scene data consumed by the renderer.
+    #[inline]
+    pub fn render_revision(&self) -> u64 {
+        self.inner.render_revision.load(Ordering::Acquire)
+    }
+
     /// Depth-first ordered snapshot of all objects (parents before children).
     /// Use this for serialisation so load order is always valid.
     fn collect_dfs(&self, parent_id: Option<&str>) -> Vec<SceneObjectSnapshot> {
@@ -519,7 +537,9 @@ impl SceneDb {
 
     pub fn set_position(&self, id: &str, v: [f32; 3]) -> bool {
         if let Some(e) = self.inner.objects.get(id) {
-            e.set_position(v);
+            if e.set_position(v) {
+                self.bump_render_revision();
+            }
             true
         } else {
             false
@@ -528,7 +548,9 @@ impl SceneDb {
 
     pub fn set_rotation(&self, id: &str, v: [f32; 3]) -> bool {
         if let Some(e) = self.inner.objects.get(id) {
-            e.set_rotation(v);
+            if e.set_rotation(v) {
+                self.bump_render_revision();
+            }
             true
         } else {
             false
@@ -537,7 +559,9 @@ impl SceneDb {
 
     pub fn set_scale(&self, id: &str, v: [f32; 3]) -> bool {
         if let Some(e) = self.inner.objects.get(id) {
-            e.set_scale(v);
+            if e.set_scale(v) {
+                self.bump_render_revision();
+            }
             true
         } else {
             false
@@ -546,7 +570,9 @@ impl SceneDb {
 
     pub fn set_visible(&self, id: &str, v: bool) -> bool {
         if let Some(e) = self.inner.objects.get(id) {
-            e.set_visible(v);
+            if e.set_visible(v) {
+                self.bump_render_revision();
+            }
             true
         } else {
             false
@@ -556,9 +582,13 @@ impl SceneDb {
     /// Update all three transform components at once from a snapshot.
     pub fn apply_transform(&self, id: &str, pos: [f32; 3], rot: [f32; 3], scale: [f32; 3]) -> bool {
         if let Some(e) = self.inner.objects.get(id) {
-            e.set_position(pos);
-            e.set_rotation(rot);
-            e.set_scale(scale);
+            let position_changed = e.set_position(pos);
+            let rotation_changed = e.set_rotation(rot);
+            let scale_changed = e.set_scale(scale);
+            let changed = position_changed || rotation_changed || scale_changed;
+            if changed {
+                self.bump_render_revision();
+            }
             true
         } else {
             false
@@ -599,6 +629,19 @@ impl SceneDb {
         } else {
             false
         }
+    }
+
+    /// Mutate cold component/property data while publishing the change to the
+    /// renderer. Editor integrations must use this instead of writing `meta`
+    /// directly, otherwise an unchanged render generation could hide the edit.
+    pub fn update_render_data(&self, id: &str, update: impl FnOnce(&mut SceneEntryMeta)) -> bool {
+        let Some(entry) = self.inner.objects.get(id) else {
+            return false;
+        };
+        update(&mut entry.meta.write());
+        drop(entry);
+        self.bump_render_revision();
+        true
     }
 
     /// Reparent an object. Prevents circular references.
@@ -652,6 +695,7 @@ impl SceneDb {
         };
         self.update_subtree_path(id, &new_path);
 
+        self.bump_render_revision();
         true
     }
 
@@ -671,6 +715,7 @@ impl SceneDb {
         self.inner.children_map.write().clear();
         *self.inner.selected.write() = None;
         *self.inner.gizmo_state.write() = GizmoState::default();
+        self.bump_render_revision();
     }
 
     // ── Gizmo API ─────────────────────────────────────────────────────────
@@ -746,10 +791,59 @@ impl SceneDb {
             }
         }
     }
+
+    #[inline]
+    fn bump_render_revision(&self) {
+        self.inner.render_revision.fetch_add(1, Ordering::Release);
+    }
 }
 
 impl Default for SceneDb {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn object() -> SceneObjectSnapshot {
+        SceneObjectSnapshot {
+            id: "object".into(),
+            name: "Object".into(),
+            scene_path: String::new(),
+            object_type: ObjectType::Empty,
+            position: [0.0; 3],
+            rotation: [0.0; 3],
+            scale: [1.0; 3],
+            parent: None,
+            children: Vec::new(),
+            visible: true,
+            locked: false,
+            props: HashMap::new(),
+            component_instances: None,
+        }
+    }
+
+    #[test]
+    fn render_revision_advances_only_when_render_data_changes() {
+        let db = SceneDb::new();
+        let initial = db.render_revision();
+        db.add_object(object(), None);
+        let added = db.render_revision();
+        assert!(added > initial);
+
+        assert!(db.set_position("object", [0.0; 3]));
+        assert_eq!(db.render_revision(), added);
+        assert!(db.set_position("object", [1.0, 0.0, 0.0]));
+        assert!(db.render_revision() > added);
+
+        let moved = db.render_revision();
+        assert!(db.update_render_data("object", |meta| {
+            meta.props
+                .insert("material".into(), serde_json::json!("rock"));
+        }));
+        assert!(db.render_revision() > moved);
     }
 }

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
@@ -3,7 +3,7 @@
 use glam::{EulerRot, Mat4, Quat, Vec3};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::Instant;
 
 use engine_fs::virtual_fs;
@@ -14,8 +14,8 @@ use helio::{
 };
 use pulsar_events::script_registry;
 use pulsar_reflection::{
-    apply_runtime_behavior_for_class, scene_id_to_tag, ComponentRuntimeContext, LiveKeySet,
-    RuntimeComponentOwner, Subsystems,
+    ComponentRuntimeContext, LiveKeySet, RuntimeComponentOwner, Subsystems,
+    apply_runtime_behavior_for_class, scene_id_to_tag,
 };
 use pulsar_rendering::subsystems::{MeshCache, SceneObjectCache};
 use pulsar_scene::{build_transform_parts, component_instances_from_props};
@@ -96,6 +96,9 @@ struct HelioInner {
     /// Tracks scene object instances keyed by tag for incremental
     /// update (avoid cascade-free on clear-all-insert-each-frame).
     object_cache: SceneObjectCache,
+    /// Last SceneDb generation fully applied to Helio. Unchanged scenes do not
+    /// need component deserialization, light recreation, or picker rebuilds.
+    last_scene_revision: u64,
 }
 
 impl HelioRenderer {
@@ -154,6 +157,8 @@ impl HelioRenderer {
         height: u32,
         format: wgpu::TextureFormat,
     ) {
+        profiling::profile_scope!("helio_frame");
+        let frame_start = Instant::now();
         let now = Instant::now();
         let dt = now.duration_since(self.last_frame).as_secs_f32().min(0.1);
         self.last_frame = now;
@@ -218,6 +223,7 @@ impl HelioRenderer {
                 scene_picker: ScenePicker::new(),
                 mesh_cache: MeshCache::new(),
                 object_cache: SceneObjectCache::new(),
+                last_scene_revision: 0,
             };
             self.populate_initial_scene(&mut inner);
             self.inner = Some(inner);
@@ -231,7 +237,10 @@ impl HelioRenderer {
             );
         }
 
-        self.apply_camera_input(dt);
+        {
+            profiling::profile_scope!("helio_camera_input");
+            self.apply_camera_input(dt);
+        }
 
         let inner = match self.inner.as_mut() {
             Some(i) => i,
@@ -239,6 +248,7 @@ impl HelioRenderer {
         };
 
         if self.viewport_size != (width, height) {
+            profiling::profile_scope!("helio_resize");
             inner.renderer.set_render_size(width, height);
             self.viewport_size = (width, height);
         }
@@ -253,41 +263,60 @@ impl HelioRenderer {
             }
         }
 
-        let t_sync = std::time::Instant::now();
-        Self::sync_scene(&self.scene_db, inner, &self.pending_errors);
-        let sync_ms = t_sync.elapsed().as_secs_f64() * 1000.0;
-        if sync_ms > 5.0 {
-            tracing::warn!("[SYNC_SCENE] took {:.2}ms — SLOW", sync_ms);
+        let mut sync_ms = 0.0;
+        let scene_revision = self.scene_db.render_revision();
+        if scene_revision != inner.last_scene_revision && !inner.editor_state.is_dragging() {
+            profiling::profile_scope!("helio_scene_sync");
+            let t_sync = Instant::now();
+            Self::sync_scene(&self.scene_db, inner, &self.pending_errors);
+            sync_ms = t_sync.elapsed().as_secs_f64() * 1000.0;
+            inner.last_scene_revision = scene_revision;
         }
 
-        let t_render = std::time::Instant::now();
-        let (sy, cy) = self.cam_yaw.sin_cos();
-        let (sp, cp) = self.cam_pitch.sin_cos();
-        let fwd = Vec3::new(sy * cp, sp, -cy * cp);
-        let aspect = width as f32 / height.max(1) as f32;
-        let camera = Camera::perspective_look_at(
-            self.cam_pos,
-            self.cam_pos + fwd,
-            Vec3::Y,
-            std::f32::consts::FRAC_PI_4,
-            aspect,
-            0.1,
-            10_000.0,
-        );
+        let t_prepare = Instant::now();
+        let camera = {
+            profiling::profile_scope!("helio_frame_prepare");
+            let (sy, cy) = self.cam_yaw.sin_cos();
+            let (sp, cp) = self.cam_pitch.sin_cos();
+            let fwd = Vec3::new(sy * cp, sp, -cy * cp);
+            let aspect = width as f32 / height.max(1) as f32;
+            let camera = Camera::perspective_look_at(
+                self.cam_pos,
+                self.cam_pos + fwd,
+                Vec3::Y,
+                std::f32::consts::FRAC_PI_4,
+                aspect,
+                0.1,
+                10_000.0,
+            );
 
-        // Mirror Helio editor demo exactly: clear debug geometry first, then draw gizmos.
-        // Without debug_clear(), each frame's gizmo lines accumulate, making it look like
-        // multiple objects are selected and leaving drag trails behind moved objects.
-        inner.renderer.debug_clear();
-        inner.renderer.set_gizmo_camera(&camera, height as f32);
-        inner.editor_state.draw_gizmos(&mut inner.renderer);
+            // Mirror Helio editor demo exactly: clear debug geometry first, then draw gizmos.
+            // Without debug_clear(), each frame's gizmo lines accumulate, making it look like
+            // multiple objects are selected and leaving drag trails behind moved objects.
+            inner.renderer.debug_clear();
+            inner.renderer.set_gizmo_camera(&camera, height as f32);
+            inner.editor_state.draw_gizmos(&mut inner.renderer);
+            camera
+        };
 
+        let prepare_ms = t_prepare.elapsed().as_secs_f64() * 1000.0;
+        let t_render = Instant::now();
+        {
+            profiling::profile_scope!("helio_render_submit");
+            if let Err(e) = inner.renderer.render(&camera, &view) {
+                tracing::error!("Helio render error: {:?}", e);
+            }
+        }
         let render_ms = t_render.elapsed().as_secs_f64() * 1000.0;
-        if render_ms > 5.0 {
-            tracing::warn!("[HELIO RENDER] gpu render took {:.2}ms — SLOW", render_ms);
-        }
-        if let Err(e) = inner.renderer.render(&camera, &view) {
-            tracing::error!("Helio render error: {:?}", e);
+        let frame_ms = frame_start.elapsed().as_secs_f64() * 1000.0;
+        if frame_ms > 50.0 {
+            tracing::warn!(
+                "[HELIO FRAME] {:.1}ms (sync {:.1}, prepare {:.1}, submit {:.1})",
+                frame_ms,
+                sync_ms,
+                prepare_ms,
+                render_ms
+            );
         }
 
         if let Ok(mut m) = self.metrics.lock() {
@@ -733,7 +762,7 @@ impl HelioRenderer {
             renderer: &'a mut Renderer,
             subsystems: Subsystems,
             error_queue: &'a Arc<Mutex<Vec<String>>>,
-            project_root: PathBuf,
+            project_root: &'a Path,
         }
 
         impl<'a> ComponentRuntimeContext for HelioRuntimeContext<'a> {
@@ -782,6 +811,9 @@ impl HelioRenderer {
             tracing::warn!("[SYNC_SCENE] get_all_snapshots took {:.2}ms", snap_ms);
         }
         let mut live_keys = LiveKeySet::new();
+        let project_root = engine_state::get_project_path()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
         for snap in &snapshots {
             if !snap.visible {
@@ -802,14 +834,11 @@ impl HelioRenderer {
             subsystems.register_ref::<MeshCache>(&mut inner.mesh_cache);
             subsystems.register_ref::<SceneObjectCache>(&mut inner.object_cache);
             subsystems.register_ref::<LiveKeySet>(&mut live_keys);
-            let project_root = engine_state::get_project_path()
-                .map(PathBuf::from)
-                .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
             let mut ctx = HelioRuntimeContext {
                 renderer: &mut inner.renderer,
                 subsystems,
                 error_queue,
-                project_root,
+                project_root: &project_root,
             };
 
             for (component_index, class_name, data) in component_instances {

--- a/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/core/scene_database.rs
@@ -228,9 +228,8 @@ impl SceneDatabase {
         self.scene_db.set_name(&id, obj.name);
         self.scene_db.set_visible(&id, obj.visible);
         self.scene_db.set_locked(&id, obj.locked);
-        if let Some(entry) = self.scene_db.get_entry(&id) {
-            entry.meta.write().props = obj.props;
-        }
+        self.scene_db
+            .update_render_data(&id, |meta| meta.props = obj.props);
         self.sync_registered_component_props_to_scene_db(&id);
         true
     }
@@ -715,8 +714,7 @@ impl SceneDatabase {
     fn sync_registered_component_props_to_scene_db(&self, object_id: &str) {
         let components = self.metadata_db.get_components(&object_id.to_string());
 
-        if let Some(entry) = self.scene_db.get_entry(object_id) {
-            let mut meta = entry.meta.write();
+        self.scene_db.update_render_data(object_id, |meta| {
             for class_name in registered_scene_props_classes() {
                 let data = components
                     .iter()
@@ -738,7 +736,7 @@ impl SceneDatabase {
                 })
                 .collect();
             meta.component_instances = Some(Value::Array(instances));
-        }
+        });
     }
 
     fn collect_descendant_ids(scene_db: &SceneDb, id: &str, out: &mut Vec<ObjectId>) {

--- a/crates/editor/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/ui/viewport/helio_viewport.rs
@@ -7,13 +7,14 @@
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use engine_backend::services::gpu_renderer::GpuRenderer;
 use gpui::*;
 use plugin_editor_api::{AssetKind, AssetPayload};
-use ui::{notification::Notification, ActiveTheme as _, ContextModal};
+use ui::{ActiveTheme as _, ContextModal, notification::Notification};
 
-use crate::level_editor::commands::{execute_command, SceneCommand};
+use crate::level_editor::commands::{SceneCommand, execute_command};
 use crate::level_editor::scene_database::{MeshType, ObjectType, SceneObjectData, Transform};
 use crate::level_editor::state::LevelEditorState;
 
@@ -24,6 +25,10 @@ pub struct HelioViewport {
     surface: Option<WgpuSurfaceHandle>,
     focus_handle: FocusHandle,
     debug_replace_with_yellow: bool,
+    last_spike_report: Instant,
+    slow_frames_since_report: u32,
+    engine_lock_misses_since_report: u32,
+    max_frame_ms_since_report: f64,
 }
 
 impl HelioViewport {
@@ -39,6 +44,10 @@ impl HelioViewport {
             surface: None,
             focus_handle: cx.focus_handle(),
             debug_replace_with_yellow,
+            last_spike_report: Instant::now(),
+            slow_frames_since_report: 0,
+            engine_lock_misses_since_report: 0,
+            max_frame_ms_since_report: 0.0,
         }
     }
 
@@ -209,6 +218,42 @@ impl HelioViewport {
 
         Ok(())
     }
+
+    fn record_frame_diagnostics(
+        &mut self,
+        total_ms: f64,
+        acquire_ms: f64,
+        render_ms: f64,
+        swap_ms: f64,
+        engine_lock_missed: bool,
+    ) {
+        if engine_lock_missed {
+            self.engine_lock_misses_since_report += 1;
+        }
+        if total_ms > 33.3 {
+            self.slow_frames_since_report += 1;
+            self.max_frame_ms_since_report = self.max_frame_ms_since_report.max(total_ms);
+        }
+
+        if (self.slow_frames_since_report > 0 || self.engine_lock_misses_since_report > 0)
+            && self.last_spike_report.elapsed().as_secs_f32() >= 1.0
+        {
+            tracing::warn!(
+                "[VIEWPORT SPIKES] slow={} lock_misses={} max={:.1}ms latest={:.1}ms (acquire {:.1}, render {:.1}, swap {:.1})",
+                self.slow_frames_since_report,
+                self.engine_lock_misses_since_report,
+                self.max_frame_ms_since_report,
+                total_ms,
+                acquire_ms,
+                render_ms,
+                swap_ms
+            );
+            self.last_spike_report = Instant::now();
+            self.slow_frames_since_report = 0;
+            self.engine_lock_misses_since_report = 0;
+            self.max_frame_ms_since_report = 0.0;
+        }
+    }
 }
 
 /// Renders the current Helio scene into an offscreen texture, reads it back
@@ -367,6 +412,7 @@ impl EventEmitter<DismissEvent> for HelioViewport {}
 
 impl Render for HelioViewport {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        profiling::profile_scope!("helio_viewport_frame");
         if self.debug_replace_with_yellow {
             return div()
                 .relative()
@@ -398,35 +444,47 @@ impl Render for HelioViewport {
         // Render into the back buffer, then swap.  If the surface is still
         // resizing, keep the previous display buffer visible and avoid forcing
         // Helio to resize mid-drag.
+        let mut frame_diagnostics = None;
         if let Some(ref surface) = self.surface {
             if !surface.is_resize_pending() {
-                if let Some((view, (w, h))) = surface.back_view_with_size() {
-                    if let Ok(mut engine) = self.gpu_engine.try_lock() {
-                        let t_frame = std::time::Instant::now();
-                        engine.render_frame_to_surface(
-                            surface.device(),
-                            surface.queue(),
-                            &view,
-                            w,
-                            h,
-                            surface.format(),
-                        );
-                        let frame_ms = t_frame.elapsed().as_secs_f64() * 1000.0;
-                        if frame_ms > 16.0 {
-                            tracing::warn!(
-                                "[VIEWPORT] render_frame_to_surface took {:.1}ms",
-                                frame_ms
+                let frame_start = Instant::now();
+                let acquire_start = Instant::now();
+                let back_view = {
+                    profiling::profile_scope!("viewport_surface_acquire");
+                    surface.back_view_with_size()
+                };
+                let acquire_ms = acquire_start.elapsed().as_secs_f64() * 1000.0;
+                if let Some((view, (w, h))) = back_view {
+                    let render_start = Instant::now();
+                    let mut engine_lock_missed = true;
+                    {
+                        profiling::profile_scope!("viewport_engine_render");
+                        if let Ok(mut engine) = self.gpu_engine.try_lock() {
+                            engine_lock_missed = false;
+                            engine.render_frame_to_surface(
+                                surface.device(),
+                                surface.queue(),
+                                &view,
+                                w,
+                                h,
+                                surface.format(),
                             );
-                        }
-                        for err in engine.drain_pending_errors() {
-                            window.push_notification(
-                                Notification::error("Mesh Load Failed").message(err),
-                                cx,
-                            );
+                            for err in engine.drain_pending_errors() {
+                                window.push_notification(
+                                    Notification::error("Mesh Load Failed").message(err),
+                                    cx,
+                                );
+                            }
                         }
                     }
+                    let render_ms = render_start.elapsed().as_secs_f64() * 1000.0;
                     drop(view);
-                    surface.swap_buffers();
+                    let swap_start = Instant::now();
+                    {
+                        profiling::profile_scope!("viewport_surface_swap");
+                        surface.swap_buffers();
+                    }
+                    let swap_ms = swap_start.elapsed().as_secs_f64() * 1000.0;
 
                     // Capture a project thumbnail if a save just requested one.
                     let capture_path = self
@@ -440,8 +498,26 @@ impl Render for HelioViewport {
                             capture_viewport_thumbnail(&mut engine, surface, w, h, format, &path);
                         }
                     }
+                    frame_diagnostics = Some((
+                        frame_start.elapsed().as_secs_f64() * 1000.0,
+                        acquire_ms,
+                        render_ms,
+                        swap_ms,
+                        engine_lock_missed,
+                    ));
                 }
             }
+        }
+        if let Some((total_ms, acquire_ms, render_ms, swap_ms, engine_lock_missed)) =
+            frame_diagnostics
+        {
+            self.record_frame_diagnostics(
+                total_ms,
+                acquire_ms,
+                render_ms,
+                swap_ms,
+                engine_lock_missed,
+            );
         }
 
         // Build the viewport element

--- a/crates/editor/ui_level_editor/src/level_editor/ui/viewport/mod.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/ui/viewport/mod.rs
@@ -26,7 +26,7 @@ use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use helio_viewport::HelioViewport;
 use ui::Sizable;
-use ui::{v_flex, ActiveTheme};
+use ui::{ActiveTheme, v_flex};
 use ui_common::ViewportControls;
 
 use crate::level_editor::state::LevelEditorState;
@@ -211,9 +211,9 @@ impl ViewportPanel {
             let mut was_capturing = false;
 
             loop {
+                std::thread::sleep(std::time::Duration::from_millis(8)); // ~120Hz
                 profiling::profile_scope!("input_poll");
                 let input_start = std::time::Instant::now();
-                std::thread::sleep(std::time::Duration::from_millis(8)); // ~120Hz
 
                 let capture =
                     ViewportCursorCapture::load(&mouse_right_captured, &mouse_middle_captured);


### PR DESCRIPTION
## Summary

- publish a monotonic SceneDb render revision only when renderer-visible data changes
- skip full Helio scene synchronization on unchanged frames while preserving deferred sync during gizmo drags
- route editor component/property writes through the revision-publishing API
- resolve the project root once per scene sync instead of once per object
- replace per-frame warning I/O with rate-limited phase diagnostics
- move the intentional input-poll sleep outside the measured profiler scope

## Evidence

Before this change, an optimized editor run produced 645 `[SYNC_SCENE]` warnings and 228 `[VIEWPORT]` warnings across 887 log lines while repeatedly rebuilding scene state. The validated run produced zero `[SYNC_SCENE]` warnings and zero legacy `[VIEWPORT]` warnings. Continuous planet movement no longer exhibits the former large freezes; resize and gizmo/light interaction remain functional.

Three isolated 266-532 ms events were measured inside Helio render submission rather than SceneDb synchronization or viewport locking. GPU/render-graph attribution for those residual hitches remains tracked in https://github.com/Far-Beyond-Pulsar/Helio/issues/122.

## Validation

- `cargo test -p engine_backend scene::tests::render_revision_advances_only_when_render_data_changes --lib --offline`
- `cargo +1.97 build --release -p pulsar_engine --offline`
- `cargo +1.97 check --release -p engine_backend --lib --offline` after rebasing onto current `main`
- targeted rustfmt and `git diff --check`
- visual validation of continuous movement, resize, selection, and light/gizmo manipulation

Closes #361