### PR TITLE
Align PBGC submodule and Blueprint test API

### DIFF
--- a/crates/core/pulsar_bp_executor/tests/complex_nodes.rs
+++ b/crates/core/pulsar_bp_executor/tests/complex_nodes.rs
@@ -9,13 +9,13 @@ use graphy::{
 };
 use pbgc::compile_graph_to_bytecode;
 use pulsar_bp_executor::BpExecutor;
-use pulsar_std_bundle::extract_to_tempfile;
+use pulsar_std_bundle::{expected_sha256, extract_to_tempfile};
 
 // ── Shared executor ───────────────────────────────────────────────────────────
 
 fn exec() -> (BpExecutor, pulsar_std_bundle::TempLib) {
     let tmp = extract_to_tempfile().unwrap();
-    let e = BpExecutor::load(&tmp.path).unwrap();
+    let e = BpExecutor::load(&tmp.path, Some(expected_sha256())).unwrap();
     (e, tmp)
 }
 
@@ -34,7 +34,7 @@ fn begin() -> NodeInstance {
     let mut n = NodeInstance::new("begin", "begin_play", Position::default());
     n.outputs.push(PinInstance::new(
         "be",
-        Pin::new("be", "Body", DataType::Execution, PinType::Output),
+        Pin::new("be", "Body", DataType::Exec, PinType::Output),
     ));
     n
 }
@@ -48,7 +48,7 @@ fn pure_f64(id: &str, node_type: &str, param_names: &[&str], consts: &[f64]) -> 
             Pin::new(
                 &pid,
                 name.to_string(),
-                DataType::Typed(graphy::TypeInfo::new("f64")),
+                DataType::typed("f64"),
                 PinType::Input,
             ),
         ));
@@ -61,7 +61,7 @@ fn pure_f64(id: &str, node_type: &str, param_names: &[&str], consts: &[f64]) -> 
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Output,
         ),
     ));
@@ -77,7 +77,7 @@ fn pure_i64(id: &str, node_type: &str, param_names: &[&str], consts: &[f64]) -> 
             Pin::new(
                 &pid,
                 name.to_string(),
-                DataType::Typed(graphy::TypeInfo::new("i64")),
+                DataType::typed("i64"),
                 PinType::Input,
             ),
         ));
@@ -90,7 +90,7 @@ fn pure_i64(id: &str, node_type: &str, param_names: &[&str], consts: &[f64]) -> 
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Output,
         ),
     ));
@@ -111,7 +111,7 @@ fn pure_bool_out(
             Pin::new(
                 &pid,
                 name.to_string(),
-                DataType::Typed(graphy::TypeInfo::new(ty)),
+                DataType::typed(ty),
                 PinType::Input,
             ),
         ));
@@ -124,7 +124,7 @@ fn pure_bool_out(
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Output,
         ),
     ));
@@ -138,7 +138,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -147,7 +147,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "actual",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -156,7 +156,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_x"),
             "expected",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -165,7 +165,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -181,7 +181,7 @@ fn assert_eq_float(id: &str, expected: f64, eps: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -190,7 +190,7 @@ fn assert_eq_float(id: &str, expected: f64, eps: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "actual",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -199,7 +199,7 @@ fn assert_eq_float(id: &str, expected: f64, eps: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_x"),
             "expected",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -208,7 +208,7 @@ fn assert_eq_float(id: &str, expected: f64, eps: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_ep"),
             "epsilon",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -217,7 +217,7 @@ fn assert_eq_float(id: &str, expected: f64, eps: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -235,7 +235,7 @@ fn assert_eq_f32(id: &str, expected: f32, eps: f32) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -244,7 +244,7 @@ fn assert_eq_f32(id: &str, expected: f32, eps: f32) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "actual",
-            DataType::Typed(graphy::TypeInfo::new("f32")),
+            DataType::typed("f32"),
             PinType::Input,
         ),
     ));
@@ -253,7 +253,7 @@ fn assert_eq_f32(id: &str, expected: f32, eps: f32) -> NodeInstance {
         Pin::new(
             &format!("{id}_x"),
             "expected",
-            DataType::Typed(graphy::TypeInfo::new("f32")),
+            DataType::typed("f32"),
             PinType::Input,
         ),
     ));
@@ -262,7 +262,7 @@ fn assert_eq_f32(id: &str, expected: f32, eps: f32) -> NodeInstance {
         Pin::new(
             &format!("{id}_ep"),
             "epsilon",
-            DataType::Typed(graphy::TypeInfo::new("f32")),
+            DataType::typed("f32"),
             PinType::Input,
         ),
     ));
@@ -271,7 +271,7 @@ fn assert_eq_f32(id: &str, expected: f32, eps: f32) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -289,7 +289,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -298,7 +298,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_c"),
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -307,7 +307,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -321,7 +321,7 @@ fn assert_false(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -330,7 +330,7 @@ fn assert_false(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_c"),
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -339,7 +339,7 @@ fn assert_false(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -694,7 +694,7 @@ fn test_smoothstep_midpoint() {
             Pin::new(
                 &pid,
                 name.to_string(),
-                DataType::Typed(graphy::TypeInfo::new("f32")),
+                DataType::typed("f32"),
                 PinType::Input,
             ),
         ));
@@ -704,7 +704,7 @@ fn test_smoothstep_midpoint() {
         Pin::new(
             "n_r",
             "result",
-            DataType::Typed(graphy::TypeInfo::new("f32")),
+            DataType::typed("f32"),
             PinType::Output,
         ),
     ));
@@ -736,7 +736,7 @@ fn test_clamp_to_range_below_min() {
             Pin::new(
                 &pid,
                 (*name).to_string(),
-                DataType::Typed(graphy::TypeInfo::new("f32")),
+                DataType::typed("f32"),
                 PinType::Input,
             ),
         ));
@@ -746,7 +746,7 @@ fn test_clamp_to_range_below_min() {
         Pin::new(
             "n_r",
             "result",
-            DataType::Typed(graphy::TypeInfo::new("f32")),
+            DataType::typed("f32"),
             PinType::Output,
         ),
     ));
@@ -1079,7 +1079,7 @@ fn test_select_number_true() {
         Pin::new(
             "n_cond",
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -1088,7 +1088,7 @@ fn test_select_number_true() {
         Pin::new(
             "n_a",
             "a",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -1097,7 +1097,7 @@ fn test_select_number_true() {
         Pin::new(
             "n_b",
             "b",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -1106,7 +1106,7 @@ fn test_select_number_true() {
         Pin::new(
             "n_r",
             "result",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Output,
         ),
     ));
@@ -1135,7 +1135,7 @@ fn test_select_number_false() {
         Pin::new(
             "n_cond",
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -1144,7 +1144,7 @@ fn test_select_number_false() {
         Pin::new(
             "n_a",
             "a",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -1153,7 +1153,7 @@ fn test_select_number_false() {
         Pin::new(
             "n_b",
             "b",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -1162,7 +1162,7 @@ fn test_select_number_false() {
         Pin::new(
             "n_r",
             "result",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Output,
         ),
     ));
@@ -1435,7 +1435,7 @@ fn color_node(id: &str, node_type: &str, r: f32, g: f32, b: f32, a: f32) -> Node
             Pin::new(
                 &pid,
                 name,
-                DataType::Typed(graphy::TypeInfo::new("f32")),
+                DataType::typed("f32"),
                 PinType::Input,
             ),
         ));
@@ -1446,7 +1446,7 @@ fn color_node(id: &str, node_type: &str, r: f32, g: f32, b: f32, a: f32) -> Node
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("(f32, f32, f32, f32)")),
+            DataType::typed("(f32, f32, f32, f32)"),
             PinType::Output,
         ),
     ));
@@ -1462,7 +1462,7 @@ fn color_lerp_node(id: &str, t: f32) -> NodeInstance {
             Pin::new(
                 &pid,
                 name,
-                DataType::Typed(graphy::TypeInfo::new("(f32, f32, f32, f32)")),
+                DataType::typed("(f32, f32, f32, f32)"),
                 PinType::Input,
             ),
         ));
@@ -1473,7 +1473,7 @@ fn color_lerp_node(id: &str, t: f32) -> NodeInstance {
         Pin::new(
             &tp,
             "t",
-            DataType::Typed(graphy::TypeInfo::new("f32")),
+            DataType::typed("f32"),
             PinType::Input,
         ),
     ));
@@ -1483,7 +1483,7 @@ fn color_lerp_node(id: &str, t: f32) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("(f32, f32, f32, f32)")),
+            DataType::typed("(f32, f32, f32, f32)"),
             PinType::Output,
         ),
     ));
@@ -1499,7 +1499,7 @@ fn color_eq_node(id: &str, eps: f32) -> NodeInstance {
             Pin::new(
                 &pid,
                 name,
-                DataType::Typed(graphy::TypeInfo::new("(f32, f32, f32, f32)")),
+                DataType::typed("(f32, f32, f32, f32)"),
                 PinType::Input,
             ),
         ));
@@ -1510,7 +1510,7 @@ fn color_eq_node(id: &str, eps: f32) -> NodeInstance {
         Pin::new(
             &ep,
             "epsilon",
-            DataType::Typed(graphy::TypeInfo::new("f32")),
+            DataType::typed("f32"),
             PinType::Input,
         ),
     ));
@@ -1520,7 +1520,7 @@ fn color_eq_node(id: &str, eps: f32) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Output,
         ),
     ));
@@ -1626,7 +1626,7 @@ fn pure_no_input(id: &str, node_type: &str, out_ty: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new(out_ty)),
+            DataType::typed(out_ty),
             PinType::Output,
         ),
     ));
@@ -1647,7 +1647,7 @@ fn pure_one_input(
         Pin::new(
             &pid,
             param,
-            DataType::Typed(graphy::TypeInfo::new(in_ty)),
+            DataType::typed(in_ty),
             PinType::Input,
         ),
     ));
@@ -1656,7 +1656,7 @@ fn pure_one_input(
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new(out_ty)),
+            DataType::typed(out_ty),
             PinType::Output,
         ),
     ));

--- a/crates/core/pulsar_bp_executor/tests/executor_tests.rs
+++ b/crates/core/pulsar_bp_executor/tests/executor_tests.rs
@@ -15,15 +15,15 @@ use graphy::{
     Connection, ConnectionType, DataType, GraphDescription, NodeInstance, Pin, PinInstance,
     PinType, Position,
 };
-use pbgc::{compile_graph_to_bytecode, BpProgram};
+use pbgc::compile_graph_to_bytecode;
 use pulsar_bp_executor::BpExecutor;
-use pulsar_std_bundle::extract_to_tempfile;
+use pulsar_std_bundle::{expected_sha256, extract_to_tempfile};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn executor() -> (BpExecutor, pulsar_std_bundle::TempLib) {
     let tmp = extract_to_tempfile().expect("extract dylib");
-    let exec = BpExecutor::load(&tmp.path).expect("load dylib");
+    let exec = BpExecutor::load(&tmp.path, Some(expected_sha256())).expect("load dylib");
     (exec, tmp)
 }
 
@@ -46,7 +46,7 @@ fn begin(pin: &str) -> NodeInstance {
     let mut n = NodeInstance::new("begin", "begin_play", Position { x: 0.0, y: 0.0 });
     n.outputs.push(PinInstance::new(
         pin,
-        Pin::new(pin, "Body", DataType::Execution, PinType::Output),
+        Pin::new(pin, "Body", DataType::Exec, PinType::Output),
     ));
     n
 }
@@ -58,7 +58,7 @@ fn add_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "a",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -67,7 +67,7 @@ fn add_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_b"),
             "b",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -76,7 +76,7 @@ fn add_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Output,
         ),
     ));
@@ -96,7 +96,7 @@ fn mul_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "a",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -105,7 +105,7 @@ fn mul_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_b"),
             "b",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -114,7 +114,7 @@ fn mul_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Output,
         ),
     ));
@@ -134,7 +134,7 @@ fn sub_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "a",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -143,7 +143,7 @@ fn sub_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_b"),
             "b",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -152,7 +152,7 @@ fn sub_i64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Output,
         ),
     ));
@@ -172,7 +172,7 @@ fn lerp_f64(id: &str, a: Option<f64>, b: Option<f64>, t: Option<f64>) -> NodeIns
         Pin::new(
             &format!("{id}_a"),
             "a",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -181,7 +181,7 @@ fn lerp_f64(id: &str, a: Option<f64>, b: Option<f64>, t: Option<f64>) -> NodeIns
         Pin::new(
             &format!("{id}_b"),
             "b",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -190,7 +190,7 @@ fn lerp_f64(id: &str, a: Option<f64>, b: Option<f64>, t: Option<f64>) -> NodeIns
         Pin::new(
             &format!("{id}_t"),
             "t",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -199,7 +199,7 @@ fn lerp_f64(id: &str, a: Option<f64>, b: Option<f64>, t: Option<f64>) -> NodeIns
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Output,
         ),
     ));
@@ -222,7 +222,7 @@ fn gt_f64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "a",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -231,7 +231,7 @@ fn gt_f64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_b"),
             "b",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -240,7 +240,7 @@ fn gt_f64(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Output,
         ),
     ));
@@ -260,7 +260,7 @@ fn branch(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -269,7 +269,7 @@ fn branch(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_c"),
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -278,7 +278,7 @@ fn branch(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_t"),
             "True",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -287,7 +287,7 @@ fn branch(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_f"),
             "False",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -301,7 +301,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -310,7 +310,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "actual",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -319,7 +319,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_x"),
             "expected",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -328,7 +328,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -344,7 +344,7 @@ fn assert_eq_float(id: &str, expected: f64, epsilon: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -353,7 +353,7 @@ fn assert_eq_float(id: &str, expected: f64, epsilon: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "actual",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -362,7 +362,7 @@ fn assert_eq_float(id: &str, expected: f64, epsilon: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_x"),
             "expected",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -371,7 +371,7 @@ fn assert_eq_float(id: &str, expected: f64, epsilon: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_ep"),
             "epsilon",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -380,7 +380,7 @@ fn assert_eq_float(id: &str, expected: f64, epsilon: f64) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -398,7 +398,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -407,7 +407,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_c"),
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -416,7 +416,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));

--- a/crates/core/pulsar_bp_executor/tests/generic_nodes.rs
+++ b/crates/core/pulsar_bp_executor/tests/generic_nodes.rs
@@ -6,11 +6,11 @@ use graphy::{
 };
 use pbgc::compile_graph_to_bytecode;
 use pulsar_bp_executor::BpExecutor;
-use pulsar_std_bundle::extract_to_tempfile;
+use pulsar_std_bundle::{expected_sha256, extract_to_tempfile};
 
 fn exec() -> (BpExecutor, pulsar_std_bundle::TempLib) {
     let tmp = extract_to_tempfile().unwrap();
-    let e = BpExecutor::load(&tmp.path).unwrap();
+    let e = BpExecutor::load(&tmp.path, Some(expected_sha256())).unwrap();
     (e, tmp)
 }
 
@@ -35,7 +35,7 @@ fn begin() -> NodeInstance {
     let mut n = NodeInstance::new("begin", "begin_play", Position::default());
     n.outputs.push(PinInstance::new(
         "be",
-        Pin::new("be", "Body", DataType::Execution, PinType::Output),
+        Pin::new("be", "Body", DataType::Exec, PinType::Output),
     ));
     n
 }
@@ -47,7 +47,7 @@ fn add_node(id: &str, a: i64, b: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "a",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -56,7 +56,7 @@ fn add_node(id: &str, a: i64, b: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_b"),
             "b",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -65,7 +65,7 @@ fn add_node(id: &str, a: i64, b: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Output,
         ),
     ));
@@ -83,7 +83,7 @@ fn array_new_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Output,
         ),
     ));
@@ -97,7 +97,7 @@ fn array_push_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -106,7 +106,7 @@ fn array_push_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_arr"),
             "array",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Input,
         ),
     ));
@@ -115,7 +115,7 @@ fn array_push_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_itm"),
             "item",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -124,7 +124,7 @@ fn array_push_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_eo"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -133,7 +133,7 @@ fn array_push_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Output,
         ),
     ));
@@ -148,7 +148,7 @@ fn array_push_vec_item_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -157,7 +157,7 @@ fn array_push_vec_item_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_arr"),
             "array",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Input,
         ),
     ));
@@ -166,7 +166,7 @@ fn array_push_vec_item_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_itm"),
             "item",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Input,
         ),
     ));
@@ -175,7 +175,7 @@ fn array_push_vec_item_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_eo"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -184,7 +184,7 @@ fn array_push_vec_item_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Output,
         ),
     ));
@@ -198,7 +198,7 @@ fn array_clear_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -207,7 +207,7 @@ fn array_clear_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_arr"),
             "array",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Input,
         ),
     ));
@@ -216,7 +216,7 @@ fn array_clear_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_eo"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -225,7 +225,7 @@ fn array_clear_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Output,
         ),
     ));
@@ -239,7 +239,7 @@ fn array_set_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -248,7 +248,7 @@ fn array_set_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_arr"),
             "array",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Input,
         ),
     ));
@@ -257,7 +257,7 @@ fn array_set_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_idx"),
             "index",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -266,7 +266,7 @@ fn array_set_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_val"),
             "value",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -275,7 +275,7 @@ fn array_set_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_eo"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -284,7 +284,7 @@ fn array_set_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Output,
         ),
     ));
@@ -298,7 +298,7 @@ fn array_length_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_arr"),
             "array",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Input,
         ),
     ));
@@ -307,7 +307,7 @@ fn array_length_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Output,
         ),
     ));
@@ -321,7 +321,7 @@ fn array_is_empty_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_arr"),
             "array",
-            DataType::Typed(graphy::TypeInfo::new("Vec")),
+            DataType::typed("Vec"),
             PinType::Input,
         ),
     ));
@@ -330,7 +330,7 @@ fn array_is_empty_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Output,
         ),
     ));
@@ -344,7 +344,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -353,7 +353,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "actual",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -362,7 +362,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_x"),
             "expected",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -371,7 +371,7 @@ fn assert_eq_int(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -387,7 +387,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -396,7 +396,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_c"),
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -405,7 +405,7 @@ fn assert_true(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -419,7 +419,7 @@ fn assert_false(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -428,7 +428,7 @@ fn assert_false(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_c"),
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -437,7 +437,7 @@ fn assert_false(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));

--- a/crates/core/pulsar_std_bundle/tests/integration.rs
+++ b/crates/core/pulsar_std_bundle/tests/integration.rs
@@ -14,13 +14,15 @@ use graphy::{
 };
 use pbgc::{compile_graph, compile_graph_to_bytecode, BpProgram};
 use pulsar_bp_executor::BpExecutor;
-use pulsar_std_bundle::{extract_to_tempfile, PULSAR_STD_LIB_BYTES, PULSAR_STD_LIB_EXT};
+use pulsar_std_bundle::{
+    expected_sha256, extract_to_tempfile, PULSAR_STD_LIB_BYTES, PULSAR_STD_LIB_EXT,
+};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn executor() -> (BpExecutor, pulsar_std_bundle::TempLib) {
     let tmp = extract_to_tempfile().expect("extract native lib");
-    let exec = BpExecutor::load(&tmp.path).expect("load native lib");
+    let exec = BpExecutor::load(&tmp.path, Some(expected_sha256())).expect("load native lib");
     (exec, tmp)
 }
 
@@ -53,7 +55,7 @@ fn begin(pin: &str) -> NodeInstance {
     let mut n = NodeInstance::new("begin", "begin_play", Position { x: 0.0, y: 0.0 });
     n.outputs.push(PinInstance::new(
         pin,
-        Pin::new(pin, "Body", DataType::Execution, PinType::Output),
+        Pin::new(pin, "Body", DataType::Exec, PinType::Output),
     ));
     n
 }
@@ -64,7 +66,7 @@ fn add_node(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "a",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -73,7 +75,7 @@ fn add_node(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_b"),
             "b",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -82,7 +84,7 @@ fn add_node(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Output,
         ),
     ));
@@ -101,7 +103,7 @@ fn gt_node(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "a",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -110,7 +112,7 @@ fn gt_node(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_b"),
             "b",
-            DataType::Typed(graphy::TypeInfo::new("f64")),
+            DataType::typed("f64"),
             PinType::Input,
         ),
     ));
@@ -119,7 +121,7 @@ fn gt_node(id: &str, a: Option<f64>, b: Option<f64>) -> NodeInstance {
         Pin::new(
             &format!("{id}_r"),
             "result",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Output,
         ),
     ));
@@ -138,7 +140,7 @@ fn branch_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -147,7 +149,7 @@ fn branch_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_c"),
             "condition",
-            DataType::Typed(graphy::TypeInfo::new("bool")),
+            DataType::typed("bool"),
             PinType::Input,
         ),
     ));
@@ -156,7 +158,7 @@ fn branch_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_t"),
             "True",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -165,7 +167,7 @@ fn branch_node(id: &str) -> NodeInstance {
         Pin::new(
             &format!("{id}_f"),
             "False",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -178,7 +180,7 @@ fn assert_eq_int_node(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_e"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Input,
         ),
     ));
@@ -187,7 +189,7 @@ fn assert_eq_int_node(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_a"),
             "actual",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -196,7 +198,7 @@ fn assert_eq_int_node(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_x"),
             "expected",
-            DataType::Typed(graphy::TypeInfo::new("i64")),
+            DataType::typed("i64"),
             PinType::Input,
         ),
     ));
@@ -205,7 +207,7 @@ fn assert_eq_int_node(id: &str, expected: i64) -> NodeInstance {
         Pin::new(
             &format!("{id}_o"),
             "exec",
-            DataType::Execution,
+            DataType::Exec,
             PinType::Output,
         ),
     ));
@@ -279,7 +281,7 @@ fn test_embedded_lib_is_non_empty() {
 fn test_lib_extracts_to_temp_and_loads() {
     let tmp = extract_to_tempfile().expect("extract");
     assert!(tmp.path.exists(), "temp file must exist");
-    let exec = BpExecutor::load(&tmp.path).expect("load");
+    let exec = BpExecutor::load(&tmp.path, Some(expected_sha256())).expect("load");
     // Prepare a trivial program to confirm the lib is functional
     let mut prog = BpProgram::new("test");
     prog.arena_size = 24;
@@ -359,12 +361,12 @@ fn test_multiple_event_nodes_produce_separate_programs() {
     let mut bp = NodeInstance::new("bp", "begin_play", Position { x: 0.0, y: 0.0 });
     bp.outputs.push(PinInstance::new(
         "bp_e",
-        Pin::new("bp_e", "Body", DataType::Execution, PinType::Output),
+        Pin::new("bp_e", "Body", DataType::Exec, PinType::Output),
     ));
     let mut main_ev = NodeInstance::new("main_ev", "main", Position { x: 200.0, y: 0.0 });
     main_ev.outputs.push(PinInstance::new(
         "main_e",
-        Pin::new("main_e", "Body", DataType::Execution, PinType::Output),
+        Pin::new("main_e", "Body", DataType::Exec, PinType::Output),
     ));
     g.add_node(bp);
     g.add_node(main_ev);


### PR DESCRIPTION
## Summary
- advance the vendored PBGC submodule to the official dependency-alignment and iterative-resolution merges
- update Blueprint executor and standard-bundle tests for Graphy’s current `DataType` API
- keep dynamic-library integrity verification enabled by supplying the embedded standard-library SHA-256 in every test load

## Why
The current PBGC alignment changes the graph type API and requires the explicit library hash. Without these test updates, Pulsar’s Blueprint test suites no longer compile against the vendored dependency.

## Validation
- `cargo test -p pulsar_bp_executor --locked` — 124 tests and doctests
- `cargo test -p pulsar_std_bundle --locked` — 15 tests and doctests, including the 500k-node compile/execute stress test

Closes #411