### PR TITLE
Align Pulsar with the current Helio API revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1665,7 +1665,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2624,7 +2624,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3238,7 +3238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4553,7 +4553,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "helio",
  "helio-core",
@@ -4638,6 +4638,7 @@ dependencies = [
  "helio-pass-occlusion-cull",
  "helio-pass-perf-overlay",
  "helio-pass-planar-reflection",
+ "helio-pass-planetary-voxel",
  "helio-pass-postprocess",
  "helio-pass-radiance-cascades",
  "helio-pass-shadow",
@@ -4661,7 +4662,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4670,7 +4671,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4681,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4692,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4703,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4715,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4726,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4737,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4748,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4761,7 +4762,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4774,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4787,7 +4788,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4798,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4811,7 +4812,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4823,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4835,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4846,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4857,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4868,7 +4869,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4879,7 +4880,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4891,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4905,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4916,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4927,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4939,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4950,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4961,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4972,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4984,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4995,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5006,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5017,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5031,7 +5032,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5042,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5054,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5065,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5079,7 +5080,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5090,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5099,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5108,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -5711,7 +5712,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6058,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=1cbd6462#1cbd6462e33802c1eb9489cf671b31d7f8d79c8c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -6959,7 +6960,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9264,7 +9265,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10184,7 +10185,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10251,7 +10252,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11110,7 +11111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11447,7 +11448,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11882,10 +11883,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11924,7 +11925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13057,7 +13058,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14531,7 +14532,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -15039,7 +15040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,7 +4553,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "helio",
  "helio-core",
@@ -4662,7 +4662,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4671,7 +4671,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4693,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4704,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4727,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4762,7 +4762,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4788,7 +4788,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4799,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4812,7 +4812,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4836,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4858,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4869,7 +4869,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4880,7 +4880,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4892,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4917,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4928,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4940,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5032,7 +5032,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5043,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5080,7 +5080,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5091,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5109,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6059,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=9757608f2a4d434d3757fc5a45b88dfc16809579#9757608f2a4d434d3757fc5a45b88dfc16809579"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7d946c10d6b2e4b0f8129b325dc651a698dc0a8d#7d946c10d6b2e4b0f8129b325dc651a698dc0a8d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,11 +147,11 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "1cbd6462" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "1cbd6462" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "1cbd6462" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "1cbd6462" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "1cbd6462" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,11 +147,11 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "9757608f2a4d434d3757fc5a45b88dfc16809579" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7d946c10d6b2e4b0f8129b325dc651a698dc0a8d" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7d946c10d6b2e4b0f8129b325dc651a698dc0a8d" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7d946c10d6b2e4b0f8129b325dc651a698dc0a8d" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7d946c10d6b2e4b0f8129b325dc651a698dc0a8d" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7d946c10d6b2e4b0f8129b325dc651a698dc0a8d" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/render_adapter.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/render_adapter.rs
@@ -487,7 +487,7 @@ mod tests {
             let mut renderer = PlanetTerrainComponentRenderAdapter::new(
                 &device,
                 &queue,
-                PlanetaryVoxelGpuConfig::new(2, 8, 8, 1, 4, 2).unwrap(),
+                PlanetaryVoxelGpuConfig::new(2, 8, 8, 1, 4).unwrap(),
             )
             .unwrap();
             let planet = TerrainId([7; 16]);


### PR DESCRIPTION
## Summary

- pin every Pulsar workspace Helio package to revision `7d946c10d6b2e4b0f8129b325dc651a698dc0a8d` from Far-Beyond-Pulsar/Helio#185
- regenerate the lockfile so the workspace resolves one Helio package identity
- update the last planetary render-adapter test fixture to the current five-argument GPU residency config
- preserve vendored WGPUI's independent dependency boundary

## Root cause

Pulsar `main` had adopted `helio::RendererBuilder`, but its workspace dependencies still resolved Helio revision `1cbd6462`, which predates that API. Linux and Windows therefore could not resolve `RendererBuilder`. Advancing the pin also exposed an independent Helio XR feature defect on Apple: Vulkan HAL portability and ash loader support were not enabled. Helio #185 fixes that at the owning layer; this PR consumes its exact commit.

Moving to the current API also revealed one stale six-argument planetary test fixture, which is now aligned with the production five-argument API.

## Impact

All current renderer, game, backend, generated-project, and planet adapter callers resolve the same audited Helio revision. Generated game projects continue to inherit the exact workspace revision through `HELIO_GIT_REVISION`.

Closes #504

## Merge order

1. Merge Far-Beyond-Pulsar/Helio#185.
2. Merge this PR.

The exact Helio commit remains stable after #185 merges; no repin is required.

## Validation

- Helio #185: `cargo check --workspace --all-targets --locked`
- Helio #185: `cargo check -p helio-xr --all-targets --locked`
- Helio #185: `cargo test -p helio-xr --lib --locked` - 3/3 passed
- feature audit confirms `wgpu/vulkan-portability` and `ash/loaded`
- `cargo check --workspace --exclude pulsar_docs --all-targets` - passed on Windows
- `cargo test -p pulsar_rendering --lib --quiet` - 16/16 passed
- `cargo test -p engine_backend generated_project_pins_the_workspace_helio_revision --quiet` - passed
- lockfile audit - no old Helio revision entries; all 45 Helio packages resolve `7d946c10...`

Linux and macOS remain covered by the PR CI matrix. Existing workspace warnings are outside this dependency/API alignment diff.