### PR TITLE
Integrate the material shader validation fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10631,6 +10631,7 @@ dependencies = [
  "gpui-ce",
  "graphy",
  "log",
+ "naga",
  "parking_lot",
  "plugin_editor_api",
  "psgc",


### PR DESCRIPTION
Closes #465.

## What changed

- advance the vendored Shader Editor to the material-preview validation fix in Far-Beyond-Pulsar/Plugin_Shaders#8
- record the plugin's direct Naga dependency in Pulsar's locked package graph

Blank fallback vector inputs now use typed shader defaults, generated WGSL is validated before preview compilation, and WGPU validation failures remain contained instead of crashing the editor.

## Landing audit

The mistakenly opened WGPUI #67, WGPUI #69, and Helio #130 PRs were closed without merging, so there is no default-branch code from them to revert. The disclosed and validated #438 integration changes, #464 dependency isolation, and validated rendering-performance work remain unchanged. This corrective PR is intentionally limited to the actual remaining Pulsar integration defect.

## Dependency

This PR pins commit `777375c` from Far-Beyond-Pulsar/Plugin_Shaders#8. Merge the upstream shader PR before this parent integration PR.

## Validation

- `cargo test -p shader_editor_plugin --lib --offline --locked`: 10 passed, 0 failed
- `cargo check -p ui_core --tests --offline --locked`: passed
- lockfile and submodule diff checks: passed

Warnings emitted by the consumer check are pre-existing warnings in vendored/UI code and are outside this two-file change.