### PR TITLE
perf: narrow Windows API feature sets to reduce focused build time (#403)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ ropey = { version = "=2.0.0-beta.1", features = ["metric_utf16", "metric_lines_l
 # Windows-specific
 ###################################
 
-windows = {version = "0.62.2",features = ["Wdk","Wdk_System","Wdk_System_SystemServices","Win32_System_Threading","Win32_System_SystemInformation","Win32_Graphics_Direct3D","Win32_Graphics_Direct3D_Fxc","Win32_Graphics_Direct3D11","Win32_Graphics_Direct3D12","Win32_Graphics_Dxgi","Win32_Graphics_Dxgi_Common","Win32_Foundation",]}
+windows = {version = "0.62.2", default-features = false}
 open = "5.0"
 quote = "1.0"
 rust-embed = { version = "8", features = ["interpolate-folder-path", "include-exclude"] }

--- a/crates/core/engine/Cargo.toml
+++ b/crates/core/engine/Cargo.toml
@@ -52,7 +52,7 @@ pulsar_std = { workspace = true }
 tracing-appender = "0.2.4"
 
 [target.'cfg(windows)'.dependencies]
-windows = { workspace = true }
+windows = { workspace = true, features = ["Win32_System_Diagnostics_Debug"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation-sys = { workspace = true }

--- a/crates/core/engine_backend/Cargo.toml
+++ b/crates/core/engine_backend/Cargo.toml
@@ -77,7 +77,7 @@ sha2 = { workspace = true }
 walkdir = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows = { workspace = true }
+windows = { workspace = true, features = ["Win32_Foundation"] }
 winapi = { workspace = true, features = ["winuser"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/editor/ui_log_viewer/Cargo.toml
+++ b/crates/editor/ui_log_viewer/Cargo.toml
@@ -47,7 +47,7 @@ wgpu.workspace = true
 notify = { version = "8.0", default-features = false, features = ["macos_kqueue"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { workspace = true, features = ["Win32_System_Performance", "Win32_System_ProcessStatus"] }
+windows = { workspace = true, features = ["Win32_System_Performance", "Win32_System_ProcessStatus", "Win32_Graphics_Dxgi"] }
 winreg = "0.56"
 
 [lints]


### PR DESCRIPTION
Closes #403

## Changes

- **Root Cargo.toml**: Strip workspace-level `windows` dep to bare pin with `default-features = false`
- **crates/core/engine**: Add `Win32_System_Diagnostics_Debug` via cfg-gated dep
- **crates/core/engine_backend**: Add `Win32_Foundation` via cfg-gated dep
- **crates/editor/ui_log_viewer**: Add `Win32_Graphics_Dxgi` to existing windows features
- **crates/graphics/wgpu/wgpu-hal**: Replace umbrella `windows/Win32` in vulkan feature with specific features; pin `windows`/`windows-core` deps directly instead of via workspace