### PR TITLE
Expose non-blocking render pipeline timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8942,7 +8942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -8961,7 +8961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -12136,7 +12136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,10 +2947,10 @@ dependencies = [
  "git2 0.21.0",
  "glam 0.33.2",
  "gpui-ce",
- "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "helio-asset-compat",
- "helio-default-graphs 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-taa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-default-graphs 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-taa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "libloading 0.9.0",
  "lsp-types",
  "parking_lot",
@@ -4537,16 +4537,16 @@ dependencies = [
 [[package]]
 name = "helio"
 version = "0.18.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "arrayvec",
  "bytemuck",
  "glam 0.33.2",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-postprocess 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-voxel-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-postprocess 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-voxel-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "image",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "meshopt",
  "pollster 0.4.0",
@@ -4560,13 +4560,13 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
- "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "image",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "solid-fbx",
  "solid-gltf",
@@ -4593,12 +4593,12 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
- "helio-voxel-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-voxel-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "thiserror 2.0.19",
  "wgpu",
 ]
@@ -4647,40 +4647,40 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
- "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-billboard 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-corona 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-debug-overlay 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-decal 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-deferred-light 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-fxaa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-gbuffer 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-hiz 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-hlfs 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-indirect-dispatch 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-light-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-occlusion-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-perf-overlay 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-planar-reflection 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-postprocess 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-radiance-cascades 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-shadow 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-shadow-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-shadow-dirty 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-shadow-matrix 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-simple-cube 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-sky 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-sky-lut 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-ssr 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-taa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-transparent 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-virtual-geometry 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-volumetric-fog 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-voxel-mesh 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-pass-water-sim 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-billboard 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-corona 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-debug-overlay 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-decal 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-deferred-light 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-fxaa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-gbuffer 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-hiz 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-hlfs 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-indirect-dispatch 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-light-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-occlusion-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-perf-overlay 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-planar-reflection 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-postprocess 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-radiance-cascades 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-shadow 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-shadow-cull 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-shadow-dirty 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-shadow-matrix 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-simple-cube 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-sky 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-sky-lut 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-ssr 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-taa 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-transparent 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-virtual-geometry 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-volumetric-fog 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-voxel-mesh 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-pass-water-sim 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "image",
  "wgpu",
 ]
@@ -4699,11 +4699,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4721,11 +4721,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4743,11 +4743,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4766,11 +4766,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "wgpu",
 ]
@@ -4789,11 +4789,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4811,11 +4811,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4835,12 +4835,12 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "wgpu",
 ]
@@ -4860,11 +4860,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "wgpu",
 ]
@@ -4884,12 +4884,12 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4907,11 +4907,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4929,11 +4929,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4951,11 +4951,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4973,11 +4973,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -4996,11 +4996,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "wgpu",
 ]
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
  "helio-planet-voxel-core",
@@ -5030,11 +5030,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5052,11 +5052,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5075,11 +5075,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "wgpu",
 ]
@@ -5098,11 +5098,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5120,11 +5120,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5142,11 +5142,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5165,11 +5165,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "wgpu",
 ]
@@ -5188,11 +5188,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5210,11 +5210,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5232,11 +5232,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5254,11 +5254,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-taa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5276,11 +5276,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5299,11 +5299,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "wgpu",
 ]
@@ -5322,11 +5322,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
@@ -5347,13 +5347,13 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-voxel-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-voxel-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "log",
  "wgpu",
 ]
@@ -5372,18 +5372,18 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
- "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio-core 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "libhelio 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5401,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -6355,7 +6355,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354#b4a8430c0a8f6d60c6227cd13ece1f1b74355354"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8#2b948b625bdf4227de778089782624a5fc900bd8"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -8942,7 +8942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -8961,7 +8961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9229,8 +9229,8 @@ version = "0.1.0"
 dependencies = [
  "engine_state",
  "glam 0.33.2",
- "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
- "helio-default-graphs 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
+ "helio-default-graphs 0.1.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "pbgc",
  "pollster 1.0.1",
  "profiling 0.1.0",
@@ -9344,7 +9344,7 @@ dependencies = [
  "engine_subsystems",
  "glam 0.33.2",
  "gpui-ce",
- "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "helio-asset-compat",
  "helio-pass-planetary-voxel",
  "helio-planet-voxel-core",
@@ -9369,7 +9369,7 @@ version = "0.1.0"
 dependencies = [
  "engine_fs",
  "glam 0.33.2",
- "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b4a8430c0a8f6d60c6227cd13ece1f1b74355354)",
+ "helio 0.18.0 (git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2b948b625bdf4227de778089782624a5fc900bd8)",
  "helio-asset-compat",
  "pulsar_events",
  "pulsar_reflection",
@@ -12136,7 +12136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,12 +142,12 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b4a8430c0a8f6d60c6227cd13ece1f1b74355354" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b4a8430c0a8f6d60c6227cd13ece1f1b74355354" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b4a8430c0a8f6d60c6227cd13ece1f1b74355354" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b4a8430c0a8f6d60c6227cd13ece1f1b74355354" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b4a8430c0a8f6d60c6227cd13ece1f1b74355354" }
-helio-pass-taa             = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b4a8430c0a8f6d60c6227cd13ece1f1b74355354" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2b948b625bdf4227de778089782624a5fc900bd8" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2b948b625bdf4227de778089782624a5fc900bd8" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2b948b625bdf4227de778089782624a5fc900bd8" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2b948b625bdf4227de778089782624a5fc900bd8" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2b948b625bdf4227de778089782624a5fc900bd8" }
+helio-pass-taa             = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2b948b625bdf4227de778089782624a5fc900bd8" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/crates/core/engine_backend/src/services/gpu_renderer.rs
+++ b/crates/core/engine_backend/src/services/gpu_renderer.rs
@@ -5,7 +5,9 @@
 //! WgpuSurface is available.
 
 use crate::scene::SceneDb;
-use crate::subsystems::render::{EditorCameraState, HelioRenderer, RenderMetrics};
+use crate::subsystems::render::{
+    EditorCameraState, HelioRenderer, RenderMetrics, RenderSpikeLogConfig,
+};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -111,6 +113,18 @@ impl GpuRenderer {
         self.helio_renderer
             .as_ref()
             .map(|r| r.get_gpu_profiler_data())
+    }
+
+    pub fn set_spike_log_config(&mut self, config: RenderSpikeLogConfig) {
+        if let Some(renderer) = self.helio_renderer.as_mut() {
+            renderer.set_spike_log_config(config);
+        }
+    }
+
+    pub fn spike_log_config(&self) -> Option<RenderSpikeLogConfig> {
+        self.helio_renderer
+            .as_ref()
+            .map(HelioRenderer::spike_log_config)
     }
 
     pub fn get_frame_count(&self) -> u64 {
@@ -253,3 +267,25 @@ impl GpuRenderer {
 
 unsafe impl Send for GpuRenderer {}
 unsafe impl Sync for GpuRenderer {}
+
+#[cfg(test)]
+mod tests {
+    use super::GpuRendererBuilder;
+    use crate::subsystems::render::RenderSpikeLogConfig;
+    use std::time::Duration;
+
+    #[test]
+    fn spike_log_config_is_available_through_the_public_renderer_service() {
+        let mut renderer = GpuRendererBuilder::new(1, 1).build();
+        let config = RenderSpikeLogConfig {
+            enabled: true,
+            cpu_threshold_ms: 18.0,
+            gpu_threshold_ms: 12.0,
+            min_interval: Duration::from_millis(125),
+        };
+
+        renderer.set_spike_log_config(config);
+
+        assert_eq!(renderer.spike_log_config(), Some(config));
+    }
+}

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/core/mod.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/core/mod.rs
@@ -3,4 +3,6 @@
 
 pub mod types;
 
-pub use types::{CameraInput, DiagnosticMetric, GpuProfilerData, RenderMetrics};
+pub use types::{
+    CameraInput, DiagnosticMetric, GpuProfilerAvailability, GpuProfilerData, RenderMetrics,
+};

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/core/mod.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/core/mod.rs
@@ -5,4 +5,5 @@ pub mod types;
 
 pub use types::{
     CameraInput, DiagnosticMetric, GpuProfilerAvailability, GpuProfilerData, RenderMetrics,
+    RenderSpikeLogConfig,
 };

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/core/types.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/core/types.rs
@@ -17,21 +17,79 @@ pub struct RenderMetrics {
 /// Represents a single diagnostic metric for GPU profiling
 #[derive(Debug, Clone)]
 pub struct DiagnosticMetric {
-    pub name: String,
-    pub path: String,
-    pub value_ms: f32,
-    pub percentage: f32,
-    pub is_gpu: bool,
+    pub name: &'static str,
+    pub cpu_ms: Option<f32>,
+    pub gpu_ms: Option<f32>,
+}
+
+/// Availability of asynchronous GPU timestamp data.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum GpuProfilerAvailability {
+    Disabled,
+    Unsupported,
+    #[default]
+    Pending,
+    Available,
+    Backpressured,
 }
 
 /// GPU Pipeline profiling data
 #[derive(Debug, Clone, Default)]
 pub struct GpuProfilerData {
-    pub total_frame_ms: f32,
-    pub fps: f32,
     pub frame_count: u64,
-    pub total_gpu_ms: f32,
+    pub gpu_frame_count: Option<u64>,
+    pub gpu_lag_frames: Option<u64>,
+    pub availability: GpuProfilerAvailability,
+    pub total_cpu_ms: Option<f32>,
+    pub total_gpu_ms: Option<f32>,
+    pub readback_drops: u64,
+    pub query_overflows: u64,
     pub render_metrics: Vec<DiagnosticMetric>,
+}
+
+impl GpuProfilerData {
+    /// Refresh this reusable host-side cache from Helio's read-only snapshot.
+    ///
+    /// The pass vector keeps its capacity between frames and pass names are
+    /// static, so steady-state collection does not allocate or poll the GPU.
+    pub fn update_from_snapshot(&mut self, snapshot: &helio::RenderTimingSnapshot) {
+        self.frame_count = snapshot.cpu_frame_index;
+        self.gpu_frame_count = snapshot.gpu_frame_index;
+        self.gpu_lag_frames = snapshot.gpu_lag_frames;
+        self.availability = match snapshot.gpu_availability {
+            helio::GpuTimingAvailability::Disabled => GpuProfilerAvailability::Disabled,
+            helio::GpuTimingAvailability::Unsupported => GpuProfilerAvailability::Unsupported,
+            helio::GpuTimingAvailability::Pending => GpuProfilerAvailability::Pending,
+            helio::GpuTimingAvailability::Available => GpuProfilerAvailability::Available,
+            helio::GpuTimingAvailability::Backpressured => GpuProfilerAvailability::Backpressured,
+        };
+        self.total_cpu_ms = snapshot.total_cpu_ms;
+        self.total_gpu_ms = snapshot.total_gpu_ms;
+        self.readback_drops = snapshot.readback_drops;
+        self.query_overflows = snapshot.query_overflows;
+
+        self.render_metrics.clear();
+        self.render_metrics
+            .extend(snapshot.passes.iter().map(|pass| DiagnosticMetric {
+                name: pass.name,
+                cpu_ms: pass.cpu_ms,
+                gpu_ms: pass.gpu_ms,
+            }));
+    }
+
+    pub fn slowest_cpu_pass(&self) -> Option<(&'static str, f32)> {
+        self.render_metrics
+            .iter()
+            .filter_map(|metric| metric.cpu_ms.map(|time| (metric.name, time)))
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
+    }
+
+    pub fn slowest_gpu_pass(&self) -> Option<(&'static str, f32)> {
+        self.render_metrics
+            .iter()
+            .filter_map(|metric| metric.gpu_ms.map(|time| (metric.name, time)))
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
+    }
 }
 
 /// Camera controller input state
@@ -103,5 +161,87 @@ impl CameraInput {
     pub fn accumulate_pan_delta(&mut self, dx: f32, dy: f32) {
         self.pan_delta_x += dx;
         self.pan_delta_y += dy;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GpuProfilerAvailability, GpuProfilerData};
+
+    #[test]
+    fn timing_snapshot_bridge_preserves_pass_order_and_unavailable_gpu_state() {
+        let snapshot = helio::RenderTimingSnapshot {
+            generation: 4,
+            cpu_frame_index: 18,
+            gpu_frame_index: None,
+            gpu_lag_frames: None,
+            gpu_availability: helio::GpuTimingAvailability::Unsupported,
+            total_cpu_ms: Some(7.0),
+            total_gpu_ms: None,
+            readback_drops: 0,
+            query_overflows: 1,
+            passes: vec![
+                helio::RenderPassTiming {
+                    name: "Prepare",
+                    cpu_ms: Some(2.0),
+                    gpu_ms: None,
+                },
+                helio::RenderPassTiming {
+                    name: "Draw",
+                    cpu_ms: Some(5.0),
+                    gpu_ms: None,
+                },
+            ],
+        };
+
+        let mut data = GpuProfilerData::default();
+        data.update_from_snapshot(&snapshot);
+
+        assert_eq!(data.availability, GpuProfilerAvailability::Unsupported);
+        assert_eq!(data.query_overflows, 1);
+        assert_eq!(
+            data.render_metrics
+                .iter()
+                .map(|metric| metric.name)
+                .collect::<Vec<_>>(),
+            ["Prepare", "Draw"]
+        );
+        assert_eq!(data.slowest_cpu_pass(), Some(("Draw", 5.0)));
+        assert_eq!(data.slowest_gpu_pass(), None);
+    }
+
+    #[test]
+    fn timing_snapshot_bridge_attributes_delayed_gpu_spike() {
+        let snapshot = helio::RenderTimingSnapshot {
+            generation: 7,
+            cpu_frame_index: 21,
+            gpu_frame_index: Some(19),
+            gpu_lag_frames: Some(2),
+            gpu_availability: helio::GpuTimingAvailability::Available,
+            total_cpu_ms: Some(1.0),
+            total_gpu_ms: Some(44.0),
+            readback_drops: 2,
+            query_overflows: 0,
+            passes: vec![
+                helio::RenderPassTiming {
+                    name: "FastPass",
+                    cpu_ms: Some(0.5),
+                    gpu_ms: Some(4.0),
+                },
+                helio::RenderPassTiming {
+                    name: "ForcedSlowPass",
+                    cpu_ms: Some(0.5),
+                    gpu_ms: Some(40.0),
+                },
+            ],
+        };
+
+        let mut data = GpuProfilerData::default();
+        data.update_from_snapshot(&snapshot);
+
+        assert_eq!(data.gpu_frame_count, Some(19));
+        assert_eq!(data.gpu_lag_frames, Some(2));
+        assert_eq!(data.readback_drops, 2);
+        assert_eq!(data.slowest_gpu_pass(), Some(("ForcedSlowPass", 40.0)));
     }
 }

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/core/types.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/core/types.rs
@@ -1,6 +1,7 @@
 //! Core data types for the Helio renderer
 
 use glam::Vec3;
+use std::time::Duration;
 
 /// Rendering metrics
 #[derive(Debug, Clone, Default)]
@@ -45,6 +46,29 @@ pub struct GpuProfilerData {
     pub readback_drops: u64,
     pub query_overflows: u64,
     pub render_metrics: Vec<DiagnosticMetric>,
+}
+
+/// Runtime policy for lightweight frame-spike warning logs.
+///
+/// This remains separate from WGPUI's opt-in deep capture profiler: callers
+/// can tune cheap continuous diagnostics without enabling full frame capture.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RenderSpikeLogConfig {
+    pub enabled: bool,
+    pub cpu_threshold_ms: f32,
+    pub gpu_threshold_ms: f32,
+    pub min_interval: Duration,
+}
+
+impl Default for RenderSpikeLogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cpu_threshold_ms: 50.0,
+            gpu_threshold_ms: 50.0,
+            min_interval: Duration::from_secs(1),
+        }
+    }
 }
 
 impl GpuProfilerData {
@@ -166,7 +190,27 @@ impl CameraInput {
 
 #[cfg(test)]
 mod tests {
-    use super::{GpuProfilerAvailability, GpuProfilerData};
+    use super::{GpuProfilerAvailability, GpuProfilerData, RenderSpikeLogConfig};
+    use std::time::Duration;
+
+    #[test]
+    fn spike_log_defaults_are_runtime_configurable() {
+        let defaults = RenderSpikeLogConfig::default();
+        assert!(defaults.enabled);
+        assert_eq!(defaults.cpu_threshold_ms, 50.0);
+        assert_eq!(defaults.gpu_threshold_ms, 50.0);
+        assert_eq!(defaults.min_interval, Duration::from_secs(1));
+
+        let granular = RenderSpikeLogConfig {
+            cpu_threshold_ms: 20.0,
+            gpu_threshold_ms: 12.0,
+            min_interval: Duration::from_millis(100),
+            ..defaults
+        };
+        assert_eq!(granular.cpu_threshold_ms, 20.0);
+        assert_eq!(granular.gpu_threshold_ms, 12.0);
+        assert_eq!(granular.min_interval, Duration::from_millis(100));
+    }
 
     #[test]
     fn timing_snapshot_bridge_preserves_pass_order_and_unavailable_gpu_state() {

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/mod.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/mod.rs
@@ -3,7 +3,9 @@
 pub mod core;
 pub mod renderer;
 
-pub use core::{CameraInput, DiagnosticMetric, GpuProfilerData, RenderMetrics};
+pub use core::{
+    CameraInput, DiagnosticMetric, GpuProfilerAvailability, GpuProfilerData, RenderMetrics,
+};
 pub use renderer::{EditorCameraState, HelioRenderer, RendererCommand};
 
 pub const RENDER_WIDTH: u32 = 1600;

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/mod.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/mod.rs
@@ -5,6 +5,7 @@ pub mod renderer;
 
 pub use core::{
     CameraInput, DiagnosticMetric, GpuProfilerAvailability, GpuProfilerData, RenderMetrics,
+    RenderSpikeLogConfig,
 };
 pub use renderer::{EditorCameraState, HelioRenderer, RendererCommand};
 

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
@@ -3,8 +3,8 @@
 use glam::{EulerRot, Mat4, Quat, Vec3};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, mpsc};
-use std::time::Instant;
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use engine_fs::virtual_fs;
 use helio::{
@@ -14,8 +14,8 @@ use helio::{
 };
 use pulsar_events::script_registry;
 use pulsar_reflection::{
-    ComponentRuntimeContext, LiveKeySet, RuntimeComponentOwner, Subsystems,
-    apply_runtime_behavior_for_class, scene_id_to_tag,
+    apply_runtime_behavior_for_class, scene_id_to_tag, ComponentRuntimeContext, LiveKeySet,
+    RuntimeComponentOwner, Subsystems,
 };
 use pulsar_rendering::subsystems::{MeshCache, SceneObjectCache};
 use pulsar_scene::{build_transform_parts, component_instances_from_props};
@@ -26,6 +26,9 @@ use crate::scene::{
 use helio_pass_taa::TaaPass;
 
 use super::core::{CameraInput, GpuProfilerData, RenderMetrics};
+
+const FRAME_SPIKE_THRESHOLD_MS: f32 = 50.0;
+const SPIKE_WARNING_INTERVAL: Duration = Duration::from_secs(1);
 
 // ── Legacy types (unused but referenced by UI code) ──────────────────────────
 
@@ -85,9 +88,11 @@ pub struct HelioRenderer {
 
     // ── Metrics ──
     pub metrics: Arc<Mutex<RenderMetrics>>,
-    pub gpu_profiler: Arc<Mutex<GpuProfilerData>>,
+    pub gpu_profiler: GpuProfilerData,
     last_frame: Instant,
     frame_count: u64,
+    last_spike_warning: Option<Instant>,
+    last_reported_gpu_frame: Option<u64>,
 }
 
 struct HelioInner {
@@ -129,9 +134,11 @@ impl HelioRenderer {
             cam_local_velocity: Vec3::ZERO,
             viewport_size: (0, 0),
             metrics: Arc::new(Mutex::new(RenderMetrics::default())),
-            gpu_profiler: Arc::new(Mutex::new(GpuProfilerData::default())),
+            gpu_profiler: GpuProfilerData::default(),
             last_frame: Instant::now(),
             frame_count: 0,
+            last_spike_warning: None,
+            last_reported_gpu_frame: None,
         }
     }
 
@@ -341,24 +348,62 @@ impl HelioRenderer {
 
         let prepare_ms = t_prepare.elapsed().as_secs_f64() * 1000.0;
         let t_render = Instant::now();
-        let mut submission_index: Option<wgpu::SubmissionIndex> = None;
-        {
+        let submission_index = {
             profiling::profile_scope!("helio_render_submit");
             if let Err(e) = inner.renderer.render(&camera, &view) {
                 tracing::error!("Helio render error: {:?}", e);
             }
-            submission_index = Some(inner.queue.submit(std::iter::empty::<wgpu::CommandBuffer>()));
-        }
+            Some(inner.queue.submit(std::iter::empty::<wgpu::CommandBuffer>()))
+        };
         let render_ms = t_render.elapsed().as_secs_f64() * 1000.0;
-        let frame_ms = frame_start.elapsed().as_secs_f64() * 1000.0;
-        if frame_ms > 50.0 {
+        let frame_ms = frame_start.elapsed().as_secs_f32() * 1_000.0;
+
+        self.gpu_profiler
+            .update_from_snapshot(inner.renderer.timing_snapshot());
+
+        let gpu_frame = self.gpu_profiler.gpu_frame_count;
+        let new_gpu_result = gpu_frame.is_some() && gpu_frame != self.last_reported_gpu_frame;
+        let gpu_spike = new_gpu_result
+            && self
+                .gpu_profiler
+                .total_gpu_ms
+                .is_some_and(|time| time > FRAME_SPIKE_THRESHOLD_MS);
+        let cpu_spike = frame_ms > FRAME_SPIKE_THRESHOLD_MS;
+        let warning_due = self
+            .last_spike_warning
+            .is_none_or(|last| last.elapsed() >= SPIKE_WARNING_INTERVAL);
+
+        if warning_due && (cpu_spike || gpu_spike) {
+            let (cpu_pass, cpu_pass_ms) = self
+                .gpu_profiler
+                .slowest_cpu_pass()
+                .unwrap_or(("unavailable", 0.0));
+            let (gpu_pass, gpu_pass_ms) = self
+                .gpu_profiler
+                .slowest_gpu_pass()
+                .unwrap_or(("pending", 0.0));
             tracing::warn!(
-                "[HELIO FRAME] {:.1}ms (sync {:.1}, prepare {:.1}, submit {:.1})",
+                "[HELIO FRAME SPIKE] frame={:.1}ms (sync {:.1}, prepare {:.1}, submit {:.1}); \
+                 slowest CPU pass={} {:.1}ms; GPU frame={:?} total={:?}ms lag={:?} \
+                 slowest pass={} {:.1}ms drops={} overflows={}",
                 frame_ms,
                 sync_ms,
                 prepare_ms,
-                render_ms
+                render_ms,
+                cpu_pass,
+                cpu_pass_ms,
+                gpu_frame,
+                self.gpu_profiler.total_gpu_ms,
+                self.gpu_profiler.gpu_lag_frames,
+                gpu_pass,
+                gpu_pass_ms,
+                self.gpu_profiler.readback_drops,
+                self.gpu_profiler.query_overflows
             );
+            self.last_spike_warning = Some(Instant::now());
+        }
+        if new_gpu_result {
+            self.last_reported_gpu_frame = gpu_frame;
         }
 
         if let Ok(mut m) = self.metrics.lock() {
@@ -448,10 +493,7 @@ impl HelioRenderer {
     }
 
     pub fn get_gpu_profiler_data(&self) -> GpuProfilerData {
-        self.gpu_profiler
-            .lock()
-            .map(|m| m.clone())
-            .unwrap_or_default()
+        self.gpu_profiler.clone()
     }
 
     // ── Editor Integration ───────────────────────────────────────────────────

--- a/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
+++ b/crates/core/engine_backend/src/subsystems/render/helio_renderer/renderer.rs
@@ -4,7 +4,7 @@ use glam::{EulerRot, Mat4, Quat, Vec3};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use engine_fs::virtual_fs;
 use helio::{
@@ -25,10 +25,7 @@ use crate::scene::{
 };
 use helio_pass_taa::TaaPass;
 
-use super::core::{CameraInput, GpuProfilerData, RenderMetrics};
-
-const FRAME_SPIKE_THRESHOLD_MS: f32 = 50.0;
-const SPIKE_WARNING_INTERVAL: Duration = Duration::from_secs(1);
+use super::core::{CameraInput, GpuProfilerData, RenderMetrics, RenderSpikeLogConfig};
 
 // ── Legacy types (unused but referenced by UI code) ──────────────────────────
 
@@ -91,6 +88,7 @@ pub struct HelioRenderer {
     pub gpu_profiler: GpuProfilerData,
     last_frame: Instant,
     frame_count: u64,
+    spike_log_config: RenderSpikeLogConfig,
     last_spike_warning: Option<Instant>,
     last_reported_gpu_frame: Option<u64>,
 }
@@ -137,6 +135,7 @@ impl HelioRenderer {
             gpu_profiler: GpuProfilerData::default(),
             last_frame: Instant::now(),
             frame_count: 0,
+            spike_log_config: RenderSpikeLogConfig::default(),
             last_spike_warning: None,
             last_reported_gpu_frame: None,
         }
@@ -162,6 +161,17 @@ impl HelioRenderer {
             input.up = 0.0;
             input.clear_transient_deltas();
         }
+    }
+
+    /// Configure cheap frame-spike warning cadence independently from deep
+    /// WGPUI capture. Disabling this affects only warning logs.
+    pub fn set_spike_log_config(&mut self, config: RenderSpikeLogConfig) {
+        self.spike_log_config = config;
+        self.last_spike_warning = None;
+    }
+
+    pub fn spike_log_config(&self) -> RenderSpikeLogConfig {
+        self.spike_log_config
     }
 
     /// Called each GPUI frame from the viewport.
@@ -367,11 +377,12 @@ impl HelioRenderer {
             && self
                 .gpu_profiler
                 .total_gpu_ms
-                .is_some_and(|time| time > FRAME_SPIKE_THRESHOLD_MS);
-        let cpu_spike = frame_ms > FRAME_SPIKE_THRESHOLD_MS;
-        let warning_due = self
-            .last_spike_warning
-            .is_none_or(|last| last.elapsed() >= SPIKE_WARNING_INTERVAL);
+                .is_some_and(|time| time > self.spike_log_config.gpu_threshold_ms);
+        let cpu_spike = frame_ms > self.spike_log_config.cpu_threshold_ms;
+        let warning_due = self.spike_log_config.enabled
+            && self
+                .last_spike_warning
+                .is_none_or(|last| last.elapsed() >= self.spike_log_config.min_interval);
 
         if warning_due && (cpu_spike || gpu_spike) {
             let (cpu_pass, cpu_pass_ms) = self

--- a/crates/core/engine_backend/src/subsystems/render/mod.rs
+++ b/crates/core/engine_backend/src/subsystems/render/mod.rs
@@ -6,7 +6,7 @@ pub mod helio_renderer;
 pub use handle_utils::{handle_to_usize, usize_to_handle};
 pub use helio_renderer::{
     CameraInput, EditorCameraState, GpuProfilerAvailability, GpuProfilerData, HelioRenderer,
-    RenderMetrics,
+    RenderMetrics, RenderSpikeLogConfig,
 };
 // pub use native_texture::{NativeTextureHandle, SharedTextureInfo, TextureFormat};
 

--- a/crates/core/engine_backend/src/subsystems/render/mod.rs
+++ b/crates/core/engine_backend/src/subsystems/render/mod.rs
@@ -5,7 +5,8 @@ pub mod helio_renderer;
 
 pub use handle_utils::{handle_to_usize, usize_to_handle};
 pub use helio_renderer::{
-    CameraInput, EditorCameraState, GpuProfilerData, HelioRenderer, RenderMetrics,
+    CameraInput, EditorCameraState, GpuProfilerAvailability, GpuProfilerData, HelioRenderer,
+    RenderMetrics,
 };
 // pub use native_texture::{NativeTextureHandle, SharedTextureInfo, TextureFormat};
 

--- a/crates/editor/ui_level_editor/src/level_editor/ui/viewport/components/gpu_pipeline_overlay.rs
+++ b/crates/editor/ui_level_editor/src/level_editor/ui/viewport/components/gpu_pipeline_overlay.rs
@@ -1,4 +1,4 @@
-//! GPU pipeline statistics overlay component.
+//! Render pipeline timing overlay component.
 
 use std::sync::{Arc, Mutex};
 
@@ -7,36 +7,52 @@ use gpui::*;
 use ui::{h_flex, v_flex, ActiveTheme, StyledExt};
 
 use crate::level_editor::state::LevelEditorState;
-use engine_backend::subsystems::render::helio_renderer::DiagnosticMetric;
+use engine_backend::subsystems::render::helio_renderer::{
+    DiagnosticMetric, GpuProfilerAvailability,
+};
 
-/// Color palette for pipeline passes
 const PASS_COLORS: &[(f32, f32, f32)] = &[
-    (0.4, 0.7, 1.0), // Light blue
-    (1.0, 0.6, 0.4), // Orange
-    (0.6, 1.0, 0.6), // Light green
-    (1.0, 0.8, 0.4), // Yellow
-    (0.8, 0.6, 1.0), // Purple
-    (1.0, 0.6, 0.8), // Pink
-    (0.6, 0.9, 1.0), // Cyan
-    (1.0, 0.9, 0.6), // Light yellow
+    (0.4, 0.7, 1.0),
+    (1.0, 0.6, 0.4),
+    (0.6, 1.0, 0.6),
+    (1.0, 0.8, 0.4),
+    (0.8, 0.6, 1.0),
+    (1.0, 0.6, 0.8),
+    (0.6, 0.9, 1.0),
+    (1.0, 0.9, 0.6),
 ];
 
-/// Render the GPU pipeline overlay with fixed-width columns.
+fn time_label(time_ms: Option<f32>) -> String {
+    time_ms
+        .map(|time| format!("{time:.2}ms"))
+        .unwrap_or_else(|| "—".to_owned())
+}
+
+fn timing_color(time_ms: Option<f32>, success: Hsla, warning: Hsla, danger: Hsla) -> Hsla {
+    match time_ms {
+        Some(time) if time < 8.0 => success,
+        Some(time) if time < 16.0 => warning,
+        Some(_) => danger,
+        None => warning,
+    }
+}
+
+/// Render the latest non-blocking Helio pass timings.
 pub fn render_gpu_pipeline_overlay<V>(
-    state: &LevelEditorState,
-    state_arc: Arc<parking_lot::RwLock<LevelEditorState>>,
+    _state: &LevelEditorState,
+    _state_arc: Arc<parking_lot::RwLock<LevelEditorState>>,
     gpu_engine: &Arc<Mutex<engine_backend::services::gpu_renderer::GpuRenderer>>,
     cx: &mut Context<V>,
 ) -> impl IntoElement
 where
     V: 'static + EventEmitter<ui::dock::PanelEvent> + Render,
 {
-    // Get GPU profiler data
-    let gpu_data = if let Ok(engine) = gpu_engine.lock() {
-        engine.get_gpu_profiler_data()
-    } else {
-        None
-    };
+    // Cloning is deliberately conditional on the overlay being visible. The
+    // render thread itself updates a reusable cache without allocating.
+    let profiler_data = gpu_engine
+        .try_lock()
+        .ok()
+        .and_then(|engine| engine.get_gpu_profiler_data());
 
     let (background, border, foreground, muted, success, warning, danger) = {
         let theme = cx.theme();
@@ -54,48 +70,59 @@ where
     v_flex()
         .gap_2()
         .p_3()
-        .w(px(340.0))
+        .w(px(410.0))
         .bg(background.opacity(0.95))
         .rounded_lg()
         .border_1()
         .border_color(border)
         .shadow_lg()
         .child(
-            // Header
-            div()
-                .text_sm()
-                .font_weight(FontWeight::SEMIBOLD)
-                .text_color(foreground)
-                .child("GPU Pipeline"),
+            h_flex()
+                .w_full()
+                .justify_between()
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(foreground)
+                        .child("Render Pipeline"),
+                )
+                .when_some(profiler_data.as_ref(), |header, data| {
+                    let (label, color) = match data.availability {
+                        GpuProfilerAvailability::Disabled => ("GPU disabled", muted),
+                        GpuProfilerAvailability::Unsupported => ("GPU unsupported", warning),
+                        GpuProfilerAvailability::Pending => ("GPU pending", warning),
+                        GpuProfilerAvailability::Available => ("GPU available", success),
+                        GpuProfilerAvailability::Backpressured => ("GPU backpressured", danger),
+                    };
+                    header.child(div().text_xs().text_color(color).child(label))
+                }),
         )
         .child(div().w_full().h(px(1.0)).bg(border))
         .map(|this| {
-            if let Some(ref data) = gpu_data {
-                // Calculate passes and percentages
+            if let Some(ref data) = profiler_data {
                 let mut render_passes: Vec<&DiagnosticMetric> = data
                     .render_metrics
                     .iter()
-                    .filter(|metric| metric.is_gpu && metric.value_ms > 0.0)
+                    .filter(|metric| metric.cpu_ms.is_some() || metric.gpu_ms.is_some())
                     .collect();
-
                 render_passes.sort_by(|a, b| {
-                    b.value_ms
-                        .partial_cmp(&a.value_ms)
-                        .unwrap_or(std::cmp::Ordering::Equal)
+                    let a_time = a.gpu_ms.or(a.cpu_ms).unwrap_or_default();
+                    let b_time = b.gpu_ms.or(b.cpu_ms).unwrap_or_default();
+                    b_time.total_cmp(&a_time)
                 });
 
                 this.child(
                     v_flex()
                         .gap_1()
                         .child(
-                            // Column headers
                             h_flex()
                                 .w_full()
                                 .items_center()
                                 .child(div().w(px(16.0)).flex_none())
                                 .child(
                                     div()
-                                        .w(px(180.0))
+                                        .w(px(210.0))
                                         .flex_none()
                                         .text_xs()
                                         .font_weight(FontWeight::SEMIBOLD)
@@ -104,27 +131,26 @@ where
                                 )
                                 .child(
                                     div()
-                                        .w(px(60.0))
+                                        .w(px(65.0))
                                         .flex_none()
                                         .text_right()
                                         .text_xs()
                                         .font_weight(FontWeight::SEMIBOLD)
                                         .text_color(muted)
-                                        .child("Time"),
+                                        .child("CPU"),
                                 )
                                 .child(
                                     div()
-                                        .w(px(50.0))
+                                        .w(px(65.0))
                                         .flex_none()
                                         .text_right()
                                         .text_xs()
                                         .font_weight(FontWeight::SEMIBOLD)
                                         .text_color(muted)
-                                        .child("%"),
+                                        .child("GPU"),
                                 ),
                         )
                         .child(
-                            // Scrollable pass list
                             div()
                                 .id("gpu-pass-list")
                                 .w_full()
@@ -132,147 +158,111 @@ where
                                 .scrollable(gpui::Axis::Vertical)
                                 .occlude()
                                 .child(v_flex().gap_0p5().children(
-                                    render_passes.iter().enumerate().map(|(i, metric)| {
-                                        let color_idx = i % PASS_COLORS.len();
-                                        let (r, g, b) = PASS_COLORS[color_idx];
-                                        let color = hsla(r, g, b, 1.0);
-                                        let percent = metric.percentage;
-
+                                    render_passes.iter().enumerate().map(|(index, metric)| {
+                                        let (r, g, b) = PASS_COLORS[index % PASS_COLORS.len()];
                                         h_flex()
                                             .w_full()
                                             .items_center()
                                             .child(
-                                                // Color indicator
                                                 div().w(px(16.0)).flex_none().child(
                                                     div()
                                                         .w(px(8.0))
                                                         .h(px(8.0))
                                                         .rounded(px(2.0))
-                                                        .bg(color),
+                                                        .bg(hsla(r, g, b, 1.0)),
                                                 ),
                                             )
                                             .child(
-                                                // Pass name
                                                 div()
-                                                    .w(px(180.0))
+                                                    .w(px(210.0))
                                                     .flex_none()
                                                     .overflow_hidden()
                                                     .text_xs()
                                                     .text_color(muted)
                                                     .line_height(relative(1.0))
                                                     .whitespace_nowrap()
-                                                    .child(metric.name.clone()),
+                                                    .child(metric.name),
                                             )
                                             .child(
-                                                // Time
                                                 div()
-                                                    .w(px(60.0))
+                                                    .w(px(65.0))
                                                     .flex_none()
                                                     .text_right()
                                                     .text_xs()
                                                     .text_color(foreground)
-                                                    .child(format!("{:.2}ms", metric.value_ms)),
+                                                    .child(time_label(metric.cpu_ms)),
                                             )
                                             .child(
-                                                // Percentage
                                                 div()
-                                                    .w(px(50.0))
+                                                    .w(px(65.0))
                                                     .flex_none()
                                                     .text_right()
                                                     .text_xs()
-                                                    .text_color(muted)
-                                                    .child(format!("{:.1}%", percent)),
+                                                    .text_color(foreground)
+                                                    .child(time_label(metric.gpu_ms)),
                                             )
                                     }),
                                 )),
                         )
                         .child(div().w_full().h(px(1.0)).bg(border).mt_1())
                         .child(
-                            // Total GPU row
                             h_flex()
                                 .w_full()
                                 .items_center()
                                 .child(div().w(px(16.0)).flex_none())
                                 .child(
                                     div()
-                                        .w(px(180.0))
+                                        .w(px(210.0))
                                         .flex_none()
                                         .text_xs()
                                         .font_weight(FontWeight::SEMIBOLD)
                                         .text_color(foreground)
-                                        .child("Total GPU"),
+                                        .child("Pass totals"),
                                 )
                                 .child(
                                     div()
-                                        .w(px(60.0))
+                                        .w(px(65.0))
                                         .flex_none()
                                         .text_right()
                                         .text_xs()
                                         .font_weight(FontWeight::SEMIBOLD)
-                                        .text_color(if data.total_gpu_ms < 8.0 {
-                                            success
-                                        } else if data.total_gpu_ms < 16.0 {
-                                            warning
-                                        } else {
-                                            danger
-                                        })
-                                        .child(format!("{:.2}ms", data.total_gpu_ms)),
+                                        .text_color(timing_color(
+                                            data.total_cpu_ms,
+                                            success,
+                                            warning,
+                                            danger,
+                                        ))
+                                        .child(time_label(data.total_cpu_ms)),
                                 )
                                 .child(
                                     div()
-                                        .w(px(50.0))
+                                        .w(px(65.0))
                                         .flex_none()
                                         .text_right()
                                         .text_xs()
-                                        .text_color(muted)
-                                        .child("100.0%"),
+                                        .font_weight(FontWeight::SEMIBOLD)
+                                        .text_color(timing_color(
+                                            data.total_gpu_ms,
+                                            success,
+                                            warning,
+                                            danger,
+                                        ))
+                                        .child(time_label(data.total_gpu_ms)),
                                 ),
                         )
                         .child(
-                            // Frame time / FPS row
-                            h_flex()
-                                .w_full()
-                                .items_center()
-                                .child(div().w(px(16.0)).flex_none())
-                                .child(
-                                    div()
-                                        .w(px(180.0))
-                                        .flex_none()
-                                        .text_xs()
-                                        .text_color(muted)
-                                        .child("Frame Time"),
-                                )
-                                .child(
-                                    div()
-                                        .w(px(60.0))
-                                        .flex_none()
-                                        .text_right()
-                                        .text_xs()
-                                        .text_color(foreground)
-                                        .child(format!("{:.2}ms", data.total_gpu_ms)),
-                                )
-                                .child(
-                                    div()
-                                        .w(px(50.0))
-                                        .flex_none()
-                                        .text_right()
-                                        .text_xs()
-                                        .font_weight(FontWeight::SEMIBOLD)
-                                        .text_color({
-                                            let fps = 1000.0 / data.total_gpu_ms.max(0.1);
-                                            if fps > 60.0 {
-                                                success
-                                            } else if fps > 30.0 {
-                                                warning
-                                            } else {
-                                                danger
-                                            }
-                                        })
-                                        .child(format!(
-                                            "{:.0} FPS",
-                                            1000.0 / data.total_gpu_ms.max(0.1)
-                                        )),
-                                ),
+                            div().text_xs().text_color(muted).child(format!(
+                                "CPU frame {} · GPU frame {} · lag {} · drops {} · overflows {}",
+                                data.frame_count,
+                                data.gpu_frame_count
+                                    .map(|frame| frame.to_string())
+                                    .unwrap_or_else(|| "—".to_owned()),
+                                data.gpu_lag_frames
+                                    .map(|lag| lag.to_string())
+                                    .unwrap_or_else(|| "—".to_owned()),
+                                data.readback_drops,
+                                data.query_overflows
+                            )),
                         ),
                 )
             } else {
@@ -280,7 +270,7 @@ where
                     div()
                         .text_xs()
                         .text_color(muted)
-                        .child("No GPU data available"),
+                        .child("Renderer busy; keeping the previous frame responsive"),
                 )
             }
         })


### PR DESCRIPTION
## Summary

- bridge Helio's asynchronous render timing snapshot into Pulsar without polling the shared GPU device
- expose CPU/GPU pass timings, frame attribution, lag, backpressure, and query overflow state in the viewport overlay
- log frame spikes with independently configurable CPU/GPU thresholds and cadence (50 ms / 50 ms / 1 s defaults)
- pin the validated current-Pulsar Helio staging revision containing Helio #123 and #127

## Performance properties

- no device poll or blocking timestamp readback on Pulsar's render thread
- reusable host-side timing storage in the steady state
- overlay uses `try_lock` so diagnostics cannot stall rendering
- lightweight continuous spike diagnostics remain separate from WGPUI's opt-in deep capture work in WGPUI #57 and #64

## Dependency

This PR is stacked on Pulsar #438 so CI and review isolate the render timing work from the Blueprint vendor API mismatch already fixed there. Merge #438 first.

## Validation

- `cargo check -p engine_backend -p ui_level_editor --locked` passes
- `cargo test -p engine_backend timing_snapshot_bridge --lib --locked`: 2 passed
- `cargo test -p engine_backend spike_log_defaults_are_runtime_configurable --lib --locked`: 1 passed
- `cargo test -p engine_backend spike_log_config_is_available_through_the_public_renderer_service --lib --locked`: 1 passed
- Helio core: 15 unit tests passed
- Helio deferred GPU timing integration: 3 passed on the available GPU adapter
- current Pulsar submodule revisions were synchronized before validation

Existing warnings are pre-existing across the editor dependency graph.

## Draft dependency boundary

This remains draft until Helio #123 and #127 land on a durable Helio revision that Pulsar can pin. The current exact pin is a validation/staging commit preserving Pulsar's current Helio lineage; it must not become the permanent integration point.

Advances #461.
