### PR TITLE
Restore scoped engine_fs features across all callers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,6 +3034,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml 1.1.3+spec-1.1.0",
  "tool_registry",
  "tool_registry_macros",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ ui-macros    = { path = "crates/ui/wgpui-component/crates/ui-macros" }
 
 # ---------- Core Engine ----------
 profiling                          = { git = "https://github.com/Far-Beyond-Pulsar/Pulsar-Profiling", rev = "12424a5f75166332f9f1d2741281f6fc4847b44d" }
-engine_fs                          = { path = "crates/core/engine_fs" }
+engine_fs                          = { path = "crates/core/engine_fs", default-features = false }
 pulsar_std                         = { path = "crates/core/pulsar_std" }
 engine_state                       = { path = "crates/core/engine_state" }
 engine_subsystems                  = { path = "crates/subsystems/engine_subsystems" }

--- a/crates/agent-providers/agent_chat_tools/Cargo.toml
+++ b/crates/agent-providers/agent_chat_tools/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 anyhow = { workspace = true }
 engine_state = { workspace = true }
 serde_json = { workspace = true }
-engine_fs = { workspace = true }
+engine_fs = { workspace = true, features = ["editor"] }
 plugin_manager = { workspace = true }
 tracing.workspace = true
 tool_registry = { workspace = true }

--- a/crates/core/engine_fs/Cargo.toml
+++ b/crates/core/engine_fs/Cargo.toml
@@ -51,6 +51,7 @@ pulsar-multiplayer-core = { path = "../pulsar-multiplayer-core", optional = true
 tempfile = { workspace = true }
 async-trait = "=0.1.91"
 tokio = { workspace = true, features = ["rt", "macros"] }
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/core/engine_fs/tests/p2p_provider_test.rs
+++ b/crates/core/engine_fs/tests/p2p_provider_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "p2p")]
+
 use std::collections::VecDeque;
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/core/engine_fs/tests/workspace_feature_policy.rs
+++ b/crates/core/engine_fs/tests/workspace_feature_policy.rs
@@ -1,0 +1,165 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Eq, PartialEq)]
+struct DependencyPolicy {
+    uses_workspace: bool,
+    default_features: bool,
+    features: BTreeSet<String>,
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("engine_fs must remain under crates/core")
+        .to_path_buf()
+}
+
+fn dependency_policy(value: &toml::Value) -> DependencyPolicy {
+    let Some(table) = value.as_table() else {
+        return DependencyPolicy {
+            uses_workspace: false,
+            default_features: true,
+            features: BTreeSet::new(),
+        };
+    };
+
+    let features = table
+        .get("features")
+        .and_then(toml::Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|feature| {
+            feature
+                .as_str()
+                .expect("dependency features must be strings")
+                .to_owned()
+        })
+        .collect();
+
+    DependencyPolicy {
+        uses_workspace: table
+            .get("workspace")
+            .and_then(toml::Value::as_bool)
+            .unwrap_or(false),
+        default_features: table
+            .get("default-features")
+            .and_then(toml::Value::as_bool)
+            .unwrap_or(true),
+        features,
+    }
+}
+
+fn engine_fs_dependency(manifest: &toml::Value) -> Option<DependencyPolicy> {
+    ["dependencies", "dev-dependencies", "build-dependencies"]
+        .into_iter()
+        .find_map(|section| {
+            manifest
+                .get(section)
+                .and_then(toml::Value::as_table)
+                .and_then(|dependencies| dependencies.get("engine_fs"))
+                .map(dependency_policy)
+        })
+}
+
+fn member_manifests(root: &Path) -> Vec<PathBuf> {
+    let mut manifests = Vec::new();
+    for group in ["core", "editor", "subsystems", "agent-providers"] {
+        let group_path = root.join("crates").join(group);
+        for entry in fs::read_dir(&group_path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", group_path.display()))
+        {
+            let path = entry
+                .expect("workspace member entry must be readable")
+                .path();
+            let manifest = path.join("Cargo.toml");
+            if manifest.is_file() {
+                manifests.push(manifest);
+            }
+        }
+    }
+
+    let asset_viewer = root.join("plugins/vendor/asset_viewer/Cargo.toml");
+    if asset_viewer.is_file() {
+        manifests.push(asset_viewer);
+    }
+    manifests
+}
+
+fn features(names: &[&str]) -> BTreeSet<String> {
+    names.iter().map(|name| (*name).to_owned()).collect()
+}
+
+#[test]
+fn workspace_engine_fs_callers_declare_their_minimum_surface() {
+    let root = workspace_root();
+    let root_manifest_source =
+        fs::read_to_string(root.join("Cargo.toml")).expect("workspace manifest must be readable");
+    let root_manifest: toml::Value =
+        toml::from_str(&root_manifest_source).expect("workspace manifest must be valid TOML");
+    let workspace_dependency = root_manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("dependencies"))
+        .and_then(|dependencies| dependencies.get("engine_fs"))
+        .expect("workspace must define engine_fs");
+    assert!(
+        !dependency_policy(workspace_dependency).default_features,
+        "the workspace engine_fs baseline must stay local-only"
+    );
+
+    let expected = BTreeMap::from([
+        ("agent_chat_tools".to_owned(), features(&["editor"])),
+        ("engine_backend".to_owned(), features(&[])),
+        ("engine_state".to_owned(), features(&["editor"])),
+        ("pulsar_rendering".to_owned(), features(&[])),
+        ("pulsar_scene".to_owned(), features(&[])),
+        ("pulsar_std".to_owned(), features(&[])),
+        ("pulsar_terrain".to_owned(), features(&[])),
+        ("ui_common".to_owned(), features(&["editor"])),
+        ("ui_entry".to_owned(), features(&["remote"])),
+        ("ui_file_manager".to_owned(), features(&["editor"])),
+        ("ui_level_editor".to_owned(), features(&[])),
+        ("ui_multiplayer".to_owned(), features(&[])),
+        ("ui_type_debugger".to_owned(), features(&["editor"])),
+    ]);
+
+    let mut actual = BTreeMap::new();
+    for manifest_path in member_manifests(&root) {
+        let manifest_source = fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", manifest_path.display()));
+        let manifest: toml::Value = toml::from_str(&manifest_source).unwrap_or_else(|error| {
+            panic!(
+                "failed to parse {} as TOML: {error}",
+                manifest_path.display()
+            )
+        });
+        let Some(policy) = engine_fs_dependency(&manifest) else {
+            continue;
+        };
+        let package = manifest
+            .get("package")
+            .and_then(|package| package.get("name"))
+            .and_then(toml::Value::as_str)
+            .expect("workspace member must have a package name");
+
+        if package == "pulsar_std" {
+            assert!(
+                !policy.uses_workspace && !policy.default_features,
+                "pulsar_std must preserve its local-only direct path dependency"
+            );
+        } else {
+            assert!(
+                policy.uses_workspace,
+                "{package} must inherit the workspace engine_fs baseline"
+            );
+        }
+        actual.insert(package.to_owned(), policy.features);
+    }
+
+    assert_eq!(
+        actual, expected,
+        "classify every engine_fs caller explicitly; new callers must not inherit the full graph"
+    );
+}

--- a/crates/core/engine_state/Cargo.toml
+++ b/crates/core/engine_state/Cargo.toml
@@ -37,7 +37,7 @@ pulsar_auth.workspace = true
 
 # Multiplayer session bridge
 pulsar-multiplayer-core = { path = "../pulsar-multiplayer-core" }
-engine_fs = { workspace = true }
+engine_fs = { workspace = true, features = ["editor"] }
 futures = { workspace = true }
 
 [lints]

--- a/crates/editor/ui_common/Cargo.toml
+++ b/crates/editor/ui_common/Cargo.toml
@@ -24,7 +24,7 @@ engine_state.workspace = true
 pulsar_auth.workspace = true
 ui_auth.workspace = true
 open.workspace = true
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["editor"] }
 plugin_editor_api.workspace = true
 # M3-alpha Task 2 (audit follow-up): `prims-gpui` is required here —
 # `property_editor_registry.rs` iterates `inventory::iter::<UiPropertyEditorHint>`

--- a/crates/editor/ui_entry/Cargo.toml
+++ b/crates/editor/ui_entry/Cargo.toml
@@ -14,7 +14,7 @@ ui_auth.workspace = true
 engine_state.workspace = true
 engine_backend.workspace = true
 window_manager.workspace = true
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["remote"] }
 pulsar_auth.workspace = true
 ui_git_manager.workspace = true
 ui_friends.workspace = true

--- a/crates/editor/ui_file_manager/Cargo.toml
+++ b/crates/editor/ui_file_manager/Cargo.toml
@@ -15,7 +15,7 @@ ui_common.workspace = true
 ui_types_common.workspace = true
 
 # Engine
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["editor"] }
 
 # Reflection system
 pulsar_reflection = { workspace = true }

--- a/crates/editor/ui_type_debugger/Cargo.toml
+++ b/crates/editor/ui_type_debugger/Cargo.toml
@@ -14,7 +14,7 @@ ui_common.workspace = true
 window_manager.workspace = true
 
 # Engine dependencies
-engine_fs.workspace = true
+engine_fs = { workspace = true, features = ["editor"] }
 plugin_editor_api.workspace = true
 rust-i18n.workspace = true
 


### PR DESCRIPTION
## Summary

- make the workspace `engine_fs` dependency local-only by default
- enable `editor` or `remote` only in the callers that use those APIs
- keep the crate's external default feature set unchanged for compatibility
- add a workspace policy test that inventories every current caller and fails when a new caller inherits the full feature graph
- gate the P2P-only integration test so local-only and remote-only configurations remain testable

## Root cause

The internal `engine_fs` crate already had feature boundaries, but the workspace dependency inherited all default features. A local-only terrain build therefore compiled editor import/export code, remote HTTP support, P2P networking, GPUI, WGPU, and their transitive dependencies.

## Impact

- focused `pulsar_terrain` dependency tree: **1,578 -> 74 lines**
- clean release terrain benchmark build: **2,630.0s -> 117.45s**
- clean build speedup: **22.4x** (**95.5% less elapsed time**)
- warm release benchmark: **3.38s**
- no production source behavior or public API changed

The clean benchmark still passed the 10,000-operation root-delete guard at 8 microseconds.

## Caller audit

- local-only: `engine_backend`, `pulsar_rendering`, `pulsar_scene`, `pulsar_std`, `pulsar_terrain`, `ui_level_editor`, `ui_multiplayer`
- editor: `agent_chat_tools`, `engine_state`, `ui_common`, `ui_file_manager`, `ui_type_debugger`
- remote: `ui_entry`
- P2P: no current workspace caller

## Validation

- `cargo test -p engine_fs --no-default-features --locked`
- `cargo test -p engine_fs --no-default-features --features remote --locked`
- `cargo test -p engine_fs --no-default-features --features p2p --locked`
- `cargo test -p engine_fs --no-default-features --features editor --locked`
- `cargo test -p engine_fs --locked`
- `cargo test -p pulsar_terrain --no-fail-fast --locked` (85 unit + 6 contract tests)
- `cargo check -p pulsar_std --locked`
- `cargo check -p pulsar_scene --locked`
- `cargo check -p engine_backend --locked`
- `cargo check -p agent_chat_tools -p engine_state -p ui_common -p ui_file_manager -p ui_type_debugger -p ui_entry -p ui_multiplayer -p ui_level_editor --locked`
- `CARGO_TARGET_DIR=target-terrain-scoped-release-20260731 cargo bench -p pulsar_terrain --bench terrain_core --locked` from an empty target
- `git diff origin/main...HEAD --check`

Existing warnings in WGPUI, `engine_backend`, and feature-specific `engine_fs` code remain unchanged and are outside this dependency-selection fix.

## Concurrent work

PR #491 changes `engine_fs` provider behavior and `Cargo.lock`, but does not change the workspace feature policy. This PR is rebased on current `main`; #491 should rebase after this lands so Cargo resolves its implementation changes under the explicit caller feature sets.

Closes #494
