### PR TITLE
Pin portable Helio HiZ capability fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1674,7 +1674,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2633,7 +2633,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4562,7 +4562,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4624,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "helio",
  "helio-core",
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4683,7 +4683,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4694,7 +4694,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4739,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4750,7 +4750,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4774,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4800,7 +4800,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4811,7 +4811,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4836,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4848,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4881,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4892,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4918,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4944,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4955,7 +4955,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4989,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5000,7 +5000,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5011,7 +5011,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5034,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5045,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5056,7 +5056,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5070,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5081,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5093,7 +5093,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5118,7 +5118,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5129,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5138,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5156,7 +5156,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -5759,7 +5759,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6106,7 +6106,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=50f0b1d461823cb5b7acfb9d58d3c71b350e86bd#50f0b1d461823cb5b7acfb9d58d3c71b350e86bd"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -7007,7 +7007,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9312,7 +9312,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10232,7 +10232,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10299,7 +10299,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11158,7 +11158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11495,7 +11495,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11930,10 +11930,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11972,7 +11972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13105,7 +13105,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14579,7 +14579,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -15087,7 +15087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,11 +147,11 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "50f0b1d461823cb5b7acfb9d58d3c71b350e86bd" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "50f0b1d461823cb5b7acfb9d58d3c71b350e86bd" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "50f0b1d461823cb5b7acfb9d58d3c71b350e86bd" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "50f0b1d461823cb5b7acfb9d58d3c71b350e86bd" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "50f0b1d461823cb5b7acfb9d58d3c71b350e86bd" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------


### PR DESCRIPTION
## What changed

- Pins all five Pulsar Helio workspace packages to Helio #220 commit `70f63a5aa6176485ad9396fac39975bd8835e712`, where HiZ probes the GLES HAL only on targets where `wgpu` exposes it.
- Regenerates the lockfile for that single Helio package identity.
- Keeps generated game projects on the same exact Helio revision through `PULSAR_HELIO_GIT_REVISION`.

Pulsar's WGPUI gitlink is unchanged from `main`. This PR intentionally does not attempt to fix or work around the known macOS error in that UI revision.

## Why this is the engine-wide fix

Apple uses Metal and supports the exact HiZ depth-copy path; Helio must not name a GLES type that `wgpu` does not compile there. Windows, Linux, and Android retain actual GLES-device detection and its conservative far-depth behavior.

This PR adds no legacy renderer, compatibility adapter, migration path, reduced render graph, caller fallback, UI-framework pin, or temporary unpinned dependency.

## Validation

- Fresh PR CI: Linux passed, Windows passed, and the release guard passed.
- Fresh macOS CI reaches the unchanged WGPUI revision and fails only at its known Rust 2024 `std::env::set_var` unsafe error; it reports no Helio failure.
- Combined current-engine and planet integration:
  - `cargo test -p pulsar_terrain --lib --locked`: 107 passed.
  - `cargo test -p pulsar_rendering --lib --locked -- --test-threads=1`: 21 passed.
  - `cargo check -p engine_backend --all-targets --locked`: passed.
- Helio `cargo test -p helio-pass-hiz --locked`: 46 passed, including live available-backend pipeline compilation.
- Helio #220 CI passed and Helio #220 is merged.
- `git diff --check`: clean in both repositories.

## Merge gate

The dependency update is validated and ready for engine review. The only red check is the explicitly retained, pre-existing WGPUI macOS error; merging therefore requires accepting that known baseline failure.
