### PR TITLE
Configure global Git author identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13263,6 +13263,7 @@ dependencies = [
  "similar 3.1.1",
  "smallvec",
  "smol",
+ "tempfile",
  "ui",
  "ui_common",
  "window_manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13266,6 +13266,7 @@ dependencies = [
  "similar 3.1.1",
  "smallvec",
  "smol",
+ "tempfile",
  "ui",
  "ui_common",
  "window_manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13265,6 +13265,7 @@ dependencies = [
  "similar 3.1.1",
  "smallvec",
  "smol",
+ "tempfile",
  "ui",
  "ui_common",
  "window_manager",

--- a/crates/editor/ui_common/src/menu/mod.rs
+++ b/crates/editor/ui_common/src/menu/mod.rs
@@ -1256,6 +1256,8 @@ pub fn init_app_menus(title: impl Into<SharedString>, cx: &mut App) {
 pub enum AppTitleBarEvent {
     /// User wants to open the multiplayer sessions / friends panel.
     MultiplayerSessionsRequested,
+    /// User wants to edit the global Git author identity.
+    ConfigureGitAuthorRequested,
 }
 
 pub struct AppTitleBar {
@@ -1299,10 +1301,13 @@ impl AppTitleBar {
             ),
             cx.subscribe(
                 &profile_dropdown,
-                |this, _, event: &crate::profile_dropdown::ProfileDropdownEvent, cx| {
+                |_this, _, event: &crate::profile_dropdown::ProfileDropdownEvent, cx| {
                     match event {
                         ProfileDropdownEvent::MultiplayerSessionsRequested => {
                             cx.emit(AppTitleBarEvent::MultiplayerSessionsRequested);
+                        }
+                        ProfileDropdownEvent::ConfigureGitAuthorRequested => {
+                            cx.emit(AppTitleBarEvent::ConfigureGitAuthorRequested);
                         }
                         _ => {}
                     }

--- a/crates/editor/ui_common/src/menu/mod.rs
+++ b/crates/editor/ui_common/src/menu/mod.rs
@@ -1301,7 +1301,7 @@ impl AppTitleBar {
             ),
             cx.subscribe(
                 &profile_dropdown,
-                |_this, _, event: &crate::profile_dropdown::ProfileDropdownEvent, cx| {
+                |this, _, event: &crate::profile_dropdown::ProfileDropdownEvent, cx| {
                     match event {
                         ProfileDropdownEvent::MultiplayerSessionsRequested => {
                             cx.emit(AppTitleBarEvent::MultiplayerSessionsRequested);
@@ -1362,6 +1362,7 @@ impl AppTitleBar {
                                 });
                             })
                             .detach();
+                        }
                         ProfileDropdownEvent::ConfigureGitAuthorRequested => {
                             cx.emit(AppTitleBarEvent::ConfigureGitAuthorRequested);
                         }

--- a/crates/editor/ui_common/src/menu/mod.rs
+++ b/crates/editor/ui_common/src/menu/mod.rs
@@ -1256,6 +1256,8 @@ pub fn init_app_menus(title: impl Into<SharedString>, cx: &mut App) {
 pub enum AppTitleBarEvent {
     /// User wants to open the multiplayer sessions / friends panel.
     MultiplayerSessionsRequested,
+    /// User wants to edit the global Git author identity.
+    ConfigureGitAuthorRequested,
 }
 
 pub struct AppTitleBar {
@@ -1299,7 +1301,7 @@ impl AppTitleBar {
             ),
             cx.subscribe(
                 &profile_dropdown,
-                |this, _, event: &crate::profile_dropdown::ProfileDropdownEvent, cx| {
+                |_this, _, event: &crate::profile_dropdown::ProfileDropdownEvent, cx| {
                     match event {
                         ProfileDropdownEvent::MultiplayerSessionsRequested => {
                             cx.emit(AppTitleBarEvent::MultiplayerSessionsRequested);
@@ -1360,6 +1362,8 @@ impl AppTitleBar {
                                 });
                             })
                             .detach();
+                        ProfileDropdownEvent::ConfigureGitAuthorRequested => {
+                            cx.emit(AppTitleBarEvent::ConfigureGitAuthorRequested);
                         }
                         _ => {}
                     }

--- a/crates/editor/ui_common/src/menu/mod.rs
+++ b/crates/editor/ui_common/src/menu/mod.rs
@@ -1306,6 +1306,7 @@ impl AppTitleBar {
                         ProfileDropdownEvent::MultiplayerSessionsRequested => {
                             cx.emit(AppTitleBarEvent::MultiplayerSessionsRequested);
                         }
+<<<<<<< HEAD
                         ProfileDropdownEvent::SignInRequested => {
                             let Some(client_id) = pulsar_auth::github_client_id_from_env() else {
                                 return;
@@ -1362,6 +1363,8 @@ impl AppTitleBar {
                                 });
                             })
                             .detach();
+=======
+>>>>>>> 686c9e1f0 (configure global Git author identity)
                         ProfileDropdownEvent::ConfigureGitAuthorRequested => {
                             cx.emit(AppTitleBarEvent::ConfigureGitAuthorRequested);
                         }

--- a/crates/editor/ui_common/src/profile_dropdown.rs
+++ b/crates/editor/ui_common/src/profile_dropdown.rs
@@ -18,6 +18,8 @@ pub enum ProfileDropdownEvent {
     SignedOut,
     /// User clicked "Multiplayer Sessions" — parent should open the friends/invite UI.
     MultiplayerSessionsRequested,
+    /// User clicked "Configure Git Author" — parent should open the Git identity UI.
+    ConfigureGitAuthorRequested,
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -314,8 +316,8 @@ impl ProfileDropdown {
                         "Configure Git Author",
                         false,
                         cx.listener(|this, _: &ClickEvent, _, cx| {
-                            // TODO: open git identity settings panel
                             this.is_open = false;
+                            cx.emit(ProfileDropdownEvent::ConfigureGitAuthorRequested);
                             cx.notify();
                         }),
                     )),

--- a/crates/editor/ui_core/src/root.rs
+++ b/crates/editor/ui_core/src/root.rs
@@ -46,12 +46,16 @@ impl EditorWindowShell {
         let title_bar = cx.new(|cx| AppTitleBar::new(title, window, cx));
         let friends_popover = cx.new(|cx| ui_friends::FriendsPopover::new(window, cx));
 
-        let subscriptions = vec![cx.subscribe(
+        let subscriptions = vec![cx.subscribe_in(
             &title_bar,
-            |this, _, event: &AppTitleBarEvent, cx| match event {
+            window,
+            |this, _, event: &AppTitleBarEvent, window, cx| match event {
                 AppTitleBarEvent::MultiplayerSessionsRequested => {
                     this.show_multiplayer = !this.show_multiplayer;
                     cx.notify();
+                }
+                AppTitleBarEvent::ConfigureGitAuthorRequested => {
+                    ui_git_manager::open_git_identity_modal(window, cx);
                 }
             },
         )];

--- a/crates/editor/ui_entry/src/screen/mod.rs
+++ b/crates/editor/ui_entry/src/screen/mod.rs
@@ -31,6 +31,20 @@ impl EntryScreen {
         let inputs = InputEntities::new(window, cx);
         let self_entity = cx.entity().clone();
 
+        cx.subscribe_in(
+            &state.auth.profile_dropdown,
+            window,
+            |_this, _, event: &ui_common::ProfileDropdownEvent, window, cx| {
+                if matches!(
+                    event,
+                    ui_common::ProfileDropdownEvent::ConfigureGitAuthorRequested
+                ) {
+                    ui_git_manager::open_git_identity_modal(window, cx);
+                }
+            },
+        )
+        .detach();
+
         let status = DependencyService::check();
         state.dependency_status = Some(status);
 

--- a/crates/editor/ui_entry/src/screen/mod.rs
+++ b/crates/editor/ui_entry/src/screen/mod.rs
@@ -32,6 +32,20 @@ impl EntryScreen {
         let inputs = InputEntities::new(window, cx);
         let self_entity = cx.entity().clone();
 
+        cx.subscribe_in(
+            &state.auth.profile_dropdown,
+            window,
+            |_this, _, event: &ui_common::ProfileDropdownEvent, window, cx| {
+                if matches!(
+                    event,
+                    ui_common::ProfileDropdownEvent::ConfigureGitAuthorRequested
+                ) {
+                    ui_git_manager::open_git_identity_modal(window, cx);
+                }
+            },
+        )
+        .detach();
+
         let status = DependencyService::check();
         state.dependency_status = Some(status);
 

--- a/crates/editor/ui_entry/src/window.rs
+++ b/crates/editor/ui_entry/src/window.rs
@@ -1,6 +1,7 @@
 use crate::screen::EntryScreen;
 use crate::{FabSearchRequested, GitManagerRequested, ProjectSelected, SettingsRequested};
 use gpui::*;
+use ui::Root;
 
 pub struct EntryWindow {
     screen: Entity<EntryScreen>,
@@ -58,7 +59,11 @@ impl EventEmitter<SettingsRequested> for EntryWindow {}
 impl EventEmitter<FabSearchRequested> for EntryWindow {}
 
 impl Render for EntryWindow {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        self.screen.clone().into_any_element()
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .child(self.screen.clone())
+            .children(Root::render_modal_layer(window, cx))
+            .children(Root::render_notification_layer(window, cx))
     }
 }

--- a/crates/editor/ui_git_manager/Cargo.toml
+++ b/crates/editor/ui_git_manager/Cargo.toml
@@ -21,6 +21,8 @@ image = { workspace = true, features = ["png", "jpeg"] }
 smallvec = { workspace = true }
 smol = { workspace = true }
 
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/editor/ui_git_manager/src/git_identity.rs
+++ b/crates/editor/ui_git_manager/src/git_identity.rs
@@ -1,0 +1,268 @@
+use git2::{Config, ErrorCode};
+use gpui::{
+    App, AppContext as _, Entity, IntoElement, ParentElement as _, Styled as _, Window, div, px,
+};
+use ui::{
+    ContextModal as _,
+    input::{InputState, TextInput},
+    modal::ModalButtonProps,
+    notification::Notification,
+    v_flex,
+};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct GitIdentity {
+    name: String,
+    email: String,
+}
+
+impl GitIdentity {
+    fn from_input(name: &str, email: &str) -> Result<Self, String> {
+        let name = name.trim();
+        let email = email.trim();
+
+        if name.is_empty() || email.is_empty() {
+            return Err("Git name and email are both required.".to_string());
+        }
+
+        Ok(Self {
+            name: name.to_string(),
+            email: email.to_string(),
+        })
+    }
+}
+
+pub fn open_git_identity_modal(window: &mut Window, cx: &mut App) {
+    let identity = match load_global_git_identity() {
+        Ok(identity) => identity,
+        Err(error) => {
+            window.push_notification(
+                Notification::error(error).title("Git identity could not be loaded"),
+                cx,
+            );
+            GitIdentity::default()
+        }
+    };
+
+    let name_input = cx.new(|cx| {
+        InputState::new(window, cx)
+            .placeholder("Your name")
+            .default_value(identity.name)
+    });
+    let email_input = cx.new(|cx| {
+        InputState::new(window, cx)
+            .placeholder("you@example.com")
+            .default_value(identity.email)
+    });
+
+    window.open_modal(cx, move |modal, _window, _cx| {
+        let name_input_for_save = name_input.clone();
+        let email_input_for_save = email_input.clone();
+
+        modal
+            .width(px(480.0))
+            .title("Global Git Identity")
+            .confirm()
+            .button_props(ModalButtonProps::default().ok_text("Save"))
+            .on_ok(move |_, window, cx| {
+                let name = name_input_for_save.read(cx).value().to_string();
+                let email = email_input_for_save.read(cx).value().to_string();
+                let result = GitIdentity::from_input(&name, &email)
+                    .and_then(|identity| save_global_git_identity(&identity));
+
+                match result {
+                    Ok(()) => {
+                        window.push_notification(Notification::success("Git identity saved"), cx);
+                        true
+                    }
+                    Err(error) => {
+                        window.push_notification(
+                            Notification::error(error).title("Git identity was not saved"),
+                            cx,
+                        );
+                        false
+                    }
+                }
+            })
+            .child(
+                v_flex()
+                    .w_full()
+                    .gap_4()
+                    .child(form_field("Name", &name_input))
+                    .child(form_field("Email", &email_input)),
+            )
+    });
+}
+
+fn form_field(label: &'static str, input: &Entity<InputState>) -> impl IntoElement {
+    v_flex()
+        .w_full()
+        .gap_2()
+        .child(
+            div()
+                .text_sm()
+                .font_weight(gpui::FontWeight::MEDIUM)
+                .child(label),
+        )
+        .child(
+            TextInput::new(input)
+                .w_full()
+                .appearance(true)
+                .bordered(true),
+        )
+}
+
+fn load_global_git_identity() -> Result<GitIdentity, String> {
+    let mut config = match Config::open_default() {
+        Ok(config) => config,
+        Err(error) if error.code() == ErrorCode::NotFound => return Ok(GitIdentity::default()),
+        Err(error) => return Err(format!("Failed to open Git configuration: {error}")),
+    };
+    let global = match config.open_global() {
+        Ok(global) => global,
+        Err(error) if error.code() == ErrorCode::NotFound => return Ok(GitIdentity::default()),
+        Err(error) => return Err(format!("Failed to open global Git configuration: {error}")),
+    };
+
+    load_git_identity(&global)
+}
+
+fn save_global_git_identity(identity: &GitIdentity) -> Result<(), String> {
+    let mut config = Config::open_default()
+        .map_err(|error| format!("Failed to open Git configuration: {error}"))?;
+    let mut global = config
+        .open_global()
+        .map_err(|error| format!("Failed to open global Git configuration: {error}"))?;
+
+    save_git_identity(&mut global, identity)
+}
+
+fn load_git_identity(config: &Config) -> Result<GitIdentity, String> {
+    Ok(GitIdentity {
+        name: read_config_value(config, "user.name")?,
+        email: read_config_value(config, "user.email")?,
+    })
+}
+
+fn read_config_value(config: &Config, key: &str) -> Result<String, String> {
+    match config.get_string(key) {
+        Ok(value) => Ok(value),
+        Err(error) if error.code() == ErrorCode::NotFound => Ok(String::new()),
+        Err(error) => Err(format!("Failed to read {key}: {error}")),
+    }
+}
+
+fn save_git_identity(config: &mut Config, identity: &GitIdentity) -> Result<(), String> {
+    config
+        .set_str("user.name", &identity.name)
+        .map_err(|error| format!("Failed to save user.name: {error}"))?;
+    config
+        .set_str("user.email", &identity.email)
+        .map_err(|error| format!("Failed to save user.email: {error}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use super::*;
+    use git2::ConfigLevel;
+
+    fn temporary_config() -> (tempfile::TempDir, PathBuf, Config) {
+        let directory = tempfile::tempdir().expect("create temporary directory");
+        let path = directory.path().join("gitconfig");
+        fs::write(&path, "").expect("create temporary Git config");
+        let config = Config::open(&path).expect("open temporary Git config");
+        (directory, path, config)
+    }
+
+    #[test]
+    fn normalizes_identity_input() {
+        let identity =
+            GitIdentity::from_input("  Jane Doe  ", " jane@example.com\n").expect("valid identity");
+
+        assert_eq!(
+            identity,
+            GitIdentity {
+                name: "Jane Doe".to_string(),
+                email: "jane@example.com".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_blank_identity_fields() {
+        assert!(GitIdentity::from_input("", "jane@example.com").is_err());
+        assert!(GitIdentity::from_input("Jane Doe", "  ").is_err());
+    }
+
+    #[test]
+    fn missing_config_values_load_as_empty_fields() {
+        let (_directory, _path, config) = temporary_config();
+
+        assert_eq!(
+            load_git_identity(&config).expect("load empty identity"),
+            GitIdentity::default()
+        );
+    }
+
+    #[test]
+    fn partial_config_keeps_missing_field_empty() {
+        let (_directory, _path, mut config) = temporary_config();
+        config
+            .set_str("user.name", "Jane Doe")
+            .expect("write Git name");
+
+        assert_eq!(
+            load_git_identity(&config).expect("load partial identity"),
+            GitIdentity {
+                name: "Jane Doe".to_string(),
+                email: String::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn saves_reloads_and_overwrites_identity() {
+        let (_directory, path, mut config) = temporary_config();
+        let first = GitIdentity {
+            name: "Jane Doe".to_string(),
+            email: "jane@example.com".to_string(),
+        };
+        let second = GitIdentity {
+            name: "Janet Doe".to_string(),
+            email: "janet@example.com".to_string(),
+        };
+
+        save_git_identity(&mut config, &first).expect("save first identity");
+        save_git_identity(&mut config, &second).expect("overwrite identity");
+        drop(config);
+
+        let config = Config::open(&path).expect("reopen temporary Git config");
+        assert_eq!(load_git_identity(&config).expect("reload identity"), second);
+    }
+
+    #[test]
+    fn save_creates_config_file_when_missing() {
+        let directory = tempfile::tempdir().expect("create temporary directory");
+        let path = directory.path().join("gitconfig");
+        let mut config = Config::new().expect("create Git config");
+        config
+            .add_file(&path, ConfigLevel::Global, false)
+            .expect("add missing Git config file");
+        let identity = GitIdentity {
+            name: "Jane Doe".to_string(),
+            email: "jane@example.com".to_string(),
+        };
+
+        save_git_identity(&mut config, &identity).expect("save identity");
+        drop(config);
+
+        let config = Config::open(&path).expect("open created Git config");
+        assert_eq!(
+            load_git_identity(&config).expect("reload identity"),
+            identity
+        );
+    }
+}

--- a/crates/editor/ui_git_manager/src/lib.rs
+++ b/crates/editor/ui_git_manager/src/lib.rs
@@ -3,6 +3,7 @@
 //! A GitHub Desktop-like Git manager built with GPUI and the UI crate
 
 mod avatar_loader;
+mod git_identity;
 mod git_operations;
 mod models;
 mod views;
@@ -20,6 +21,7 @@ use ui::{
     v_flex,
 };
 
+pub use git_identity::open_git_identity_modal;
 pub use git_operations::*;
 pub use models::*;
 


### PR DESCRIPTION
## Summary

- wire the existing **Configure Git Author** profile action through both the entry and editor windows
- add a modal that loads and updates the global Git `user.name` and `user.email`
- validate trimmed input, keep the modal open on errors, and report load/save outcomes with notifications
- cover empty, partial, create, reload, and overwrite behavior with isolated Git config tests

## Why

The profile menu already exposed a **Configure Git Author** item, but its click handler only contained a TODO. Users therefore had no in-app way to inspect or update the author identity used for commits.

This implements the name and email MVP discussed in #470. Git hooks and repository auto-refresh settings can be layered onto the same settings surface separately.

## Impact

Users can now configure their global Git author name and email from either application shell without leaving Pulsar Native. Invalid or failed writes do not dismiss the modal, so the values can be corrected and retried.

## Validation

- `cargo test -p ui_git_manager git_identity` (6 passed)
- `cargo check -p ui_git_manager -p ui_entry -p ui_core`
- `cargo clippy -p ui_git_manager --tests --no-deps`
- `cargo metadata --locked`
- edition 2024 `rustfmt` on the changed Rust modules
- `git diff --check`

Closes #470
