### PR TITLE
Add authoritative density and error summaries to the terrain VSBT

### DIFF
--- a/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
+++ b/crates/subsystems/pulsar_terrain/benches/terrain_core.rs
@@ -159,6 +159,30 @@ fn main() {
     plan_times.sort_unstable();
     let plan_p95 = plan_times[18];
     let latest_plan = latest_plan.unwrap();
+    let planning_core = TerrainCore::new(
+        planet.planet_id,
+        planet.root_lod,
+        FixedSphereGenerator {
+            center_cell: planet.center_cell,
+            radius_cells: planet.radius_cells,
+            material: planet.material,
+        },
+    )
+    .unwrap();
+    let mut authoritative_plan_times = Vec::with_capacity(20);
+    let mut latest_authoritative_plan = None;
+    for _ in 0..20 {
+        let started = Instant::now();
+        let plan = planner
+            .plan_with_classifier(&planet, view, &planning_core)
+            .unwrap();
+        authoritative_plan_times.push(started.elapsed());
+        latest_authoritative_plan = Some(plan);
+    }
+    authoritative_plan_times.sort_unstable();
+    let authoritative_plan_p95 = authoritative_plan_times[18];
+    let latest_authoritative_plan = latest_authoritative_plan.unwrap();
+    assert_eq!(latest_authoritative_plan, latest_plan);
 
     let ground_planet = PlanetDefinition {
         max_resident_pages: 8_192,
@@ -193,7 +217,7 @@ fn main() {
     // A billion logical cells are represented by the root without allocation.
     let logical_dense_bytes = 1_000_000_000_u64 * 4;
     println!(
-        "terrain_core sparse_touches={TOUCHES} nodes={} sparse_ms={:.3} dense_sample_cells={} dense_sample_bytes={} dense_fill_ms={:.3} billion_dense_equivalent_bytes={logical_dense_bytes} edited_page_bytes={} resident_dense_bytes={} generated_cells={} edit_attachment_regions={} edit_attachment_refs={} edit_candidates_replayed={} edit_compact_ms={:.3} coarse_lod=12 coarse_generated_cells={} coarse_edit_candidates={} coarse_compact_ms={:.3} edit_radius_cells=[1,10,100,1000] edit_aabb_pages={edit_amplification:?} root_delete_prefix_ops={DELETE_EDIT_PREFIX} root_delete_us={:.3} orbit_plan_pages={} orbit_plan_nodes={} orbit_plan_p95_ms={:.3} orbit_plan_limits={:?} ground_plan_pages={} ground_plan_nodes={} ground_plan_p95_ms={:.3} ground_plan_limits={:?}",
+        "terrain_core sparse_touches={TOUCHES} nodes={} sparse_ms={:.3} dense_sample_cells={} dense_sample_bytes={} dense_fill_ms={:.3} billion_dense_equivalent_bytes={logical_dense_bytes} edited_page_bytes={} resident_dense_bytes={} generated_cells={} edit_attachment_regions={} edit_attachment_refs={} edit_candidates_replayed={} edit_compact_ms={:.3} coarse_lod=12 coarse_generated_cells={} coarse_edit_candidates={} coarse_compact_ms={:.3} edit_radius_cells=[1,10,100,1000] edit_aabb_pages={edit_amplification:?} root_delete_prefix_ops={DELETE_EDIT_PREFIX} root_delete_us={:.3} orbit_plan_pages={} orbit_plan_nodes={} orbit_uniform_pruned={} orbit_plan_p95_ms={:.3} orbit_authoritative_p95_ms={:.3} orbit_plan_limits={:?} ground_plan_pages={} ground_plan_nodes={} ground_uniform_pruned={} ground_plan_p95_ms={:.3} ground_plan_limits={:?}",
         sparse.node_count(),
         sparse_time.as_secs_f64() * 1_000.0,
         dense.len(),
@@ -212,10 +236,13 @@ fn main() {
         delete_time.as_secs_f64() * 1_000_000.0,
         latest_plan.demands().len(),
         latest_plan.counters().traversed_nodes,
+        latest_plan.counters().uniform_regions_pruned,
         plan_p95.as_secs_f64() * 1_000.0,
+        authoritative_plan_p95.as_secs_f64() * 1_000.0,
         latest_plan.limits(),
         latest_ground_plan.demands().len(),
         latest_ground_plan.counters().traversed_nodes,
+        latest_ground_plan.counters().uniform_regions_pruned,
         ground_p95.as_secs_f64() * 1_000.0,
         latest_ground_plan.limits(),
     );

--- a/crates/subsystems/pulsar_terrain/src/core.rs
+++ b/crates/subsystems/pulsar_terrain/src/core.rs
@@ -1,10 +1,11 @@
 use crate::edit::EditIndex;
 use crate::mutation::{TerrainMutation, TerrainMutationBase, TerrainOverrideIndex};
 use crate::{
-    CompactedPageRecord, ContentHash, DeterministicGenerator, EditError, EditLog, EditOp,
+    CompactedPageRecord, ContentHash, DeterministicGenerator, EditError, EditLog, EditMode, EditOp,
     HierarchyError, NodeState, PageCodecError, PageKey, PlanetId, SnapshotCodecError,
-    SparseBrickTree, TerrainOverrideError, TerrainOverrideLog, TerrainOverrideOp,
-    TerrainOverrideTarget, TerrainSnapshot, VoxelPage,
+    SparseBrickTree, TerrainNodeSummary, TerrainOverrideError, TerrainOverrideLog,
+    TerrainOverrideOp, TerrainOverrideTarget, TerrainRegionClassifier, TerrainSnapshot,
+    TerrainStreamingError, VoxelPage,
 };
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -174,8 +175,9 @@ impl PageBuildResult {
 
 impl<G: DeterministicGenerator> TerrainCore<G> {
     pub fn new(planet_id: PlanetId, root_lod: u8, generator: G) -> Result<Self, TerrainCoreError> {
-        let hierarchy =
-            SparseBrickTree::centered(root_lod, NodeState::Procedural(generator.hash()))?;
+        let state = NodeState::Procedural(generator.hash());
+        let summary = summarize_centered_root(root_lod, &generator, &state, 0);
+        let hierarchy = SparseBrickTree::centered_with_summary(root_lod, state, summary)?;
         Ok(Self {
             planet_id,
             generator,
@@ -216,6 +218,13 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             .edit_tail
             .latest_sequence()
             .max(snapshot.override_tail.latest_sequence());
+        let hierarchy_sequence = snapshot.hierarchy.max_summary_sequence();
+        if hierarchy_sequence > latest_sequence {
+            return Err(TerrainCoreError::HierarchySummaryBeyondMutationTail {
+                summary: hierarchy_sequence,
+                latest: latest_sequence,
+            });
+        }
         let mut compacted = BTreeMap::new();
         for record in snapshot.compacted_pages {
             let _ = snapshot.hierarchy.resolve(record.key)?;
@@ -247,6 +256,21 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
 
     pub fn hierarchy(&self) -> &SparseBrickTree {
         &self.hierarchy
+    }
+
+    /// Conservative canonical summary after every spatially relevant mutation
+    /// through the current global sequence. This query never materializes a
+    /// page and is suitable for bounded view-demand traversal.
+    pub fn node_summary(&self, key: PageKey) -> Result<TerrainNodeSummary, TerrainCoreError> {
+        let (_, mut summary) =
+            self.hierarchy
+                .resolve_with_summary(key, |target, inherited, state| {
+                    summarize_split_leaf(&self.generator, target, inherited, state)
+                })?;
+        for mutation in self.mutations_for_page(key, summary.through_sequence()) {
+            summary = apply_summary_mutation(&self.generator, key, summary, &mutation);
+        }
+        Ok(summary.with_through_sequence(self.latest_sequence))
     }
 
     pub fn planet_id(&self) -> PlanetId {
@@ -313,10 +337,29 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
         }
         self.validate_next_sequence(operation.sequence)?;
 
+        let sequence = operation.sequence;
+        let state = operation.state.clone();
         match operation.target {
-            TerrainOverrideTarget::Root => self.hierarchy.set_root(operation.state.clone())?,
+            TerrainOverrideTarget::Root => {
+                let summary = summarize_centered_root(
+                    self.hierarchy.root_lod(),
+                    &self.generator,
+                    &state,
+                    sequence,
+                );
+                self.hierarchy.set_root_with_summary(state, summary)?;
+            }
             TerrainOverrideTarget::Region(key) => {
-                self.hierarchy.set(key, operation.state.clone())?
+                let summary = summarize_state(&self.generator, key, &state, sequence);
+                let generator = &self.generator;
+                self.hierarchy.set_with_summary(
+                    key,
+                    state,
+                    summary,
+                    |child_key, inherited, child_state| {
+                        summarize_split_leaf(generator, child_key, inherited, child_state)
+                    },
+                )?;
             }
         }
         let operation_index = self.overrides.operations().len();
@@ -455,7 +498,16 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
                     NodeState::Air
                 }
             });
-        self.hierarchy.set(result.key, state)?;
+        let summary = result.page.node_summary(result.key.lod, latest_sequence);
+        let generator = &self.generator;
+        self.hierarchy.set_with_summary(
+            result.key,
+            state,
+            summary,
+            |child_key, inherited, child_state| {
+                summarize_split_leaf(generator, child_key, inherited, child_state)
+            },
+        )?;
         self.pages.insert(result.key, result.page);
         self.compacted.insert(result.key, record);
         self.work.pages_compacted = self.work.pages_compacted.saturating_add(1);
@@ -680,6 +732,131 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
     }
 }
 
+fn summarize_centered_root<G: DeterministicGenerator>(
+    root_lod: u8,
+    generator: &G,
+    state: &NodeState,
+    through_sequence: u64,
+) -> TerrainNodeSummary {
+    let Some(child_lod) = root_lod.checked_sub(1) else {
+        return TerrainNodeSummary::unknown(through_sequence);
+    };
+    let mut summaries = (0..8).map(|index| {
+        let page_xyz = [
+            (index & 1) as i64 - 1,
+            ((index >> 1) & 1) as i64 - 1,
+            ((index >> 2) & 1) as i64 - 1,
+        ];
+        summarize_state(
+            generator,
+            PageKey::new(child_lod, page_xyz),
+            state,
+            through_sequence,
+        )
+    });
+    let first = summaries
+        .next()
+        .expect("a centered hierarchy always has eight root children");
+    summaries.fold(first, TerrainNodeSummary::union)
+}
+
+fn summarize_state<G: DeterministicGenerator>(
+    generator: &G,
+    key: PageKey,
+    state: &NodeState,
+    through_sequence: u64,
+) -> TerrainNodeSummary {
+    match state {
+        NodeState::Air => TerrainNodeSummary::uniform_air(through_sequence),
+        NodeState::Solid(_) => TerrainNodeSummary::uniform_solid(through_sequence),
+        NodeState::Procedural(hash) if *hash == generator.hash() => generator
+            .summarize_region(key)
+            .with_through_sequence(through_sequence),
+        NodeState::Procedural(_) | NodeState::Page(_) | NodeState::Branch => {
+            TerrainNodeSummary::unknown(through_sequence)
+        }
+    }
+}
+
+fn summarize_split_leaf<G: DeterministicGenerator>(
+    generator: &G,
+    key: PageKey,
+    inherited: TerrainNodeSummary,
+    state: &NodeState,
+) -> TerrainNodeSummary {
+    match state {
+        NodeState::Page(_) => inherited,
+        _ => summarize_state(generator, key, state, inherited.through_sequence()),
+    }
+}
+
+fn apply_summary_mutation<G: DeterministicGenerator>(
+    generator: &G,
+    key: PageKey,
+    summary: TerrainNodeSummary,
+    mutation: &TerrainMutation,
+) -> TerrainNodeSummary {
+    match mutation {
+        TerrainMutation::Override(operation) => {
+            let replacement = summarize_state(generator, key, &operation.state, operation.sequence);
+            if operation.page_base(key).is_some() {
+                replacement
+            } else {
+                summary
+                    .union(replacement)
+                    .with_through_sequence(operation.sequence)
+            }
+        }
+        TerrainMutation::Edit(operation) => {
+            if operation.mode == EditMode::Paint {
+                return summary.with_through_sequence(operation.sequence);
+            }
+            let bounds = match operation.shape.signed_distance_bounds_in_page(key) {
+                Ok(Some(bounds)) => bounds,
+                Ok(None) => return summary.with_through_sequence(operation.sequence),
+                Err(()) => return TerrainNodeSummary::unknown(operation.sequence),
+            };
+            let (shape_min, shape_max) = bounds;
+            let (min_density, max_density) = match operation.mode {
+                EditMode::Union => (
+                    summary.min_density().min(shape_min),
+                    summary.max_density().min(shape_max),
+                ),
+                EditMode::Subtract => (
+                    summary.min_density().max(shape_max.saturating_neg()),
+                    summary.max_density().max(shape_min.saturating_neg()),
+                ),
+                EditMode::Replace => (
+                    summary.min_density().min(shape_min),
+                    summary.max_density().max(shape_max),
+                ),
+                EditMode::Paint => unreachable!("paint returned before density evaluation"),
+            };
+            let geometric_error = if min_density > 0 || max_density <= 0 {
+                0
+            } else {
+                summary
+                    .geometric_error_lod0_cells()
+                    .max(1_u64.checked_shl(u32::from(key.lod)).unwrap_or(u64::MAX))
+            };
+            TerrainNodeSummary::new(
+                min_density,
+                max_density,
+                geometric_error,
+                operation.sequence,
+            )
+            .expect("edit interval transforms preserve range ordering")
+        }
+    }
+}
+
+impl<G: DeterministicGenerator> TerrainRegionClassifier for TerrainCore<G> {
+    fn summarize_region(&self, key: PageKey) -> Result<TerrainNodeSummary, TerrainStreamingError> {
+        self.node_summary(key)
+            .map_err(|error| TerrainStreamingError::TerrainSummary(error.to_string()))
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum TerrainCoreError {
     #[error(transparent)]
@@ -702,6 +879,8 @@ pub enum TerrainCoreError {
     GeneratorMismatch,
     #[error("compacted page sequence {compacted} exceeds the canonical mutation tail {latest}")]
     CompactedBeyondMutationTail { compacted: u64, latest: u64 },
+    #[error("hierarchy summary sequence {summary} exceeds the canonical mutation tail {latest}")]
+    HierarchySummaryBeyondMutationTail { summary: u64, latest: u64 },
     #[error("rehydrated page {0:?} does not match its authoritative content hash")]
     RehydratedPageMismatch(PageKey),
 }
@@ -1151,6 +1330,97 @@ mod tests {
     }
 
     #[test]
+    fn fine_descendant_edit_changes_coarse_summary_without_materializing_pages() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([31; 16]), 12, generator).unwrap();
+        let coarse = PageKey::new(4, [2, 0, 0]);
+        let before = core.node_summary(coarse).unwrap();
+        assert!(before.is_uniform_air());
+        assert_eq!(before.through_sequence(), 0);
+
+        let min = coarse.lod0_cell_min().unwrap();
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [1; 16],
+            shape: EditShape::Sphere {
+                center_cell: min.map(|axis| axis + 64),
+                radius_cells: 8,
+            },
+            mode: EditMode::Union,
+            material: 9,
+        })
+        .unwrap();
+
+        let after = core.node_summary(coarse).unwrap();
+        assert!(after.contains_surface());
+        assert!(after.min_density() <= -8);
+        assert!(after.max_density() > 0);
+        assert_eq!(after.through_sequence(), 1);
+        assert_eq!(core.resident_page_count(), 0);
+        assert_eq!(core.memory_counters().compacted_page_records, 0);
+    }
+
+    #[test]
+    fn summaries_survive_compaction_eviction_and_snapshot_rehydration() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 1_000,
+            material: 5,
+        };
+        let key = PageKey::new(0, [31, 0, 0]);
+        let mut core = TerrainCore::new(PlanetId([32; 16]), 12, generator).unwrap();
+        core.append_edit(EditOp {
+            sequence: 1,
+            stable_id: [1; 16],
+            shape: EditShape::Sphere {
+                center_cell: [1_000, 0, 0],
+                radius_cells: 3,
+            },
+            mode: EditMode::Subtract,
+            material: 0,
+        })
+        .unwrap();
+        core.compact_page(key).unwrap();
+        let expected_summary = core.node_summary(key).unwrap();
+        let expected_hash = core.snapshot().content_hash().unwrap();
+
+        assert!(core.evict_resident_page(key));
+        assert_eq!(core.node_summary(key).unwrap(), expected_summary);
+        assert_eq!(core.snapshot().content_hash().unwrap(), expected_hash);
+
+        let snapshot = TerrainSnapshot::decode(&core.snapshot().encode().unwrap()).unwrap();
+        let mut restored = TerrainCore::from_snapshot(snapshot, generator).unwrap();
+        assert_eq!(restored.node_summary(key).unwrap(), expected_summary);
+        restored.compact_page(key).unwrap();
+        assert_eq!(restored.node_summary(key).unwrap(), expected_summary);
+        assert_eq!(restored.snapshot().content_hash().unwrap(), expected_hash);
+    }
+
+    #[test]
+    fn root_delete_replaces_the_authoritative_summary_in_constant_work() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 10_000,
+            material: 5,
+        };
+        let mut core = TerrainCore::new(PlanetId([33; 16]), 24, generator).unwrap();
+        core.compact_page(PageKey::new(0, [0; 3])).unwrap();
+        assert!(core.hierarchy().node_count() > 1);
+
+        core.set_root(NodeState::Air).unwrap();
+        assert_eq!(core.hierarchy().node_count(), 1);
+        assert!(core.hierarchy().root_summary().is_uniform_air());
+        assert_eq!(core.hierarchy().root_summary().through_sequence(), 1);
+        let summary = core.node_summary(PageKey::new(12, [0; 3])).unwrap();
+        assert!(summary.is_uniform_air());
+        assert_eq!(summary.through_sequence(), 1);
+    }
+
+    #[test]
     fn procedural_root_reset_discards_older_materialized_edits() {
         let generator = FixedSphereGenerator {
             center_cell: [0; 3],
@@ -1211,6 +1481,35 @@ mod tests {
             Some(crate::CellWord::AIR)
         );
         assert_eq!(restored.snapshot().content_hash().unwrap(), canonical_hash);
+    }
+
+    #[test]
+    fn snapshot_rejects_hierarchy_summary_from_the_future() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 5,
+        };
+        let snapshot = TerrainSnapshot {
+            planet_id: PlanetId([34; 16]),
+            generator_hash: generator.hash(),
+            hierarchy: SparseBrickTree::centered_with_summary(
+                12,
+                NodeState::Air,
+                TerrainNodeSummary::uniform_air(1),
+            )
+            .unwrap(),
+            edit_tail: EditLog::default(),
+            override_tail: TerrainOverrideLog::default(),
+            compacted_pages: Vec::new(),
+        };
+        assert!(matches!(
+            TerrainCore::from_snapshot(snapshot, generator),
+            Err(TerrainCoreError::HierarchySummaryBeyondMutationTail {
+                summary: 1,
+                latest: 0,
+            })
+        ));
     }
 
     #[test]

--- a/crates/subsystems/pulsar_terrain/src/edit.rs
+++ b/crates/subsystems/pulsar_terrain/src/edit.rs
@@ -1,3 +1,4 @@
+use crate::generator::sphere_signed_distance_bounds;
 use crate::{CellWord, ContentHash, MaterialId, PageKey};
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
@@ -90,6 +91,38 @@ impl EditShape {
                 u128::try_from(last.saturating_sub(first).saturating_add(1)).unwrap_or(u128::MAX)
             })
             .fold(1_u128, u128::saturating_mul)
+    }
+
+    pub(crate) fn signed_distance_bounds_in_page(
+        self,
+        key: PageKey,
+    ) -> Result<Option<(i32, i32)>, ()> {
+        let page_min = key.lod0_cell_min().ok_or(())?;
+        let page_span = key.lod0_cell_span().ok_or(())?;
+        let page_max_exclusive = [
+            page_min[0].checked_add(page_span).ok_or(())?,
+            page_min[1].checked_add(page_span).ok_or(())?,
+            page_min[2].checked_add(page_span).ok_or(())?,
+        ];
+        let (shape_min, shape_max_exclusive) = self.bounds();
+        let intersection_min = std::array::from_fn(|axis| page_min[axis].max(shape_min[axis]));
+        let intersection_max_exclusive =
+            std::array::from_fn(|axis| page_max_exclusive[axis].min(shape_max_exclusive[axis]));
+        if (0..3).any(|axis| intersection_min[axis] >= intersection_max_exclusive[axis]) {
+            return Ok(None);
+        }
+        let intersection_max = intersection_max_exclusive.map(|axis| axis - 1);
+        match self {
+            Self::Sphere {
+                center_cell,
+                radius_cells,
+            } => Ok(Some(sphere_signed_distance_bounds(
+                center_cell,
+                u64::from(radius_cells),
+                intersection_min,
+                intersection_max,
+            ))),
+        }
     }
 
     /// Smallest canonical hierarchy region that contains the edit AABB.

--- a/crates/subsystems/pulsar_terrain/src/generator.rs
+++ b/crates/subsystems/pulsar_terrain/src/generator.rs
@@ -1,10 +1,17 @@
-use crate::{CellWord, ContentHash, MaterialId};
+use crate::{CellWord, ContentHash, MaterialId, PageKey, TerrainNodeSummary};
 
 /// Deterministic canonical terrain source. Implementations must use integer or
 /// fixed-point math and include every behavior-changing parameter in `hash`.
 pub trait DeterministicGenerator: Send + Sync {
     fn hash(&self) -> ContentHash;
     fn sample_cell(&self, cell_xyz: [i64; 3]) -> CellWord;
+
+    /// Conservatively summarize every canonical sample in one hierarchy
+    /// region. Generators that cannot provide a tighter analytic bound remain
+    /// correct by returning `unknown`, but cannot prune that region.
+    fn summarize_region(&self, _key: PageKey) -> TerrainNodeSummary {
+        TerrainNodeSummary::unknown(0)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -46,6 +53,70 @@ impl DeterministicGenerator for FixedSphereGenerator {
         };
         CellWord::new(signed_distance, material, 0)
     }
+
+    fn summarize_region(&self, key: PageKey) -> TerrainNodeSummary {
+        let Some(min) = key.lod0_cell_min() else {
+            return TerrainNodeSummary::unknown(0);
+        };
+        let Some(span) = key.lod0_cell_span() else {
+            return TerrainNodeSummary::unknown(0);
+        };
+        let Some(max_x) = min[0].checked_add(span - 1) else {
+            return TerrainNodeSummary::unknown(0);
+        };
+        let Some(max_y) = min[1].checked_add(span - 1) else {
+            return TerrainNodeSummary::unknown(0);
+        };
+        let Some(max_z) = min[2].checked_add(span - 1) else {
+            return TerrainNodeSummary::unknown(0);
+        };
+        let max = [max_x, max_y, max_z];
+        let (min_density, max_density) =
+            sphere_signed_distance_bounds(self.center_cell, self.radius_cells, min, max);
+        let error = if min_density > 0 || max_density <= 0 {
+            0
+        } else {
+            1_u64.checked_shl(u32::from(key.lod)).unwrap_or(u64::MAX)
+        };
+        TerrainNodeSummary::new(min_density, max_density, error, 0)
+            .expect("sphere bounds are ordered")
+    }
+}
+
+pub(crate) fn sphere_signed_distance_bounds(
+    center_cell: [i64; 3],
+    radius_cells: u64,
+    min_cell: [i64; 3],
+    max_cell: [i64; 3],
+) -> (i32, i32) {
+    let mut minimum_distance_squared = 0_u128;
+    let mut maximum_distance_squared = 0_u128;
+    for axis in 0..3 {
+        let center = i128::from(center_cell[axis]);
+        let low = i128::from(min_cell[axis]);
+        let high = i128::from(max_cell[axis]);
+        let nearest = if center < low {
+            low - center
+        } else if center > high {
+            center - high
+        } else {
+            0
+        }
+        .unsigned_abs();
+        let farthest = (low - center)
+            .unsigned_abs()
+            .max((high - center).unsigned_abs());
+        minimum_distance_squared =
+            minimum_distance_squared.saturating_add(nearest.saturating_mul(nearest));
+        maximum_distance_squared =
+            maximum_distance_squared.saturating_add(farthest.saturating_mul(farthest));
+    }
+    let radius = i128::from(radius_cells);
+    let minimum = (integer_sqrt(minimum_distance_squared) as i128 - radius)
+        .clamp(i128::from(i32::MIN), i128::from(i32::MAX)) as i32;
+    let maximum = (integer_sqrt(maximum_distance_squared) as i128 - radius)
+        .clamp(i128::from(i32::MIN), i128::from(i32::MAX)) as i32;
+    (minimum, maximum)
 }
 
 fn integer_sqrt(value: u128) -> u128 {
@@ -80,5 +151,54 @@ mod tests {
         assert_eq!(generator.sample_cell([0; 3]).material(), 7);
         assert!(!generator.sample_cell([20, 0, 0]).is_solid());
         assert_eq!(generator.hash(), generator.hash());
+    }
+
+    #[test]
+    fn fixed_sphere_summaries_never_reject_sampled_surface_values() {
+        let generator = FixedSphereGenerator {
+            center_cell: [-17, 29, -43],
+            radius_cells: 1_003,
+            material: 7,
+        };
+        for lod in [0, 1, 3, 5] {
+            let span = PageKey::new(lod, [0; 3]).lod0_cell_span().unwrap();
+            let radial_page = (generator.radius_cells as i64).div_euclid(span);
+            for x in [
+                -radial_page - 2,
+                -radial_page - 1,
+                radial_page,
+                radial_page + 1,
+            ] {
+                for y in [-1, 0] {
+                    for z in [-1, 0] {
+                        let key = PageKey::new(lod, [x, y, z]);
+                        let summary = generator.summarize_region(key);
+                        let min = key.lod0_cell_min().unwrap();
+                        for dz in [0, span / 4, span / 2, span * 3 / 4, span - 1] {
+                            for dy in [0, span / 4, span / 2, span * 3 / 4, span - 1] {
+                                for dx in [0, span / 4, span / 2, span * 3 / 4, span - 1] {
+                                    let density = i32::from(
+                                        generator
+                                            .sample_cell([min[0] + dx, min[1] + dy, min[2] + dz])
+                                            .density(),
+                                    );
+                                    assert!(
+                                        summary.min_density() <= density
+                                            && density <= summary.max_density(),
+                                        "LOD{lod} {key:?} summary {summary:?} missed {density}"
+                                    );
+                                    if summary.is_uniform_air() {
+                                        assert!(density > 0);
+                                    }
+                                    if summary.is_uniform_solid() {
+                                        assert!(density <= 0);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/hierarchy.rs
+++ b/crates/subsystems/pulsar_terrain/src/hierarchy.rs
@@ -1,12 +1,26 @@
-use crate::{ContentHash, NodeState, PageKey};
+use crate::{ContentHash, NodeState, PageKey, TerrainNodeSummary};
 use thiserror::Error;
 
-const HIERARCHY_MAGIC: &[u8; 8] = b"PTHIER01";
+const HIERARCHY_MAGIC: &[u8; 8] = b"PTHIER02";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum TreeNode {
-    Leaf(NodeState),
-    Branch(Box<[TreeNode; 8]>),
+    Leaf {
+        state: NodeState,
+        summary: TerrainNodeSummary,
+    },
+    Branch {
+        summary: TerrainNodeSummary,
+        children: Box<[TreeNode; 8]>,
+    },
+}
+
+impl TreeNode {
+    const fn summary(&self) -> TerrainNodeSummary {
+        match self {
+            Self::Leaf { summary, .. } | Self::Branch { summary, .. } => *summary,
+        }
+    }
 }
 
 /// A mutable sparse brick hierarchy covering a centered cube of LOD0 pages.
@@ -20,22 +34,36 @@ pub struct SparseBrickTree {
 
 impl SparseBrickTree {
     pub fn centered(root_lod: u8, state: NodeState) -> Result<Self, HierarchyError> {
+        let summary = TerrainNodeSummary::for_state(&state, 0);
+        Self::centered_with_summary(root_lod, state, summary)
+    }
+
+    pub fn centered_with_summary(
+        root_lod: u8,
+        state: NodeState,
+        summary: TerrainNodeSummary,
+    ) -> Result<Self, HierarchyError> {
         if root_lod == 0 || root_lod > 62 || state == NodeState::Branch {
             return Err(HierarchyError::InvalidRoot);
         }
+        validate_leaf_summary(&state, summary)?;
         let half = 1_i64 << (root_lod - 1);
         Ok(Self {
             root_lod,
             root_min_page: [-half; 3],
-            root: TreeNode::Leaf(state),
+            root: TreeNode::Leaf { state, summary },
         })
     }
 
     pub fn root_state(&self) -> NodeState {
         match &self.root {
-            TreeNode::Leaf(state) => state.clone(),
-            TreeNode::Branch(_) => NodeState::Branch,
+            TreeNode::Leaf { state, .. } => state.clone(),
+            TreeNode::Branch { .. } => NodeState::Branch,
         }
+    }
+
+    pub const fn root_summary(&self) -> TerrainNodeSummary {
+        self.root.summary()
     }
 
     pub fn root_lod(&self) -> u8 {
@@ -44,39 +72,103 @@ impl SparseBrickTree {
 
     /// Exact O(1) root replacement, including whole-planet deletion.
     pub fn set_root(&mut self, state: NodeState) -> Result<(), HierarchyError> {
+        let summary = TerrainNodeSummary::for_state(&state, 0);
+        self.set_root_with_summary(state, summary)
+    }
+
+    pub fn set_root_with_summary(
+        &mut self,
+        state: NodeState,
+        summary: TerrainNodeSummary,
+    ) -> Result<(), HierarchyError> {
         if state == NodeState::Branch {
             return Err(HierarchyError::BranchIsInternal);
         }
-        self.root = TreeNode::Leaf(state);
+        validate_leaf_summary(&state, summary)?;
+        self.root = TreeNode::Leaf { state, summary };
         Ok(())
     }
 
     pub fn set(&mut self, key: PageKey, state: NodeState) -> Result<(), HierarchyError> {
+        let summary = TerrainNodeSummary::for_state(&state, 0);
+        self.set_with_summary(key, state, summary, |_, inherited, _| inherited)
+    }
+
+    pub fn set_with_summary<F>(
+        &mut self,
+        key: PageKey,
+        state: NodeState,
+        summary: TerrainNodeSummary,
+        summarize_split_leaf: F,
+    ) -> Result<(), HierarchyError>
+    where
+        F: Fn(PageKey, TerrainNodeSummary, &NodeState) -> TerrainNodeSummary,
+    {
         if state == NodeState::Branch {
             return Err(HierarchyError::BranchIsInternal);
         }
+        validate_leaf_summary(&state, summary)?;
         let path = self.path_for(key)?;
-        set_recursive(&mut self.root, &path, state);
+        set_recursive(
+            &mut self.root,
+            None,
+            &path,
+            state,
+            summary,
+            self.root_lod,
+            &summarize_split_leaf,
+        );
         Ok(())
     }
 
     pub fn resolve(&self, key: PageKey) -> Result<NodeState, HierarchyError> {
         let path = self.path_for(key)?;
         let mut node = &self.root;
-        for child in path {
+        for step in path {
             match node {
-                TreeNode::Leaf(state) => return Ok(state.clone()),
-                TreeNode::Branch(children) => node = &children[child],
+                TreeNode::Leaf { state, .. } => return Ok(state.clone()),
+                TreeNode::Branch { children, .. } => node = &children[step.child],
             }
         }
         Ok(match node {
-            TreeNode::Leaf(state) => state.clone(),
-            TreeNode::Branch(_) => NodeState::Branch,
+            TreeNode::Leaf { state, .. } => state.clone(),
+            TreeNode::Branch { .. } => NodeState::Branch,
+        })
+    }
+
+    /// Resolve canonical node metadata. If a target lies below a compressed
+    /// leaf, `summarize_descendant` derives the target-specific conservative
+    /// summary without materializing hierarchy nodes.
+    pub fn resolve_with_summary<F>(
+        &self,
+        key: PageKey,
+        summarize_descendant: F,
+    ) -> Result<(NodeState, TerrainNodeSummary), HierarchyError>
+    where
+        F: Fn(PageKey, TerrainNodeSummary, &NodeState) -> TerrainNodeSummary,
+    {
+        let path = self.path_for(key)?;
+        let mut node = &self.root;
+        for step in &path {
+            match node {
+                TreeNode::Leaf { state, summary } => {
+                    return Ok((state.clone(), summarize_descendant(key, *summary, state)));
+                }
+                TreeNode::Branch { children, .. } => node = &children[step.child],
+            }
+        }
+        Ok(match node {
+            TreeNode::Leaf { state, summary } => (state.clone(), *summary),
+            TreeNode::Branch { summary, .. } => (NodeState::Branch, *summary),
         })
     }
 
     pub fn node_count(&self) -> usize {
         count_nodes(&self.root)
+    }
+
+    pub fn max_summary_sequence(&self) -> u64 {
+        max_summary_sequence(&self.root)
     }
 
     pub fn encode(&self) -> Vec<u8> {
@@ -92,7 +184,7 @@ impl SparseBrickTree {
     }
 
     pub fn decode(bytes: &[u8]) -> Result<Self, HierarchyError> {
-        if bytes.len() < 41
+        if bytes.len() < 65
             || bytes.get(..8) != Some(HIERARCHY_MAGIC)
             || bytes.get(9..16) != Some(&[0; 7])
         {
@@ -133,7 +225,7 @@ impl SparseBrickTree {
         ContentHash::of(&self.encode())
     }
 
-    fn path_for(&self, key: PageKey) -> Result<Vec<usize>, HierarchyError> {
+    fn path_for(&self, key: PageKey) -> Result<Vec<PathStep>, HierarchyError> {
         if key.lod >= self.root_lod {
             return Err(HierarchyError::LodOutsideRoot(key.lod));
         }
@@ -161,68 +253,192 @@ impl SparseBrickTree {
             let x = ((relative[0] >> bit) & 1) as usize;
             let y = ((relative[1] >> bit) & 1) as usize;
             let z = ((relative[2] >> bit) & 1) as usize;
-            path.push(x | (y << 1) | (z << 2));
+            let lod = self.root_lod - 1 - step as u8;
+            let scale = 1_i64 << lod;
+            path.push(PathStep {
+                child: x | (y << 1) | (z << 2),
+                key: PageKey::new(lod, target_min.map(|axis| axis.div_euclid(scale))),
+            });
         }
         Ok(path)
     }
 }
 
-fn set_recursive(node: &mut TreeNode, path: &[usize], state: NodeState) {
+#[derive(Clone, Copy)]
+struct PathStep {
+    child: usize,
+    key: PageKey,
+}
+
+fn set_recursive<F>(
+    node: &mut TreeNode,
+    node_key: Option<PageKey>,
+    path: &[PathStep],
+    state: NodeState,
+    summary: TerrainNodeSummary,
+    root_lod: u8,
+    summarize_split_leaf: &F,
+) where
+    F: Fn(PageKey, TerrainNodeSummary, &NodeState) -> TerrainNodeSummary,
+{
     if path.is_empty() {
-        *node = TreeNode::Leaf(state);
+        *node = TreeNode::Leaf { state, summary };
         return;
     }
-    if let TreeNode::Leaf(previous) = node {
-        let child = TreeNode::Leaf(previous.clone());
-        *node = TreeNode::Branch(Box::new(std::array::from_fn(|_| child.clone())));
+    if let TreeNode::Leaf {
+        state: previous,
+        summary: inherited,
+    } = node
+    {
+        let previous = previous.clone();
+        let inherited = *inherited;
+        let keys = child_keys(node_key, root_lod);
+        let children = Box::new(std::array::from_fn(|index| TreeNode::Leaf {
+            state: previous.clone(),
+            summary: summarize_split_leaf(keys[index], inherited, &previous),
+        }));
+        let summary = union_children(&children);
+        *node = TreeNode::Branch { summary, children };
     }
-    let TreeNode::Branch(children) = node else {
+    let TreeNode::Branch {
+        summary: node_summary,
+        children,
+    } = node
+    else {
         unreachable!();
     };
-    set_recursive(&mut children[path[0]], &path[1..], state);
+    let step = path[0];
+    set_recursive(
+        &mut children[step.child],
+        Some(step.key),
+        &path[1..],
+        state,
+        summary,
+        root_lod,
+        summarize_split_leaf,
+    );
 
     let first = match &children[0] {
-        TreeNode::Leaf(first) => first.clone(),
-        TreeNode::Branch(_) => return,
+        TreeNode::Leaf { state, .. } => state.clone(),
+        TreeNode::Branch { .. } => {
+            *node_summary = union_children(children);
+            return;
+        }
     };
     if children
         .iter()
-        .all(|child| matches!(child, TreeNode::Leaf(value) if *value == first))
+        .all(|child| matches!(child, TreeNode::Leaf { state, .. } if *state == first))
     {
-        *node = TreeNode::Leaf(first);
+        *node = TreeNode::Leaf {
+            state: first,
+            summary: union_children(children),
+        };
+    } else {
+        *node_summary = union_children(children);
     }
+}
+
+fn child_keys(parent: Option<PageKey>, root_lod: u8) -> [PageKey; 8] {
+    let lod = parent.map_or(root_lod - 1, |key| key.lod - 1);
+    std::array::from_fn(|index| {
+        let offsets = [
+            (index & 1) as i64,
+            ((index >> 1) & 1) as i64,
+            ((index >> 2) & 1) as i64,
+        ];
+        let page_xyz = parent.map_or_else(
+            || offsets.map(|offset| offset - 1),
+            |key| {
+                std::array::from_fn(|axis| {
+                    key.page_xyz[axis]
+                        .checked_mul(2)
+                        .and_then(|value| value.checked_add(offsets[axis]))
+                        .expect("a validated hierarchy path cannot overflow")
+                })
+            },
+        );
+        PageKey::new(lod, page_xyz)
+    })
+}
+
+fn union_children(children: &[TreeNode; 8]) -> TerrainNodeSummary {
+    children[1..]
+        .iter()
+        .fold(children[0].summary(), |summary, child| {
+            summary.union(child.summary())
+        })
 }
 
 fn count_nodes(node: &TreeNode) -> usize {
     match node {
-        TreeNode::Leaf(_) => 1,
-        TreeNode::Branch(children) => 1 + children.iter().map(count_nodes).sum::<usize>(),
+        TreeNode::Leaf { .. } => 1,
+        TreeNode::Branch { children, .. } => 1 + children.iter().map(count_nodes).sum::<usize>(),
+    }
+}
+
+fn max_summary_sequence(node: &TreeNode) -> u64 {
+    match node {
+        TreeNode::Leaf { summary, .. } => summary.through_sequence(),
+        TreeNode::Branch { summary, children } => children
+            .iter()
+            .fold(summary.through_sequence(), |latest, child| {
+                latest.max(max_summary_sequence(child))
+            }),
     }
 }
 
 fn encode_node(node: &TreeNode, output: &mut Vec<u8>) {
     match node {
-        TreeNode::Leaf(NodeState::Air) => output.push(0),
-        TreeNode::Leaf(NodeState::Solid(material)) => {
+        TreeNode::Leaf {
+            state: NodeState::Air,
+            summary,
+        } => {
+            output.push(0);
+            encode_summary(*summary, output);
+        }
+        TreeNode::Leaf {
+            state: NodeState::Solid(material),
+            summary,
+        } => {
             output.push(1);
+            encode_summary(*summary, output);
             output.push(*material);
         }
-        TreeNode::Leaf(NodeState::Procedural(hash)) => {
+        TreeNode::Leaf {
+            state: NodeState::Procedural(hash),
+            summary,
+        } => {
             output.push(2);
+            encode_summary(*summary, output);
             output.extend_from_slice(&hash.0);
         }
-        TreeNode::Branch(children) => {
+        TreeNode::Branch { summary, children } => {
             output.push(3);
+            encode_summary(*summary, output);
             for child in children.iter() {
                 encode_node(child, output);
             }
         }
-        TreeNode::Leaf(NodeState::Page(hash)) => {
+        TreeNode::Leaf {
+            state: NodeState::Page(hash),
+            summary,
+        } => {
             output.push(4);
+            encode_summary(*summary, output);
             output.extend_from_slice(&hash.0);
         }
-        TreeNode::Leaf(NodeState::Branch) => unreachable!("Branch is stored structurally"),
+        TreeNode::Leaf {
+            state: NodeState::Branch,
+            ..
+        } => unreachable!("Branch is stored structurally"),
     }
+}
+
+fn encode_summary(summary: TerrainNodeSummary, output: &mut Vec<u8>) {
+    output.extend_from_slice(&summary.min_density().to_le_bytes());
+    output.extend_from_slice(&summary.max_density().to_le_bytes());
+    output.extend_from_slice(&summary.geometric_error_lod0_cells().to_le_bytes());
+    output.extend_from_slice(&summary.through_sequence().to_le_bytes());
 }
 
 fn decode_node(
@@ -233,12 +449,13 @@ fn decode_node(
 ) -> Result<TreeNode, HierarchyError> {
     let tag = *bytes.get(*cursor).ok_or(HierarchyError::Codec)?;
     *cursor += 1;
+    let summary = decode_summary(bytes, cursor)?;
     match tag {
-        0 => Ok(TreeNode::Leaf(NodeState::Air)),
+        0 => decode_leaf(NodeState::Air, summary),
         1 => {
             let material = *bytes.get(*cursor).ok_or(HierarchyError::Codec)?;
             *cursor += 1;
-            Ok(TreeNode::Leaf(NodeState::Solid(material)))
+            decode_leaf(NodeState::Solid(material), summary)
         }
         2 | 4 => {
             let hash = ContentHash(
@@ -249,23 +466,74 @@ fn decode_node(
                     .map_err(|_| HierarchyError::Codec)?,
             );
             *cursor += 32;
-            Ok(TreeNode::Leaf(if tag == 2 {
-                NodeState::Procedural(hash)
-            } else {
-                NodeState::Page(hash)
-            }))
+            decode_leaf(
+                if tag == 2 {
+                    NodeState::Procedural(hash)
+                } else {
+                    NodeState::Page(hash)
+                },
+                summary,
+            )
         }
         3 if depth < root_lod => {
             let mut children = Vec::with_capacity(8);
             for _ in 0..8 {
                 children.push(decode_node(bytes, cursor, depth + 1, root_lod)?);
             }
-            Ok(TreeNode::Branch(Box::new(
-                children.try_into().map_err(|_| HierarchyError::Codec)?,
-            )))
+            let children: Box<[TreeNode; 8]> =
+                Box::new(children.try_into().map_err(|_| HierarchyError::Codec)?);
+            if union_children(&children) != summary {
+                return Err(HierarchyError::Codec);
+            }
+            Ok(TreeNode::Branch { summary, children })
         }
         _ => Err(HierarchyError::Codec),
     }
+}
+
+fn decode_summary(bytes: &[u8], cursor: &mut usize) -> Result<TerrainNodeSummary, HierarchyError> {
+    let min_density = i32::from_le_bytes(read_array(bytes, *cursor)?);
+    let max_density = i32::from_le_bytes(read_array(bytes, *cursor + 4)?);
+    let geometric_error_lod0_cells = u64::from_le_bytes(read_array(bytes, *cursor + 8)?);
+    let through_sequence = u64::from_le_bytes(read_array(bytes, *cursor + 16)?);
+    *cursor += 24;
+    TerrainNodeSummary::new(
+        min_density,
+        max_density,
+        geometric_error_lod0_cells,
+        through_sequence,
+    )
+    .ok_or(HierarchyError::Codec)
+}
+
+fn decode_leaf(state: NodeState, summary: TerrainNodeSummary) -> Result<TreeNode, HierarchyError> {
+    validate_leaf_summary(&state, summary).map_err(|_| HierarchyError::Codec)?;
+    Ok(TreeNode::Leaf { state, summary })
+}
+
+fn validate_leaf_summary(
+    state: &NodeState,
+    summary: TerrainNodeSummary,
+) -> Result<(), HierarchyError> {
+    let valid = match state {
+        NodeState::Air => summary.is_uniform_air(),
+        NodeState::Solid(_) => summary.is_uniform_solid(),
+        NodeState::Procedural(_) | NodeState::Page(_) => true,
+        NodeState::Branch => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(HierarchyError::InvalidSummary)
+    }
+}
+
+fn read_array<const N: usize>(bytes: &[u8], offset: usize) -> Result<[u8; N], HierarchyError> {
+    bytes
+        .get(offset..offset + N)
+        .ok_or(HierarchyError::Codec)?
+        .try_into()
+        .map_err(|_| HierarchyError::Codec)
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -282,6 +550,8 @@ pub enum HierarchyError {
     CoordinateOverflow,
     #[error("invalid canonical sparse-hierarchy encoding")]
     Codec,
+    #[error("terrain node summary contradicts its canonical node state")]
+    InvalidSummary,
 }
 
 #[cfg(test)]
@@ -328,5 +598,37 @@ mod tests {
         let decoded = SparseBrickTree::decode(&tree.encode()).unwrap();
         assert_eq!(decoded, tree);
         assert_eq!(decoded.content_hash(), tree.content_hash());
+    }
+
+    #[test]
+    fn summary_sequences_are_canonical_and_branch_corruption_is_rejected() {
+        let mut tree = SparseBrickTree::centered_with_summary(
+            4,
+            NodeState::Air,
+            TerrainNodeSummary::uniform_air(7),
+        )
+        .unwrap();
+        tree.set_with_summary(
+            PageKey::new(0, [1, 1, 1]),
+            NodeState::Solid(4),
+            TerrainNodeSummary::uniform_solid(9),
+            |_, inherited, _| inherited,
+        )
+        .unwrap();
+        let encoded = tree.encode();
+        let decoded = SparseBrickTree::decode(&encoded).unwrap();
+        assert_eq!(decoded.max_summary_sequence(), 9);
+        assert_eq!(decoded, tree);
+
+        let mut corrupt = encoded;
+        corrupt[41] ^= 1;
+        assert_eq!(
+            SparseBrickTree::decode(&corrupt),
+            Err(HierarchyError::Codec)
+        );
+        assert_eq!(
+            SparseBrickTree::decode(b"PTHIER01"),
+            Err(HierarchyError::Codec)
+        );
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/lib.rs
+++ b/crates/subsystems/pulsar_terrain/src/lib.rs
@@ -59,6 +59,6 @@ pub use streaming::{
 };
 pub use types::{
     CellWord, ContentHash, MaterialId, NodeState, PageId, PageKey, PlanetFrame, PlanetFramePayload,
-    PlanetId, PlanetIdParseError, PlanetPosition, PositionError, LOD0_CELL_SIZE_METERS,
-    MILLIMETER_INTERACTION_RADIUS_METERS, PAGE_EDGE_CELLS,
+    PlanetId, PlanetIdParseError, PlanetPosition, PositionError, TerrainNodeSummary,
+    LOD0_CELL_SIZE_METERS, MILLIMETER_INTERACTION_RADIUS_METERS, PAGE_EDGE_CELLS,
 };

--- a/crates/subsystems/pulsar_terrain/src/page.rs
+++ b/crates/subsystems/pulsar_terrain/src/page.rs
@@ -1,5 +1,8 @@
 use crate::mutation::TerrainMutation;
-use crate::{CellWord, ContentHash, DeterministicGenerator, EditLog, EditOp, PageId, PageKey};
+use crate::{
+    CellWord, ContentHash, DeterministicGenerator, EditLog, EditOp, PageId, PageKey,
+    TerrainNodeSummary,
+};
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -240,6 +243,32 @@ impl VoxelPage {
 
     pub fn cells(&self) -> impl ExactSizeIterator<Item = CellWord> + '_ {
         (0..CELL_COUNT).map(|index| self.cell_at_index(index))
+    }
+
+    pub fn node_summary(&self, lod: u8, through_sequence: u64) -> TerrainNodeSummary {
+        let mut cells = self.cells();
+        let first = cells
+            .next()
+            .expect("canonical terrain pages always contain cells");
+        let mut min_density = i32::from(first.density());
+        let mut max_density = min_density;
+        for cell in cells {
+            let density = i32::from(cell.density());
+            min_density = min_density.min(density);
+            max_density = max_density.max(density);
+        }
+        let geometric_error_lod0_cells = if min_density > 0 || max_density <= 0 {
+            0
+        } else {
+            1_u64.checked_shl(u32::from(lod)).unwrap_or(u64::MAX)
+        };
+        TerrainNodeSummary::new(
+            min_density,
+            max_density,
+            geometric_error_lod0_cells,
+            through_sequence,
+        )
+        .expect("page density extrema are ordered")
     }
 
     pub fn constant_cell(&self) -> Option<CellWord> {

--- a/crates/subsystems/pulsar_terrain/src/snapshot.rs
+++ b/crates/subsystems/pulsar_terrain/src/snapshot.rs
@@ -2,7 +2,7 @@ use crate::{ContentHash, EditLog, PageId, PageKey, PlanetId, SparseBrickTree, Te
 use std::collections::BTreeSet;
 use thiserror::Error;
 
-const SNAPSHOT_MAGIC: &[u8; 8] = b"PTSNAP02";
+const SNAPSHOT_MAGIC: &[u8; 8] = b"PTSNAP03";
 const SNAPSHOT_HEADER_BYTES: usize = 88;
 const PAGE_RECORD_BYTES: usize = 72;
 
@@ -303,10 +303,11 @@ mod tests {
 
     #[test]
     fn obsolete_snapshot_versions_are_rejected() {
-        let obsolete = b"PTSNAP01";
-        assert_eq!(
-            TerrainSnapshot::decode(obsolete),
-            Err(SnapshotCodecError::Codec)
-        );
+        for obsolete in [b"PTSNAP01".as_slice(), b"PTSNAP02".as_slice()] {
+            assert_eq!(
+                TerrainSnapshot::decode(obsolete),
+                Err(SnapshotCodecError::Codec)
+            );
+        }
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/streaming.rs
+++ b/crates/subsystems/pulsar_terrain/src/streaming.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FixedSphereGenerator, PageKey, PlanetDefinition, PlanetId, PlanetPosition, TerrainRequestClass,
-    LOD0_CELL_SIZE_METERS,
+    DeterministicGenerator, FixedSphereGenerator, PageKey, PlanetDefinition, PlanetId,
+    PlanetPosition, TerrainNodeSummary, TerrainRequestClass, LOD0_CELL_SIZE_METERS,
 };
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet};
@@ -19,59 +19,23 @@ pub enum TerrainRegion {
 /// Returning `Surface` is always safe. Returning a uniform state promises that
 /// no surface sample exists inside the page and allows the traversal to stop.
 pub trait TerrainRegionClassifier {
-    fn classify_region(&self, key: PageKey) -> Result<TerrainRegion, TerrainStreamingError>;
+    fn summarize_region(&self, key: PageKey) -> Result<TerrainNodeSummary, TerrainStreamingError>;
+
+    fn classify_region(&self, key: PageKey) -> Result<TerrainRegion, TerrainStreamingError> {
+        let summary = self.summarize_region(key)?;
+        Ok(if summary.is_uniform_air() {
+            TerrainRegion::UniformAir
+        } else if summary.is_uniform_solid() {
+            TerrainRegion::UniformSolid
+        } else {
+            TerrainRegion::Surface
+        })
+    }
 }
 
 impl TerrainRegionClassifier for FixedSphereGenerator {
-    fn classify_region(&self, key: PageKey) -> Result<TerrainRegion, TerrainStreamingError> {
-        let min = key
-            .lod0_cell_min()
-            .ok_or(TerrainStreamingError::CoordinateOverflow)?;
-        let span = key
-            .lod0_cell_span()
-            .ok_or(TerrainStreamingError::CoordinateOverflow)?;
-        let max = [
-            min[0]
-                .checked_add(span - 1)
-                .ok_or(TerrainStreamingError::CoordinateOverflow)?,
-            min[1]
-                .checked_add(span - 1)
-                .ok_or(TerrainStreamingError::CoordinateOverflow)?,
-            min[2]
-                .checked_add(span - 1)
-                .ok_or(TerrainStreamingError::CoordinateOverflow)?,
-        ];
-
-        let mut minimum_distance_squared = 0_u128;
-        let mut maximum_distance_squared = 0_u128;
-        for axis in 0..3 {
-            let center = i128::from(self.center_cell[axis]);
-            let low = i128::from(min[axis]);
-            let high = i128::from(max[axis]);
-            let nearest = if center < low {
-                low - center
-            } else if center > high {
-                center - high
-            } else {
-                0
-            } as u128;
-            let farthest = (low - center)
-                .unsigned_abs()
-                .max((high - center).unsigned_abs());
-            minimum_distance_squared =
-                minimum_distance_squared.saturating_add(nearest.saturating_mul(nearest));
-            maximum_distance_squared =
-                maximum_distance_squared.saturating_add(farthest.saturating_mul(farthest));
-        }
-
-        let radius_squared = u128::from(self.radius_cells).pow(2);
-        if minimum_distance_squared > radius_squared {
-            Ok(TerrainRegion::UniformAir)
-        } else if maximum_distance_squared <= radius_squared {
-            Ok(TerrainRegion::UniformSolid)
-        } else {
-            Ok(TerrainRegion::Surface)
-        }
+    fn summarize_region(&self, key: PageKey) -> Result<TerrainNodeSummary, TerrainStreamingError> {
+        Ok(DeterministicGenerator::summarize_region(self, key))
     }
 }
 
@@ -248,6 +212,7 @@ pub enum TerrainStreamingLimit {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TerrainStreamingCounters {
     pub traversed_nodes: usize,
+    pub uniform_regions_pruned: usize,
     pub refinements: usize,
     pub balance_refinements: usize,
     pub page_high_water: usize,
@@ -359,6 +324,8 @@ pub enum TerrainStreamingError {
     PlanetOutsideRoot,
     #[error("planetary page coordinate arithmetic overflowed")]
     CoordinateOverflow,
+    #[error("authoritative terrain summary failed: {0}")]
+    TerrainSummary(String),
     #[error("page budget {available} cannot represent {required} visible root regions")]
     RootPageBudget { required: usize, available: usize },
 }
@@ -583,9 +550,13 @@ impl<C: TerrainRegionClassifier> PlannerState<'_, C> {
             return Ok(Evaluation::TraversalBudget);
         }
         self.counters.traversed_nodes = self.counters.traversed_nodes.saturating_add(1);
-        let info = if self.classifier.classify_region(key)? == TerrainRegion::Surface {
-            self.geometry.relevance(key)?
+        let summary = self.classifier.summarize_region(key)?;
+        let info = if summary.contains_surface() {
+            self.geometry
+                .relevance(key, summary.geometric_error_lod0_cells())?
         } else {
+            self.counters.uniform_regions_pruned =
+                self.counters.uniform_regions_pruned.saturating_add(1);
             None
         };
         self.evaluations.insert(key, info);
@@ -700,7 +671,11 @@ impl ViewGeometry {
         })
     }
 
-    fn relevance(&self, key: PageKey) -> Result<Option<LeafInfo>, TerrainStreamingError> {
+    fn relevance(
+        &self,
+        key: PageKey,
+        geometric_error_lod0_cells: u64,
+    ) -> Result<Option<LeafInfo>, TerrainStreamingError> {
         let bounds = RelativeAabb::from_page(key, self.camera)?;
         let current_distance = bounds.distance_to_point([0.0; 3]);
         let predicted_distance = bounds.distance_to_point(self.motion_m);
@@ -723,11 +698,12 @@ impl ViewGeometry {
         } else {
             predicted_distance
         };
-        let cell_size_m = LOD0_CELL_SIZE_METERS * 2_f64.powi(i32::from(key.lod));
+        let geometric_error_m = geometric_error_lod0_cells as f64 * LOD0_CELL_SIZE_METERS;
         let error_distance = current_distance
             .min(predicted_distance)
-            .max(cell_size_m * 0.5);
-        let projected_error_px = self.focal_length_px * cell_size_m / error_distance;
+            .max(geometric_error_m * 0.5)
+            .max(f64::EPSILON);
+        let projected_error_px = self.focal_length_px * geometric_error_m / error_distance;
         let interaction_forced = current_distance <= self.interaction_radius_m
             || swept_distance <= self.interaction_radius_m;
         Ok(Some(LeafInfo {
@@ -1146,6 +1122,108 @@ mod tests {
             .demands()
             .iter()
             .any(|demand| demand.page_key().lod == 0));
+    }
+
+    #[test]
+    fn authoritative_core_summaries_match_the_generator_and_prune_unknown_volume() {
+        struct UnknownVolume;
+
+        impl TerrainRegionClassifier for UnknownVolume {
+            fn summarize_region(
+                &self,
+                key: PageKey,
+            ) -> Result<TerrainNodeSummary, TerrainStreamingError> {
+                Ok(TerrainNodeSummary::new(
+                    i32::MIN,
+                    i32::MAX,
+                    1_u64.checked_shl(u32::from(key.lod)).unwrap_or(u64::MAX),
+                    0,
+                )
+                .unwrap())
+            }
+        }
+
+        let definition = definition(1_000, 6, 4_096);
+        let generator = FixedSphereGenerator {
+            center_cell: definition.center_cell,
+            radius_cells: definition.radius_cells,
+            material: definition.material,
+        };
+        let core =
+            crate::TerrainCore::new(definition.planet_id, definition.root_lod, generator).unwrap();
+        let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
+            interaction_radius_m: 8.0,
+            target_projected_error_px: 2.0,
+            prediction_seconds: 0.5,
+            max_pages: 4_096,
+            max_traversal_nodes: 65_536,
+        })
+        .unwrap();
+        let view = view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]);
+        let direct = planner.plan_fixed_sphere(&definition, view).unwrap();
+        let authoritative = planner
+            .plan_with_classifier(&definition, view, &core)
+            .unwrap();
+        let unknown = planner
+            .plan_with_classifier(&definition, view, &UnknownVolume)
+            .unwrap();
+
+        assert_eq!(authoritative, direct);
+        assert!(authoritative.counters().uniform_regions_pruned > 0);
+        assert!(
+            authoritative.counters().traversed_nodes < unknown.counters().traversed_nodes,
+            "summaries did not reduce traversal: authoritative={:?}, unknown={:?}",
+            authoritative.counters(),
+            unknown.counters()
+        );
+        assert!(authoritative.demands().len() < unknown.demands().len());
+    }
+
+    #[test]
+    fn authoritative_planning_sees_fine_edits_outside_the_procedural_surface() {
+        let definition = definition(100, 6, 4_096);
+        let generator = FixedSphereGenerator {
+            center_cell: definition.center_cell,
+            radius_cells: definition.radius_cells,
+            material: definition.material,
+        };
+        let mut core =
+            crate::TerrainCore::new(definition.planet_id, definition.root_lod, generator).unwrap();
+        core.append_edit(crate::EditOp {
+            sequence: 1,
+            stable_id: [1; 16],
+            shape: crate::EditShape::Sphere {
+                center_cell: [600, 0, 0],
+                radius_cells: 8,
+            },
+            mode: crate::EditMode::Union,
+            material: 11,
+        })
+        .unwrap();
+        let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
+            interaction_radius_m: 8.0,
+            max_pages: 4_096,
+            max_traversal_nodes: 65_536,
+            ..TerrainStreamingConfig::default()
+        })
+        .unwrap();
+        let view = view([620, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]);
+        let procedural = planner.plan_fixed_sphere(&definition, view).unwrap();
+        let authoritative = planner
+            .plan_with_classifier(&definition, view, &core)
+            .unwrap();
+        let edited_page = PageKey::address_lod0_cell(0, [600, 0, 0]).unwrap().0;
+
+        assert!(!procedural
+            .demands()
+            .iter()
+            .any(|demand| demand.page_key() == edited_page));
+        assert!(authoritative
+            .demands()
+            .iter()
+            .any(|demand| demand.page_key() == edited_page));
+        assert!(authoritative.is_face_balanced());
+        assert!(authoritative.demands().len() <= 4_096);
     }
 
     #[test]

--- a/crates/subsystems/pulsar_terrain/src/types.rs
+++ b/crates/subsystems/pulsar_terrain/src/types.rs
@@ -419,6 +419,132 @@ pub enum NodeState {
     Page(PageId),
 }
 
+/// Conservative canonical metadata for one sparse-hierarchy region.
+///
+/// Density is expressed in signed LOD0-cell units: values at or below zero
+/// are solid and positive values are air. The interval must contain every
+/// canonical sample represented by the node. `geometric_error_lod0_cells`
+/// bounds the surface approximation error for renderer/physics refinement;
+/// uniform regions therefore carry zero error. `through_sequence` records the
+/// newest global terrain mutation already folded into the interval.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TerrainNodeSummary {
+    min_density: i32,
+    max_density: i32,
+    geometric_error_lod0_cells: u64,
+    through_sequence: u64,
+}
+
+impl TerrainNodeSummary {
+    pub const fn new(
+        min_density: i32,
+        max_density: i32,
+        geometric_error_lod0_cells: u64,
+        through_sequence: u64,
+    ) -> Option<Self> {
+        if min_density > max_density {
+            return None;
+        }
+        Some(Self {
+            min_density,
+            max_density,
+            geometric_error_lod0_cells,
+            through_sequence,
+        })
+    }
+
+    pub const fn unknown(through_sequence: u64) -> Self {
+        Self {
+            min_density: i32::MIN,
+            max_density: i32::MAX,
+            geometric_error_lod0_cells: u64::MAX,
+            through_sequence,
+        }
+    }
+
+    pub const fn uniform_air(through_sequence: u64) -> Self {
+        Self {
+            min_density: 1,
+            max_density: i32::MAX,
+            geometric_error_lod0_cells: 0,
+            through_sequence,
+        }
+    }
+
+    pub const fn uniform_solid(through_sequence: u64) -> Self {
+        Self {
+            min_density: i32::MIN,
+            max_density: 0,
+            geometric_error_lod0_cells: 0,
+            through_sequence,
+        }
+    }
+
+    pub const fn for_state(state: &NodeState, through_sequence: u64) -> Self {
+        match state {
+            NodeState::Air => Self::uniform_air(through_sequence),
+            NodeState::Solid(_) => Self::uniform_solid(through_sequence),
+            NodeState::Procedural(_) | NodeState::Page(_) | NodeState::Branch => {
+                Self::unknown(through_sequence)
+            }
+        }
+    }
+
+    pub const fn min_density(self) -> i32 {
+        self.min_density
+    }
+
+    pub const fn max_density(self) -> i32 {
+        self.max_density
+    }
+
+    pub const fn geometric_error_lod0_cells(self) -> u64 {
+        self.geometric_error_lod0_cells
+    }
+
+    pub const fn through_sequence(self) -> u64 {
+        self.through_sequence
+    }
+
+    pub const fn is_uniform_air(self) -> bool {
+        self.min_density > 0
+    }
+
+    pub const fn is_uniform_solid(self) -> bool {
+        self.max_density <= 0
+    }
+
+    pub const fn contains_surface(self) -> bool {
+        !self.is_uniform_air() && !self.is_uniform_solid()
+    }
+
+    pub const fn with_through_sequence(self, through_sequence: u64) -> Self {
+        Self {
+            through_sequence,
+            ..self
+        }
+    }
+
+    /// Union summaries conservatively. A branch is current only through the
+    /// oldest child sequence; later mutations are replayed at query time.
+    pub fn union(self, other: Self) -> Self {
+        Self {
+            min_density: self.min_density.min(other.min_density),
+            max_density: self.max_density.max(other.max_density),
+            geometric_error_lod0_cells: self
+                .geometric_error_lod0_cells
+                .max(other.geometric_error_lod0_cells),
+            through_sequence: self.through_sequence.min(other.through_sequence),
+        }
+    }
+}
+
+impl Default for TerrainNodeSummary {
+    fn default() -> Self {
+        Self::unknown(0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CellWord(pub u32);

--- a/docs/planetary-voxel-terrain.md
+++ b/docs/planetary-voxel-terrain.md
@@ -1,6 +1,6 @@
 # Planetary voxel terrain goal and architecture
 
-Status: research-backed implementation plan, 2026-07-13
+Status: active implementation, updated 2026-08-01
 
 ## Goal
 
@@ -59,6 +59,12 @@ PlanetId
 PlanetPosition { lod0_cell: [i64; 3], subcell_m: [f64; 3] }
 PageKey { lod: u8, page_xyz: [i64; 3] }
 NodeState = Air | Solid(material) | Procedural(source) | Branch | Page(PageId)
+NodeSummary = {
+    min_density,
+    max_density,
+    geometric_error_lod0_cells,
+    through_mutation_sequence,
+}
 ```
 
 Do not use one 64-bit Morton key for the full address. About 27 binary levels are required to span an Earth diameter down to 10 cm, which exceeds 64 bits when three coordinate bits are interleaved at every level. Keep level and signed axes explicit on CPU and serialize them canonically.
@@ -71,6 +77,17 @@ absolute coordinates are never collapsed into one floating-point value before
 the active frame origin is subtracted.
 
 GPU page addresses are camera-relative 32-bit values plus a per-frame origin. WGSL has no concrete 64-bit integer type, and absolute planet coordinates must never reach shader arithmetic as one `f32`.
+
+Every materialized VSBT node carries a conservative signed-density interval,
+a surface-error bound in canonical LOD0-cell units, and the newest global
+mutation sequence already folded into that summary. Branch summaries are the
+deterministic union of their children. Compressed procedural descendants derive
+the same metadata analytically from the canonical generator without allocating
+nodes or materializing pages. Query-time edit/override replay advances stale
+summaries conservatively, so a fine union/subtraction can affect coarse planning
+before a dense page exists. Summary bytes are part of hierarchy and snapshot
+hashes; the current canonical snapshot version is `PTSNAP03`, with no legacy
+planet-format migration layer.
 
 ### Page layout
 
@@ -139,6 +156,9 @@ This avoids an engine-wide conversion of existing scene components, Helio camera
 - Pages transition through explicit states: `Absent -> Requested -> CPUReady -> GPUResident -> Meshed`, each carrying a generation number to reject stale jobs.
 - GPU data uses a few large suballocated buffers. Never allocate one wgpu buffer per terrain page.
 - Coarse pages use conservative filtering so thin solid features do not disappear or flip topology unpredictably.
+- Bounded traversal consumes authoritative VSBT summaries. Uniform air/solid
+  nodes terminate traversal, while the stored geometric-error bound—not a
+  renderer-owned terrain guess—drives projected-error refinement.
 
 Successive complete demand plans use a bounded two-set handoff. The currently
 committed visible/prefetch set remains resident while its replacement is
@@ -310,6 +330,17 @@ Current boundary: canonical real-radius addressing and bounded mixed-LOD
 streaming have passed on a flat tangent validation patch. The full spherical
 shell, visible curvature, orbital globe, and continuous travel around the
 planet have not passed yet and remain part of this milestone.
+
+Authoritative density/error summaries are implemented and tested in
+`pulsar_terrain`: analytic sphere intervals never reject sampled crossings,
+fine edits alter coarse summaries without page materialization, root deletion
+replaces the summary in constant work, and compaction/eviction/snapshot
+rehydration preserve summary identity. The release fixture currently reports
+5,592 orbit traversal nodes with 2,636 uniform-region prunes and approximately
+18.5 ms authoritative planning p95 on the development machine (16.9 ms for the
+direct generator baseline). This proves bounded correctness, not the final
+<= 0.5 ms main/render-thread gate; asynchronous scheduling and further planner
+optimization remain required before promotion.
 
 ### Milestone 5: destruction and persistence
 


### PR DESCRIPTION
## Summary

- store conservative signed-density intervals, geometric-error bounds, and mutation sequence coverage in every canonical terrain VSBT node
- derive compressed procedural descendants analytically without materializing pages
- replay only the relevant mutation tail so fine edits immediately affect coarse planning
- make the streaming planner consume authoritative terrain summaries and report uniform-region pruning
- version the canonical hierarchy/snapshot formats to `PTHIER02` / `PTSNAP03`; no legacy planet migration path is retained

## Why

Helio's demo-side occupancy heuristic could not safely reduce the real planetary working set because it did not own canonical edits, overrides, compaction, or persistence. This change puts density/error authority in Pulsar's terrain state, where rendering, physics, persistence, and later replication can consume the same answer.

Part of Far-Beyond-Pulsar/Helio#134
Supports Far-Beyond-Pulsar/Helio#168
Closes #500

## Validation

- `cargo fmt -p pulsar_terrain -- --check`
- `cargo test -p pulsar_terrain --quiet` — 93 unit + 6 integration tests passed
- `cargo clippy -p pulsar_terrain --all-targets -- -D warnings`
- `cargo test -p pulsar_rendering --lib --message-format short` — 16/16 tests passed against current `main`, including the current Helio/WGPUI revisions
- `cargo check -p engine_backend --message-format short` — passed against the current upstream GPU-renderer update
- `cargo bench -p pulsar_terrain --bench terrain_core`
  - root deletion after a 10,000-operation history: 5.6 us (executable gate: <10 ms)
  - orbit: 2,048 pages, 5,592 traversed nodes, 2,636 uniform regions pruned
  - direct generator p95: 16.895 ms
  - authoritative `TerrainCore` p95: 18.455 ms, with an exactly equal demand plan
  - ground: 1,336 pages, 4,552 traversed nodes, 2,252 uniform regions pruned, 10.567 ms p95

The warnings in the broader rendering/backend builds are pre-existing and outside `pulsar_terrain`.

## Caller and compatibility audit

`pulsar_rendering` is the only workspace crate that directly depends on `pulsar_terrain`. It consumes runtime/render deltas and does not implement the changed classifier contract or construct the extended counters. Its complete library test suite and the broader `engine_backend` check pass on the rebased branch.

This intentionally rejects the obsolete planet snapshot encodings instead of carrying a migration layer. Current planet callers must generate the new canonical format.

## Promotion boundary

This proves bounded, canonical traversal and persistence behavior. It does **not** pass the documented <=0.5 ms main/render-thread terrain-planning gate: authoritative planning is currently 18.455 ms p95. Async scheduling and further planner optimization remain required, so this PR stays draft and is not a production-planet promotion.