### PR TITLE
Publish coarse-owned terrain transition masks

### DIFF
--- a/crates/subsystems/pulsar_terrain/src/render.rs
+++ b/crates/subsystems/pulsar_terrain/src/render.rs
@@ -141,6 +141,8 @@ pub struct TerrainVisiblePage {
     pub page_key: PageKey,
     pub planet_generation: u64,
     pub page_generation: u64,
+    /// Faces owned by this coarse page that border render-relevant leaves
+    /// exactly one LOD finer.
     pub transition_mask: u8,
 }
 
@@ -557,23 +559,34 @@ mod tests {
 
     #[test]
     fn transition_masks_cover_all_faces_and_signed_boundaries() {
-        for face in TerrainTransitionFace::ALL {
-            let axis = face.axis();
-            let mut fine_xyz = [-3, -3, -3];
-            fine_xyz[axis] = if face.is_positive() { -3 } else { -2 };
-            let fine = PageKey::new(0, fine_xyz);
-            let mut coarse_xyz = fine_xyz.map(|coordinate| coordinate.div_euclid(2));
-            coarse_xyz[axis] += if face.is_positive() { 1 } else { -1 };
-            let coarse = PageKey::new(1, coarse_xyz);
-            let plan = TerrainStreamingPlan::for_test(
-                PlanetId([1; 16]),
-                vec![
-                    PageDemand::for_test(fine, TerrainRequestClass::Visible),
-                    PageDemand::for_test(coarse, TerrainRequestClass::Visible),
-                ],
-            );
-            assert_eq!(plan.transition_masks().get(&fine), Some(&face.bit()));
-            assert_eq!(plan.transition_masks().get(&coarse), Some(&0));
+        for coarse_face in TerrainTransitionFace::ALL {
+            let axis = coarse_face.axis();
+            let coarse = PageKey::new(1, [-3, -3, -3]);
+            let tangential = match axis {
+                0 => [1, 2],
+                1 => [0, 2],
+                2 => [0, 1],
+                _ => unreachable!(),
+            };
+            for quadrant in 0..4 {
+                let mut fine_xyz = coarse.page_xyz.map(|coordinate| coordinate * 2);
+                fine_xyz[axis] += if coarse_face.is_positive() { 2 } else { -1 };
+                fine_xyz[tangential[0]] += (quadrant & 1) as i64;
+                fine_xyz[tangential[1]] += ((quadrant >> 1) & 1) as i64;
+                let fine = PageKey::new(0, fine_xyz);
+                let plan = TerrainStreamingPlan::for_test(
+                    PlanetId([1; 16]),
+                    vec![
+                        PageDemand::for_test(fine, TerrainRequestClass::Visible),
+                        PageDemand::for_test(coarse, TerrainRequestClass::Visible),
+                    ],
+                );
+                assert_eq!(plan.transition_masks().get(&fine), Some(&0));
+                assert_eq!(
+                    plan.transition_masks().get(&coarse),
+                    Some(&coarse_face.bit())
+                );
+            }
         }
         assert_eq!(
             TerrainTransitionFace::ALL

--- a/crates/subsystems/pulsar_terrain/src/streaming.rs
+++ b/crates/subsystems/pulsar_terrain/src/streaming.rs
@@ -319,9 +319,10 @@ impl TerrainStreamingPlan {
 
     /// Six-face transition masks for the complete deterministic leaf set.
     ///
-    /// Bit order is `-X,+X,-Y,+Y,-Z,+Z`. A bit is set on the fine page when
-    /// its covering face neighbor is exactly one LOD coarser. Coarse pages do
-    /// not mark faces adjacent to finer leaves.
+    /// Bit order is `-X,+X,-Y,+Y,-Z,+Z`. A bit is set on the coarse page when
+    /// at least one render-relevant leaf exactly one LOD finer touches that
+    /// face. Helio's Transvoxel extractor owns the transition mesh on this
+    /// coarse page and samples the adjacent finer field over the complete face.
     pub fn transition_masks(&self) -> BTreeMap<PageKey, u8> {
         let leaves = self
             .demands
@@ -334,9 +335,9 @@ impl TerrainStreamingPlan {
             .map(|leaf| {
                 let mut mask = 0_u8;
                 for (face, (axis, direction)) in faces().into_iter().enumerate() {
-                    if covering_face_neighbor(leaf, axis, direction, &leaves)
-                        .is_some_and(|neighbor| neighbor.lod == leaf.lod.saturating_add(1))
-                    {
+                    if finer_face_neighbors(leaf, axis, direction).is_some_and(|neighbors| {
+                        neighbors.iter().any(|neighbor| leaves.contains(neighbor))
+                    }) {
                         mask |= 1 << face;
                     }
                 }
@@ -946,6 +947,35 @@ fn covering_face_neighbor(
             return None;
         }
     }
+}
+
+fn finer_face_neighbors(coarse: PageKey, axis: usize, direction: i64) -> Option<[PageKey; 4]> {
+    let lod = coarse.lod.checked_sub(1)?;
+    let mut base = [0_i64; 3];
+    for coordinate in 0..3 {
+        base[coordinate] = coarse.page_xyz[coordinate].checked_mul(2)?;
+    }
+    let face_coordinate = if direction < 0 {
+        base[axis].checked_sub(1)?
+    } else {
+        base[axis].checked_add(2)?
+    };
+    let tangential = match axis {
+        0 => [1, 2],
+        1 => [0, 2],
+        2 => [0, 1],
+        _ => return None,
+    };
+    let mut neighbors = [PageKey::default(); 4];
+    for (quadrant, neighbor) in neighbors.iter_mut().enumerate() {
+        let mut page_xyz = base;
+        page_xyz[axis] = face_coordinate;
+        page_xyz[tangential[0]] = page_xyz[tangential[0]].checked_add((quadrant & 1) as i64)?;
+        page_xyz[tangential[1]] =
+            page_xyz[tangential[1]].checked_add(((quadrant >> 1) & 1) as i64)?;
+        *neighbor = PageKey::new(lod, page_xyz);
+    }
+    Some(neighbors)
 }
 
 trait PageKeySet {


### PR DESCRIPTION
## What changed

- publish terrain transition bits on the coarse page that owns Helio's Transvoxel seam
- detect every adjacent fine-page quadrant on all six faces with checked signed-coordinate arithmetic
- document the ownership contract on the immutable visible-page payload
- extend the executable test across every face, quadrant, and negative boundary

## Why

Pulsar previously marked a fine page when its neighbor was one LOD coarser. Helio's production Transvoxel extractor owns the transition mesh on the coarse page and samples the adjacent finer field over that coarse face, so the old handoff requested seams from the wrong page.

This is confined to the planetary terrain subsystem. The visible-page type shape, stable face-bit order, residency protocol, and shared engine APIs are unchanged.

## Validation

- `cargo test -p pulsar_terrain` — 68 unit tests and 6 contract tests passed
- `cargo test -p pulsar_terrain render::tests::transition_masks_cover_all_faces_and_signed_boundaries -- --exact`
- `cargo clippy -p pulsar_terrain --all-targets --no-deps -- -D warnings`
- `git diff --check`

Closes #487.
Required by Far-Beyond-Pulsar/Helio#162.
