### PR TITLE
Unify editor UI type package identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,7 @@ dependencies = [
  "tracing",
  "ui",
  "ui_common",
- "ui_types_common 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Pulsar-Native?rev=f91bbba2b90ebad0afa6b9940ecd52da0430e326)",
+ "ui_types_common",
  "uuid",
 ]
 
@@ -3016,7 +3016,7 @@ dependencies = [
  "tool_registry",
  "tool_registry_macros",
  "tracing",
- "ui_types_common 0.1.0",
+ "ui_types_common",
  "ureq",
  "urlencoding",
  "uuid",
@@ -3044,7 +3044,7 @@ dependencies = [
  "smol",
  "toml 1.1.3+spec-1.1.0",
  "tracing",
- "ui_types_common 0.1.0",
+ "ui_types_common",
  "window_manager",
 ]
 
@@ -8527,7 +8527,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "ui",
- "ui_types_common 0.1.0",
+ "ui_types_common",
  "window_manager",
 ]
 
@@ -10777,7 +10777,7 @@ dependencies = [
  "tracing",
  "ui",
  "ui_common",
- "ui_types_common 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Pulsar-Native?rev=f91bbba2b90ebad0afa6b9940ecd52da0430e326)",
+ "ui_types_common",
  "uuid",
 ]
 
@@ -13467,7 +13467,7 @@ dependencies = [
  "ui_problems",
  "ui_settings",
  "ui_type_debugger",
- "ui_types_common 0.1.0",
+ "ui_types_common",
  "window_manager",
 ]
 
@@ -13565,7 +13565,7 @@ dependencies = [
  "tracing",
  "ui",
  "ui_common",
- "ui_types_common 0.1.0",
+ "ui_types_common",
  "window_manager",
 ]
 
@@ -13681,7 +13681,7 @@ dependencies = [
  "tracing",
  "ui",
  "ui_common",
- "ui_types_common 0.1.0",
+ "ui_types_common",
  "wgpu",
  "winapi",
  "window_manager",
@@ -13827,20 +13827,6 @@ dependencies = [
 [[package]]
 name = "ui_types_common"
 version = "0.1.0"
-dependencies = [
- "chrono",
- "lazy_static",
- "regex",
- "schemars",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
-]
-
-[[package]]
-name = "ui_types_common"
-version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Native?rev=f91bbba2b90ebad0afa6b9940ecd52da0430e326#f91bbba2b90ebad0afa6b9940ecd52da0430e326"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -14762,7 +14748,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tracing",
  "ui_gen_macros",
- "ui_types_common 0.1.0",
+ "ui_types_common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,6 +291,7 @@ plugin_editor_api = { path = "crates/core/plugin_editor_api" }
 ui_common         = { path = "crates/editor/ui_common" }
 engine_backend    = { path = "crates/core/engine_backend" }
 engine_state      = { path = "crates/core/engine_state" }
+ui_types_common   = { path = "crates/editor/ui_types_common" }
 pulsar_std_bundle = { path = "crates/core/pulsar_std_bundle" }
 pulsar_bp_executor = { path = "crates/core/pulsar_bp_executor" }
 # Point at the same unified source as the Pulsar-Reflection patch below so every


### PR DESCRIPTION
## Summary

- patch external `ui_types_common` references to the workspace crate
- collapse the editor graph to one local `ui_types_common` package identity
- remove the stale Git package from `Cargo.lock`

## Dependency

This PR is intentionally stacked on #438, which owns the Blueprint vendor API update and the broader dependency cleanup. Merge #438 first; this PR then contains only the remaining UI type identity fix.

## Evidence

- `cargo tree -p pulsar_engine -i pulsar_std_bundle --edges normal` reports no matching package in the editor target
- `cargo tree -p pulsar_engine -i ui_types_common --edges normal` resolves one local workspace package
- duplicate-package inspection shows no duplicate `gpui`, `ui`, `ui-macros`, or `ui_types_common` package identity
- `cargo check -p pulsar_engine --locked -q` passes on Windows after the rebase

Existing warnings are pre-existing across the editor dependency graph. This is an engine/shared build-graph change and requires review before merge.

Advances #402.