### PR TITLE
Route planet publication through the Helio render pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=b086551b23eef5fb18c8fda762e219ede60bfe7e#b086551b23eef5fb18c8fda762e219ede60bfe7e"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,7 +1674,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=a35cc9eaeb0fcbb05af626e6288814c3495b8b93#a35cc9eaeb0fcbb05af626e6288814c3495b8b93"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -14625,7 +14625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=70f63a5aa6176485ad9396fac39975bd8835e712#70f63a5aa6176485ad9396fac39975bd8835e712"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2577089624318d973da844cf1377536b4e60e941#2577089624318d973da844cf1377536b4e60e941"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=379e868463bc8ab9adc35b745e4b2435a9b733d0#379e868463bc8ab9adc35b745e4b2435a9b733d0"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,7 +3254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -5766,7 +5766,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=2d86f1898295b8213cb19e4f5f526b171e800d5d#2d86f1898295b8213cb19e4f5f526b171e800d5d"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=7c48e8da5e09f70829903814b5345c75527b0763#7c48e8da5e09f70829903814b5345c75527b0763"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -9357,7 +9357,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10277,7 +10277,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10344,7 +10344,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11978,7 +11978,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=435ccfb72518995b3f0b8ba609c090e4f37211f6#435ccfb72518995b3f0b8ba609c090e4f37211f6"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=d2c9841c10ccc5a6fed1fad8512664f6c56fdba1#d2c9841c10ccc5a6fed1fad8512664f6c56fdba1"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1674,7 +1674,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2633,7 +2633,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4618,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "helio",
  "helio-core",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -5766,7 +5766,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=535d0732d6560cd8c56d80058febd99b9b15d94c#535d0732d6560cd8c56d80058febd99b9b15d94c"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c83d15d4589c6b2ed718110c2af7ad7301ab3d9f#c83d15d4589c6b2ed718110c2af7ad7301ab3d9f"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -7014,7 +7014,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9357,7 +9357,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10277,7 +10277,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10344,7 +10344,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11203,7 +11203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11540,7 +11540,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11975,10 +11975,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12017,7 +12017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13150,7 +13150,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14625,7 +14625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -15133,7 +15133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "535d0732d6560cd8c56d80058febd99b9b15d94c" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "379e868463bc8ab9adc35b745e4b2435a9b733d0" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "70f63a5aa6176485ad9396fac39975bd8835e712" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2577089624318d973da844cf1377536b4e60e941" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "d2c9841c10ccc5a6fed1fad8512664f6c56fdba1" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "b086551b23eef5fb18c8fda762e219ede60bfe7e" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "a35cc9eaeb0fcbb05af626e6288814c3495b8b93" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7c48e8da5e09f70829903814b5345c75527b0763" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7c48e8da5e09f70829903814b5345c75527b0763" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7c48e8da5e09f70829903814b5345c75527b0763" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7c48e8da5e09f70829903814b5345c75527b0763" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7c48e8da5e09f70829903814b5345c75527b0763" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "2d86f1898295b8213cb19e4f5f526b171e800d5d" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "7c48e8da5e09f70829903814b5345c75527b0763" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,17 +153,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c83d15d4589c6b2ed718110c2af7ad7301ab3d9f" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "435ccfb72518995b3f0b8ba609c090e4f37211f6" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/component.rs
@@ -21,7 +21,8 @@ pub struct PlanetTerrainComponent {
     pub center_cell_y: i64,
     #[property]
     pub center_cell_z: i64,
-    /// Canonical radius in 10 cm LOD0 cells.
+    /// Canonical radius in 10 cm address cells. This is independent of the
+    /// smooth surface's adaptive rendered sample spacing.
     #[property]
     pub radius_cells: u64,
     #[property]

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/component.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/component.rs
@@ -3,6 +3,7 @@ use pulsar_terrain::{PlanetDefinition, PlanetId, PlanetIdParseError, TerrainRunt
 use thiserror::Error;
 
 pub const PLANET_TERRAIN_CLASS_NAME: &str = "PlanetTerrainComponent";
+pub const DEFAULT_PLANET_RESIDENT_PAGES: u64 = 1_024;
 
 /// Scene-owned planetary terrain definition. Canonical data and worker state
 /// remain in the `pulsar_terrain` runtime supplied to the component context.
@@ -42,7 +43,7 @@ impl Default for PlanetTerrainComponent {
             radius_cells: 63_710_000,
             material: 1,
             root_lod: 22,
-            max_resident_pages: 8_192,
+            max_resident_pages: DEFAULT_PLANET_RESIDENT_PAGES,
         }
     }
 }

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use engine_subsystems::{Subsystem, SubsystemContext, SubsystemError};
-use helio_pass_planetary_voxel::PlanetaryVoxelRenderConfig;
+use helio_pass_planetary_voxel::{
+    PlanetaryVoxelGpuConfig, PlanetaryVoxelRenderConfig, TransvoxelGpuExtractorConfig,
+    TransvoxelGpuTransitionExtractorConfig,
+};
 use helio_planet_voxel_core::VisibilityOutcome;
 use pulsar_reflection::LiveKeySet;
 use pulsar_terrain::{
@@ -18,8 +21,9 @@ use super::{
 
 const LIVE_MAX_PLANETS: usize = 4;
 const LIVE_ACTIVE_PAGES_PER_PLANET: usize = 96;
-const LIVE_TRANSITION_PAGES_PER_PLANET: usize = 96;
+const LIVE_HANDOFF_PAGES_PER_PLANET: usize = 1_024;
 const LIVE_GPU_VISIBLE_PAGES: usize = 384;
+const LIVE_GPU_RESIDENT_PAGES: usize = LIVE_MAX_PLANETS * LIVE_HANDOFF_PAGES_PER_PLANET;
 
 /// Component identities retained between revisions of Pulsar's current legacy
 /// `engine_backend::scene::SceneDb` snapshot bridge. This is not the external
@@ -135,7 +139,23 @@ impl PlanetTerrainRuntime {
     }
 
     pub fn renderer_config() -> PlanetaryVoxelRenderConfig {
-        PlanetaryVoxelRenderConfig::horizon_demo()
+        PlanetaryVoxelRenderConfig {
+            residency: PlanetaryVoxelGpuConfig::new(
+                LIVE_GPU_RESIDENT_PAGES as u32,
+                16_384,
+                64,
+                192,
+                LIVE_GPU_RESIDENT_PAGES as u32,
+            )
+            .expect("production planet residency configuration is valid"),
+            max_surface_pages: LIVE_GPU_VISIBLE_PAGES as u32,
+            max_pending_surfaces: 192,
+            regular: TransvoxelGpuExtractorConfig::new(8_192, 16_384)
+                .expect("production regular extraction configuration is valid"),
+            transition: TransvoxelGpuTransitionExtractorConfig::new(2_048, 6_144)
+                .expect("production transition extraction configuration is valid"),
+            max_surface_bytes: 512 * 1024 * 1024,
+        }
     }
 
     pub fn component_context_mut(
@@ -240,8 +260,10 @@ fn live_runtime_config() -> TerrainRuntimeConfig {
     TerrainRuntimeConfig {
         max_planets: LIVE_MAX_PLANETS,
         max_component_sources: 16,
-        max_resident_pages: 8_192,
-        max_resident_dense_bytes: 8_192 * CELL_COUNT * core::mem::size_of::<u32>(),
+        max_resident_pages: LIVE_GPU_RESIDENT_PAGES,
+        max_resident_dense_bytes: LIVE_GPU_RESIDENT_PAGES
+            * CELL_COUNT
+            * core::mem::size_of::<u32>(),
         ..TerrainRuntimeConfig::default()
     }
 }
@@ -258,7 +280,7 @@ fn live_controller_config() -> TerrainControllerConfig {
         },
         refinement: TerrainRefinementConfig {
             max_active_pages: LIVE_ACTIVE_PAGES_PER_PLANET,
-            max_transition_pages: LIVE_TRANSITION_PAGES_PER_PLANET,
+            max_transition_pages: LIVE_HANDOFF_PAGES_PER_PLANET,
             initial_coarse_pages: 32,
             max_requests_per_reconcile: 16,
             max_commits_per_reconcile: 8,

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use engine_subsystems::{Subsystem, SubsystemContext, SubsystemError};
 use helio_pass_planetary_voxel::{
-    PlanetaryVoxelGpuConfig, PlanetaryVoxelRenderConfig, TransvoxelGpuExtractorConfig,
-    TransvoxelGpuTransitionExtractorConfig,
+    ExtractionLimits, PlanetaryVoxelGpuConfig, PlanetaryVoxelRenderConfig,
+    TransvoxelGpuExtractorConfig, TransvoxelGpuTransitionExtractorConfig,
 };
 use helio_planet_voxel_core::VisibilityOutcome;
 use pulsar_reflection::LiveKeySet;
@@ -154,10 +154,24 @@ impl PlanetTerrainRuntime {
             // bounded frontier is extracted and acknowledged by Helio.
             max_surface_pages: LIVE_GPU_SURFACE_PAGES as u32,
             max_pending_surfaces: 192,
-            regular: TransvoxelGpuExtractorConfig::new(8_192, 16_384)
-                .expect("production regular extraction configuration is valid"),
-            transition: TransvoxelGpuTransitionExtractorConfig::new(2_048, 6_144)
-                .expect("production transition extraction configuration is valid"),
+            regular: TransvoxelGpuExtractorConfig::default(),
+            transition: TransvoxelGpuTransitionExtractorConfig::default(),
+            regular_arena: ExtractionLimits::new(
+                LIVE_GPU_SURFACE_PAGES as u32,
+                192,
+                7_864_320,
+                15_728_640,
+                250_560,
+            )
+            .expect("production regular arena configuration is valid"),
+            transition_arena: ExtractionLimits::new(
+                LIVE_GPU_SURFACE_PAGES as u32,
+                192,
+                1_966_080,
+                5_898_240,
+                94_080,
+            )
+            .expect("production transition arena configuration is valid"),
             max_surface_bytes: 512 * 1024 * 1024,
         }
     }

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
@@ -308,11 +308,20 @@ impl From<SubsystemError> for PlanetTerrainLiveError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::components::planet_terrain_component::PlanetTerrainComponent;
 
     #[test]
     fn live_cpu_and_gpu_budgets_are_one_consistent_bounded_contract() {
         let controller = live_controller_config();
         let renderer = PlanetTerrainRuntime::renderer_config();
+        let default_planet = PlanetTerrainComponent::default()
+            .definition("default-production-planet")
+            .unwrap();
+        assert_eq!(
+            default_planet.max_resident_pages,
+            LIVE_HANDOFF_PAGES_PER_PLANET
+        );
+        assert!(default_planet.max_resident_pages <= live_runtime_config().max_resident_pages);
         assert_eq!(
             controller.max_planets * controller.refinement.max_active_pages,
             controller.rendering.max_visible_pages

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
@@ -291,6 +291,10 @@ fn live_controller_config() -> TerrainControllerConfig {
     TerrainControllerConfig {
         planning: TerrainPlanningConfig {
             streaming: TerrainStreamingConfig {
+                // Smooth SDF extraction is screen-error driven and bottoms out
+                // at an 80 cm sample grid. The canonical 10 cm LOD0 quantum is
+                // reserved for precise edits and the separate true block path.
+                finest_surface_lod: 3,
                 max_pages: LIVE_ACTIVE_PAGES_PER_PLANET,
                 ..TerrainStreamingConfig::default()
             },

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/live_runtime.rs
@@ -8,10 +8,11 @@ use helio_pass_planetary_voxel::{
 use helio_planet_voxel_core::VisibilityOutcome;
 use pulsar_reflection::LiveKeySet;
 use pulsar_terrain::{
-    CELL_COUNT, PlanetId, PlanetPosition, PlanetView, PositionError, TerrainControllerConfig,
+    PlanetId, PlanetPosition, PlanetView, PositionError, TerrainControllerConfig,
     TerrainControllerError, TerrainPlanningConfig, TerrainRefinementConfig,
     TerrainRenderDeltaConfig, TerrainRuntimeConfig, TerrainRuntimeError, TerrainRuntimeHandle,
     TerrainStreamingConfig, TerrainStreamingController, TerrainStreamingError, TerrainSubsystem,
+    CELL_COUNT,
 };
 use thiserror::Error;
 
@@ -23,6 +24,7 @@ const LIVE_MAX_PLANETS: usize = 4;
 const LIVE_ACTIVE_PAGES_PER_PLANET: usize = 96;
 const LIVE_HANDOFF_PAGES_PER_PLANET: usize = 1_024;
 const LIVE_GPU_VISIBLE_PAGES: usize = 384;
+const LIVE_GPU_SURFACE_PAGES: usize = LIVE_GPU_VISIBLE_PAGES + LIVE_ACTIVE_PAGES_PER_PLANET;
 const LIVE_GPU_RESIDENT_PAGES: usize = LIVE_MAX_PLANETS * LIVE_HANDOFF_PAGES_PER_PLANET;
 
 /// Component identities retained between revisions of Pulsar's current legacy
@@ -148,7 +150,9 @@ impl PlanetTerrainRuntime {
                 LIVE_GPU_RESIDENT_PAGES as u32,
             )
             .expect("production planet residency configuration is valid"),
-            max_surface_pages: LIVE_GPU_VISIBLE_PAGES as u32,
+            // The active aggregate remains drawable while one planet's next
+            // bounded frontier is extracted and acknowledged by Helio.
+            max_surface_pages: LIVE_GPU_SURFACE_PAGES as u32,
             max_pending_surfaces: 192,
             regular: TransvoxelGpuExtractorConfig::new(8_192, 16_384)
                 .expect("production regular extraction configuration is valid"),
@@ -335,6 +339,10 @@ mod tests {
                 <= controller.rendering.max_tracked_pages
         );
         assert!(controller.rendering.max_visible_pages <= controller.rendering.max_tracked_pages);
+        assert_eq!(
+            usize::try_from(renderer.max_surface_pages).unwrap(),
+            controller.rendering.max_visible_pages + controller.refinement.max_active_pages
+        );
         renderer.allocation_plan().unwrap();
     }
 }

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/render_adapter.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/render_adapter.rs
@@ -992,17 +992,29 @@ mod tests {
                 ))],
                 counters: TerrainRenderDeltaCounters::default(),
             };
+            let after_retirement_id = after_retirement.commands[0].id();
+            let reincarnated = apply_delta_to_test_residency(
+                &mut residency,
+                &device,
+                &queue,
+                after_retirement,
+            )
+            .unwrap();
             assert!(matches!(
-                apply_delta_to_test_residency(
-                    &mut residency,
-                    &device,
-                    &queue,
-                    after_retirement,
-                ),
-                Err(PlanetaryTerrainRenderError::Residency(
-                    GpuResidencyError::MissingPlanetFrame(PlanetId(id))
-                )) if id == [7; 16]
+                reincarnated.uploads.as_slice(),
+                [GpuUploadOutcome::Residency(UploadOutcome::Inserted { .. })]
             ));
+            assert_eq!(
+                reincarnated.feedback.commands,
+                vec![TerrainRenderCommandFeedback {
+                    command: after_retirement_id,
+                    disposition: TerrainRenderCommandDisposition::Applied,
+                }]
+            );
+            assert!(
+                residency.planet_frame(PlanetId([7; 16])).is_none(),
+                "page residency must not implicitly recreate retired frame state"
+            );
         });
     }
 }

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/render_adapter.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/render_adapter.rs
@@ -582,14 +582,16 @@ fn translate_page_key(page: pulsar_terrain::PageKey) -> Result<PageKey, AddressE
 #[cfg(test)]
 mod tests {
     use super::*;
-    use helio_pass_planetary_voxel::PlanetaryVoxelGpuConfig;
+    use helio_pass_planetary_voxel::{PlanetarySurfaceRequest, PlanetaryVoxelGpuConfig};
     use helio_planet_voxel_core::{
-        PAGE_CELL_COUNT, PAGE_EDGE as HELIO_PAGE_EDGE, TRANSITION_FACE_MASK, UploadOutcome,
+        PAGE_CELL_COUNT, PAGE_EDGE as HELIO_PAGE_EDGE, PlanetPageKey, SourceGeneration,
+        TRANSITION_FACE_MASK, UploadOutcome,
     };
     use pulsar_terrain::{
         CELL_COUNT, CellWord as TerrainCellWord, LOD0_CELL_SIZE_METERS as TERRAIN_CELL_SIZE_METERS,
         PAGE_EDGE, PageKey as TerrainPageKey, PlanetFrame, PlanetId as TerrainId, PlanetPosition,
         TERRAIN_TRANSITION_FACE_MASK, TerrainRenderDeltaCounters, TerrainVisiblePage,
+        terrain_surface_required_pages,
     };
 
     fn terrain_upload(
@@ -725,6 +727,35 @@ mod tests {
                 AddressError::UnsupportedLod(u8::MAX)
             ))
         ));
+    }
+
+    #[test]
+    fn pulsar_sampling_dependencies_match_helio_exactly() {
+        for (page, transition_mask) in [
+            (TerrainPageKey::new(1, [0, 0, 0]), 0),
+            (TerrainPageKey::new(3, [-17, 4, -9]), 0b00_111111),
+            (
+                TerrainPageKey::new(7, [i32::MAX as i64, -3, 11]),
+                0b00_010101,
+            ),
+        ] {
+            let pulsar = terrain_surface_required_pages(page, transition_mask).unwrap();
+            let helio = PlanetarySurfaceRequest {
+                key: PlanetPageKey::new(
+                    PlanetId([9; 16]),
+                    helio_planet_voxel_core::PageKey::new(page.lod, page.page_xyz),
+                ),
+                generation: SourceGeneration::new(1, 2),
+                transition_mask,
+                dirty_microbricks: u64::MAX,
+            }
+            .required_pages()
+            .unwrap()
+            .into_iter()
+            .map(|key| TerrainPageKey::new(key.page.lod, key.page.page_xyz))
+            .collect::<BTreeSet<_>>();
+            assert_eq!(pulsar, helio);
+        }
     }
 
     #[test]

--- a/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/render_adapter.rs
+++ b/crates/subsystems/pulsar_rendering/src/components/planet_terrain_component/render_adapter.rs
@@ -9,8 +9,8 @@
 use std::collections::{BTreeSet, VecDeque};
 
 use helio_pass_planetary_voxel::{
-    FrameUpdateOutcome, GpuResidencyError, GpuUploadOutcome, PlanetaryVoxelRenderPass,
-    PlanetaryVoxelResidency,
+    FrameUpdateOutcome, GpuResidencyError, GpuUploadOutcome, PlanetaryRenderError,
+    PlanetaryVoxelRenderPass, PlanetaryVoxelResidency,
 };
 use helio_planet_voxel_core::{
     AddressError, ContractError, EvictOutcome, EvictedPage, LOD0_CELL_SIZE_METERS, PAGE_EDGE_CELLS,
@@ -56,6 +56,8 @@ pub enum PlanetaryTerrainRenderError {
     Contract(#[from] ContractError),
     #[error(transparent)]
     Residency(#[from] GpuResidencyError),
+    #[error(transparent)]
+    Render(#[from] PlanetaryRenderError),
     #[error("planet frame contains non-finite camera-relative coordinates")]
     NonFiniteFrame,
     #[error("planet frame LOD0 cell size {actual} does not match Helio's {expected}")]
@@ -101,13 +103,12 @@ impl PlanetTerrainComponentRenderAdapter {
             .ok_or(PlanetaryTerrainRenderError::MissingPlanetaryPass)
     }
 
-    pub fn residency_mut<'a>(
+    fn render_pass_mut<'a>(
         &self,
         renderer: &'a mut helio::Renderer,
-    ) -> Result<&'a mut PlanetaryVoxelResidency, PlanetaryTerrainRenderError> {
+    ) -> Result<&'a mut PlanetaryVoxelRenderPass, PlanetaryTerrainRenderError> {
         renderer
             .find_pass_mut::<PlanetaryVoxelRenderPass>()
-            .map(PlanetaryVoxelRenderPass::residency_mut)
             .ok_or(PlanetaryTerrainRenderError::MissingPlanetaryPass)
     }
 
@@ -118,7 +119,7 @@ impl PlanetTerrainComponentRenderAdapter {
         frame: PlanetFramePayload,
     ) -> Result<FrameUpdateOutcome, PlanetaryTerrainRenderError> {
         Ok(self
-            .residency_mut(renderer)?
+            .render_pass_mut(renderer)?
             .set_planet_frame(queue, translate_frame(frame)?)?)
     }
 
@@ -146,7 +147,7 @@ impl PlanetTerrainComponentRenderAdapter {
         queue: &wgpu::Queue,
         batch: HelioTerrainRenderBatch,
     ) -> Result<TerrainRenderApplyReport, PlanetaryTerrainRenderError> {
-        apply_batch_to_residency(self.residency_mut(renderer)?, device, queue, batch)
+        apply_batch_to_render_pass(self.render_pass_mut(renderer)?, device, queue, batch)
     }
 
     pub fn apply_visible_sets(
@@ -158,7 +159,7 @@ impl PlanetTerrainComponentRenderAdapter {
     ) -> Result<VisibilityOutcome, PlanetaryTerrainRenderError> {
         let set = translate_visible_sets(frame_index, sets)?;
         Ok(self
-            .residency_mut(renderer)?
+            .render_pass_mut(renderer)?
             .apply_visible_set(queue, set)?)
     }
 
@@ -169,11 +170,53 @@ impl PlanetTerrainComponentRenderAdapter {
         queue: &wgpu::Queue,
     ) -> Result<(), PlanetaryTerrainRenderError> {
         Ok(self
-            .residency_mut(renderer)?
+            .render_pass_mut(renderer)?
+            .residency_mut()
             .recreate_gpu_resources(device, queue)?)
     }
 }
 
+fn apply_batch_to_render_pass(
+    pass: &mut PlanetaryVoxelRenderPass,
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    batch: HelioTerrainRenderBatch,
+) -> Result<TerrainRenderApplyReport, PlanetaryTerrainRenderError> {
+    let chunk_size = pass.residency().config().max_batch_pages as usize;
+    let mut report = TerrainRenderApplyReport::default();
+    let mut uploads = VecDeque::from(batch.uploads);
+    while !uploads.is_empty() {
+        let count = uploads.len().min(chunk_size);
+        let chunk = uploads.drain(..count).collect();
+        report
+            .uploads
+            .extend(pass.apply_upload_batch(device, queue, chunk)?);
+    }
+
+    let mut evictions = VecDeque::from(batch.evictions);
+    while !evictions.is_empty() {
+        let count = evictions.len().min(chunk_size);
+        let chunk = evictions.drain(..count).collect();
+        report
+            .evictions
+            .extend(pass.apply_evict_batch(device, queue, chunk)?);
+    }
+
+    for planet in batch.retired_planets {
+        let retirement = match pass.residency_mut().remove_planet_frame(planet) {
+            Ok(true) => PlanetFrameRetirement::Removed(planet),
+            Ok(false) => PlanetFrameRetirement::AlreadyAbsent(planet),
+            Err(GpuResidencyError::PlanetFrameInUse(_)) => {
+                PlanetFrameRetirement::RetainedInUse(planet)
+            }
+            Err(error) => return Err(error.into()),
+        };
+        report.frame_retirements.push(retirement);
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
 fn apply_batch_to_residency(
     residency: &mut PlanetaryVoxelResidency,
     device: &wgpu::Device,

--- a/crates/subsystems/pulsar_terrain/src/controller.rs
+++ b/crates/subsystems/pulsar_terrain/src/controller.rs
@@ -193,7 +193,7 @@ impl TerrainStreamingController {
             };
             if !state
                 .residency
-                .committed_pages()
+                .protected_pages()
                 .any(|page| page == eviction.page_key)
             {
                 continue;
@@ -231,7 +231,7 @@ impl TerrainStreamingController {
             let resident = self
                 .runtime
                 .resident_page_generations(state.residency.planet_id())?;
-            for page_key in state.residency.committed_pages() {
+            for page_key in state.residency.protected_pages() {
                 if let Some(generation) = resident.get(&page_key) {
                     self.publisher.ensure_resident_upload(
                         state.residency.planet_id(),
@@ -316,7 +316,7 @@ impl TerrainStreamingController {
                 .published_resident_pages(state.residency.planet_id(), &resident);
             if state
                 .residency
-                .committed_pages()
+                .protected_pages()
                 .all(|page| published.contains(&page))
             {
                 frame.visible_sets.push(self.publisher.visible_set(
@@ -397,7 +397,7 @@ mod tests {
             },
             refinement: TerrainRefinementConfig {
                 max_active_pages: 64,
-                max_transition_pages: 80,
+                max_transition_pages: 256,
                 initial_coarse_pages: 8,
                 max_requests_per_reconcile: 32,
                 max_commits_per_reconcile: 8,
@@ -531,11 +531,33 @@ mod tests {
             })
             .unwrap();
         assert!(controller.published_page_count() > 0);
-        frame_index += 1;
-        let restored = controller
-            .process_frame(&[], frame_index, frame_index)
-            .unwrap();
-        assert_eq!(restored.visible_sets.len(), 1);
+        let restored = loop {
+            frame_index += 1;
+            let restored = controller
+                .process_frame(&[], frame_index, frame_index)
+                .unwrap();
+            controller
+                .acknowledge_render_feedback(&TerrainRenderFeedback {
+                    commands: restored
+                        .render_delta
+                        .commands
+                        .iter()
+                        .map(|command| TerrainRenderCommandFeedback {
+                            command: command.id(),
+                            disposition: TerrainRenderCommandDisposition::Applied,
+                        })
+                        .collect(),
+                    cache_evictions: Vec::new(),
+                })
+                .unwrap();
+            if !restored.visible_sets.is_empty() {
+                break restored;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "renderer cache did not republish"
+            );
+        };
         assert!(!restored.visible_sets[0].pages.is_empty());
         subsystem.shutdown().unwrap();
     }

--- a/crates/subsystems/pulsar_terrain/src/core.rs
+++ b/crates/subsystems/pulsar_terrain/src/core.rs
@@ -1,11 +1,11 @@
 use crate::edit::EditIndex;
 use crate::mutation::{TerrainMutation, TerrainMutationBase, TerrainOverrideIndex};
 use crate::{
-    CompactedPageRecord, ContentHash, DeterministicGenerator, EditError, EditLog, EditMode, EditOp,
-    HierarchyError, NodeState, PageCodecError, PageKey, PlanetId, SnapshotCodecError,
-    SparseBrickTree, TerrainNodeSummary, TerrainOverrideError, TerrainOverrideLog,
-    TerrainOverrideOp, TerrainOverrideTarget, TerrainRegionClassifier, TerrainSnapshot,
-    TerrainStreamingError, VoxelPage,
+    CellWord, CompactedPageRecord, ContentHash, DeterministicGenerator, EditError, EditLog,
+    EditMode, EditOp, HierarchyError, NodeState, PageCodecError, PageKey, PlanetId,
+    SnapshotCodecError, SparseBrickTree, TerrainNodeSummary, TerrainOverrideError,
+    TerrainOverrideLog, TerrainOverrideOp, TerrainOverrideTarget, TerrainRegionClassifier,
+    TerrainSnapshot, TerrainStreamingError, VoxelPage,
 };
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -24,6 +24,10 @@ pub struct TerrainCore<G> {
     override_index: TerrainOverrideIndex,
     latest_sequence: u64,
     pages: BTreeMap<PageKey, VoxelPage>,
+    /// Disposable canonical-air pages used only to satisfy extraction halos
+    /// beyond the authoritative hierarchy root. They never enter snapshots
+    /// or mutate the sparse brick tree.
+    exterior_pages: BTreeMap<PageKey, (VoxelPage, CompactedPageRecord)>,
     compacted: BTreeMap<PageKey, CompactedPageRecord>,
     work: TerrainWorkCounters,
 }
@@ -89,6 +93,7 @@ pub struct PageBuildRequest<G> {
     previous_sequence: u64,
     target_sequence: u64,
     operations: Vec<TerrainMutation>,
+    exterior_air: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -101,6 +106,7 @@ pub struct PageBuildResult {
     replayed_edits: usize,
     replayed_overrides: usize,
     reused_resident_page: bool,
+    exterior_air: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -132,7 +138,11 @@ impl<G: DeterministicGenerator> PageBuildRequest<G> {
             .enumerate()
             .rev()
             .find_map(|(index, mutation)| mutation.page_base(self.key).map(|base| (index, base)));
-        let (page, reused_resident_page) = if let Some((index, base)) = reset {
+        let (page, reused_resident_page) = if self.exterior_air {
+            debug_assert!(self.base_page.is_none());
+            debug_assert!(self.operations.is_empty());
+            (VoxelPage::constant(CellWord::AIR), false)
+        } else if let Some((index, base)) = reset {
             let tail = &self.operations[index + 1..];
             match base {
                 TerrainMutationBase::Constant(cell) if tail.is_empty() => {
@@ -171,6 +181,7 @@ impl<G: DeterministicGenerator> PageBuildRequest<G> {
             replayed_edits,
             replayed_overrides,
             reused_resident_page,
+            exterior_air: self.exterior_air,
         })
     }
 }
@@ -207,6 +218,7 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             ),
             latest_sequence: 0,
             pages: BTreeMap::new(),
+            exterior_pages: BTreeMap::new(),
             compacted: BTreeMap::new(),
             work: TerrainWorkCounters::default(),
         })
@@ -265,6 +277,7 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             override_index,
             latest_sequence,
             pages: BTreeMap::new(),
+            exterior_pages: BTreeMap::new(),
             compacted,
             work: TerrainWorkCounters::default(),
         })
@@ -422,7 +435,26 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
     where
         G: Clone,
     {
-        let _ = self.hierarchy.resolve(key)?;
+        let exterior_air = match self.hierarchy.resolve(key) {
+            Ok(_) => false,
+            Err(HierarchyError::OutsideRoot(_)) => true,
+            Err(error) => return Err(error.into()),
+        };
+        if exterior_air {
+            if let Some((_, record)) = self.exterior_pages.get(&key) {
+                return Ok(PageBuildPreparation::Current(*record));
+            }
+            return Ok(PageBuildPreparation::Build(PageBuildRequest {
+                key,
+                generator: self.generator.clone(),
+                base_page_id: None,
+                base_page: None,
+                previous_sequence: 0,
+                target_sequence: self.latest_sequence,
+                operations: Vec::new(),
+                exterior_air: true,
+            }));
+        }
         let previous_sequence = self
             .compacted
             .get(&key)
@@ -461,6 +493,7 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             previous_sequence: replay_from_sequence,
             target_sequence: latest_sequence,
             operations,
+            exterior_air: false,
         }))
     }
 
@@ -473,6 +506,30 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             return Ok(PageBuildCommitOutcome::Stale {
                 newest_sequence: latest_sequence,
             });
+        }
+        if result.exterior_air {
+            if !matches!(
+                self.hierarchy.resolve(result.key),
+                Err(HierarchyError::OutsideRoot(_))
+            ) {
+                return Err(TerrainCoreError::ExteriorSupportDomainMismatch(result.key));
+            }
+            if result.page.constant_cell() != Some(CellWord::AIR) {
+                return Err(TerrainCoreError::ExteriorSupportNotAir(result.key));
+            }
+            let record = CompactedPageRecord {
+                key: result.key,
+                page_id: result.page.page_id(),
+                compacted_through_sequence: latest_sequence,
+            };
+            let outcome = if self.exterior_pages.contains_key(&result.key) {
+                PageBuildCommitOutcome::Duplicate(record)
+            } else {
+                PageBuildCommitOutcome::Committed(record)
+            };
+            self.exterior_pages
+                .insert(result.key, (result.page, record));
+            return Ok(outcome);
         }
         if let Some(newest_sequence) = self
             .mutations_for_page(result.key, result.target_sequence)
@@ -599,23 +656,26 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
     }
 
     pub fn page(&self, key: PageKey) -> Option<&VoxelPage> {
-        self.pages.get(&key)
+        self.pages
+            .get(&key)
+            .or_else(|| self.exterior_pages.get(&key).map(|(page, _)| page))
     }
 
-    pub fn resident_page_keys(&self) -> impl ExactSizeIterator<Item = PageKey> + '_ {
-        self.pages.keys().copied()
+    pub fn resident_page_keys(&self) -> impl Iterator<Item = PageKey> + '_ {
+        self.pages.keys().chain(self.exterior_pages.keys()).copied()
     }
 
     /// Drop one decompressed page while retaining its authoritative compacted
     /// record and hierarchy entry. A later request rehydrates the exact bytes
     /// from the deterministic generator and ordered edit prefix.
     pub fn evict_resident_page(&mut self, key: PageKey) -> bool {
-        self.pages.remove(&key).is_some()
+        self.pages.remove(&key).is_some() || self.exterior_pages.remove(&key).is_some()
     }
 
     pub fn evict_all_resident_pages(&mut self) -> usize {
-        let count = self.pages.len();
+        let count = self.pages.len() + self.exterior_pages.len();
         self.pages.clear();
+        self.exterior_pages.clear();
         count
     }
 
@@ -661,7 +721,7 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
     }
 
     pub fn resident_page_count(&self) -> usize {
-        self.pages.len()
+        self.pages.len() + self.exterior_pages.len()
     }
 
     pub fn work_counters(&self) -> TerrainWorkCounters {
@@ -678,12 +738,17 @@ impl<G: DeterministicGenerator> TerrainCore<G> {
             override_operations: self.overrides.operations().len(),
             override_attachment_regions: self.override_index.region_count(),
             override_attachment_references: self.override_index.reference_count(),
-            resident_pages: self.pages.len(),
+            resident_pages: self.pages.len() + self.exterior_pages.len(),
             resident_dense_bytes: self
                 .pages
                 .values()
                 .map(VoxelPage::dense_allocation_bytes)
-                .sum(),
+                .sum::<usize>()
+                + self
+                    .exterior_pages
+                    .values()
+                    .map(|(page, _)| page.dense_allocation_bytes())
+                    .sum::<usize>(),
             compacted_page_records: self.compacted.len(),
         }
     }
@@ -941,12 +1006,47 @@ pub enum TerrainCoreError {
     HierarchySummaryBeyondMutationTail { summary: u64, latest: u64 },
     #[error("rehydrated page {0:?} does not match its authoritative content hash")]
     RehydratedPageMismatch(PageKey),
+    #[error("exterior sampling support page {0:?} resolved inside the authoritative root")]
+    ExteriorSupportDomainMismatch(PageKey),
+    #[error("exterior sampling support page {0:?} was not canonical air")]
+    ExteriorSupportNotAir(PageKey),
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{EditMode, EditShape, FixedSphereGenerator};
+
+    #[test]
+    fn exterior_sampling_support_is_disposable_canonical_air() {
+        let generator = FixedSphereGenerator {
+            center_cell: [0; 3],
+            radius_cells: 100,
+            material: 3,
+        };
+        let mut core = TerrainCore::new(PlanetId([1; 16]), 12, generator).unwrap();
+        let hierarchy_before = core.hierarchy().content_hash();
+        let outside = PageKey::new(11, [-2, -2, -2]);
+        assert!(matches!(
+            core.hierarchy().resolve(outside),
+            Err(HierarchyError::OutsideRoot(key)) if key == outside
+        ));
+
+        let first = core.compact_page(outside).unwrap();
+        assert_eq!(
+            core.page(outside).unwrap().constant_cell(),
+            Some(CellWord::AIR)
+        );
+        assert_eq!(core.hierarchy().content_hash(), hierarchy_before);
+        assert!(core.snapshot().compacted_pages.is_empty());
+
+        assert!(core.evict_resident_page(outside));
+        assert!(core.page(outside).is_none());
+        let rebuilt = core.compact_page(outside).unwrap();
+        assert_eq!(rebuilt.page_id, first.page_id);
+        assert_eq!(core.hierarchy().content_hash(), hierarchy_before);
+        assert!(core.snapshot().compacted_pages.is_empty());
+    }
 
     #[test]
     fn compaction_publishes_a_hashed_page_and_snapshot() {

--- a/crates/subsystems/pulsar_terrain/src/lib.rs
+++ b/crates/subsystems/pulsar_terrain/src/lib.rs
@@ -18,6 +18,7 @@ mod planning;
 mod refinement;
 mod render;
 mod runtime;
+mod sampling;
 mod snapshot;
 mod store;
 mod streaming;
@@ -67,6 +68,7 @@ pub use runtime::{
     TerrainRuntimeConfig, TerrainRuntimeCounters, TerrainRuntimeError, TerrainRuntimeEvent,
     TerrainRuntimeHandle, TerrainSubsystem, TERRAIN_SUBSYSTEM_ID,
 };
+pub use sampling::{terrain_surface_required_pages, TerrainSurfaceSamplingError};
 pub use snapshot::{CompactedPageRecord, SnapshotCodecError, TerrainSnapshot};
 pub use store::{SnapshotRecord, TerrainStore, TerrainStoreError};
 pub use streaming::{

--- a/crates/subsystems/pulsar_terrain/src/refinement.rs
+++ b/crates/subsystems/pulsar_terrain/src/refinement.rs
@@ -1,7 +1,8 @@
 use crate::{
-    PageDemand, PageKey, PlanetId, TerrainRenderDeltaError, TerrainRenderDeltaPublisher,
-    TerrainRequestClass, TerrainRequestOutcome, TerrainRuntimeError, TerrainRuntimeHandle,
-    TerrainStreamingPlan,
+    sampling::terrain_frontier_sampling_support, PageDemand, PageKey, PlanetId,
+    TerrainRenderDeltaError, TerrainRenderDeltaPublisher, TerrainRequestClass,
+    TerrainRequestOutcome, TerrainRuntimeError, TerrainRuntimeHandle, TerrainStreamingPlan,
+    TerrainSurfaceSamplingError,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
@@ -11,7 +12,9 @@ use thiserror::Error;
 pub struct TerrainRefinementConfig {
     /// Maximum stable visible/prefetch frontier.
     pub max_active_pages: usize,
-    /// Maximum union of committed and staged pages.
+    /// Maximum union of committed surfaces, their extraction support, and the
+    /// next staged handoff. This bounds canonical and renderer residency while
+    /// a parent-preserving replacement is prepared.
     pub max_transition_pages: usize,
     /// Maximum pages in the first coarse publication.
     pub initial_coarse_pages: usize,
@@ -27,7 +30,7 @@ impl Default for TerrainRefinementConfig {
     fn default() -> Self {
         Self {
             max_active_pages: 2_048,
-            max_transition_pages: 2_112,
+            max_transition_pages: 8_192,
             initial_coarse_pages: 32,
             max_requests_per_reconcile: 8,
             max_commits_per_reconcile: 4,
@@ -92,7 +95,9 @@ pub struct TerrainRefinementReport {
     pub deferred: usize,
     pub evicted: usize,
     pub committed_pages: usize,
+    pub committed_sampling_pages: usize,
     pub staged_pages: usize,
+    pub staged_sampling_pages: usize,
     pub target_pages: usize,
     pub replacements_committed: usize,
     pub visible_set_changed: bool,
@@ -108,6 +113,7 @@ struct TargetFrontier {
 struct StagedReplacement {
     additions: BTreeMap<PageKey, TerrainRequestClass>,
     removals: BTreeSet<PageKey>,
+    sampling_support: BTreeSet<PageKey>,
 }
 
 /// Persistent canonical LOD frontier. Staged pages are never part of
@@ -117,6 +123,7 @@ pub struct TerrainRefinementFrontier {
     planet_id: PlanetId,
     config: TerrainRefinementConfig,
     committed: BTreeMap<PageKey, TerrainRequestClass>,
+    sampling_support: BTreeSet<PageKey>,
     target: Option<TargetFrontier>,
     staged: Option<StagedReplacement>,
     counters: TerrainRefinementCounters,
@@ -131,6 +138,7 @@ impl TerrainRefinementFrontier {
             planet_id,
             config: config.validate()?,
             committed: BTreeMap::new(),
+            sampling_support: BTreeSet::new(),
             target: None,
             staged: None,
             counters: TerrainRefinementCounters::default(),
@@ -159,11 +167,34 @@ impl TerrainRefinementFrontier {
         self.committed.iter().map(|(key, class)| (*key, *class))
     }
 
-    pub fn staged_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
+    pub fn sampling_support_pages(&self) -> impl ExactSizeIterator<Item = PageKey> + '_ {
+        self.sampling_support.iter().copied()
+    }
+
+    pub fn protected_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
+        self.committed
+            .keys()
+            .copied()
+            .chain(self.sampling_support.iter().copied())
+    }
+
+    pub fn staged_surface_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
         self.staged
             .as_ref()
             .into_iter()
             .flat_map(|stage| stage.additions.keys().copied())
+    }
+
+    pub fn staged_sampling_support_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
+        self.staged
+            .as_ref()
+            .into_iter()
+            .flat_map(|stage| stage.sampling_support.iter().copied())
+    }
+
+    pub fn staged_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
+        self.staged_surface_pages()
+            .chain(self.staged_sampling_support_pages())
     }
 
     pub fn is_converged(&self) -> bool {
@@ -235,7 +266,12 @@ impl TerrainRefinementFrontier {
                 stage
                     .additions
                     .into_keys()
-                    .filter(|key| !self.committed.contains_key(key))
+                    .chain(stage.sampling_support)
+                    .filter(|key| {
+                        !self.committed.contains_key(key) && !self.sampling_support.contains(key)
+                    })
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
                     .collect()
             }
         });
@@ -251,19 +287,23 @@ impl TerrainRefinementFrontier {
             .target
             .as_ref()
             .ok_or(TerrainRefinementError::MissingTarget)?;
-        let stage = if self.committed.is_empty() {
+        let mut stage = if self.committed.is_empty() {
             StagedReplacement {
                 additions: coarse_seed(target, self.config.initial_coarse_pages)?,
                 removals: BTreeSet::new(),
+                sampling_support: BTreeSet::new(),
             }
         } else {
             choose_replacement(&self.committed, target)?
                 .ok_or(TerrainRefinementError::NoSafeReplacement)?
         };
+        stage.sampling_support = sampling_support_after(&self.committed, &stage)?;
         let transition_pages = self
             .committed
             .keys()
+            .chain(self.sampling_support.iter())
             .chain(stage.additions.keys())
+            .chain(stage.sampling_support.iter())
             .copied()
             .collect::<BTreeSet<_>>()
             .len();
@@ -285,14 +325,19 @@ impl TerrainRefinementFrontier {
         &mut self,
         resident: &BTreeSet<PageKey>,
     ) -> Result<(Vec<PageKey>, usize), TerrainRefinementError> {
-        let mut retired = Vec::new();
+        let mut retired = BTreeSet::new();
         let mut committed = 0;
         while committed < self.config.max_commits_per_reconcile {
             self.prepare_stage()?;
             let Some(stage) = self.staged.as_ref() else {
                 break;
             };
-            if !stage.additions.keys().all(|key| resident.contains(key)) {
+            if !stage
+                .additions
+                .keys()
+                .chain(stage.sampling_support.iter())
+                .all(|key| resident.contains(key))
+            {
                 break;
             }
             let stage = self.staged.take().expect("the ready stage exists");
@@ -305,14 +350,21 @@ impl TerrainRefinementFrontier {
             if !is_face_balanced(prospective.keys().copied()) {
                 return Err(TerrainRefinementError::UnbalancedCommit);
             }
+            let retained = prospective
+                .keys()
+                .copied()
+                .chain(stage.sampling_support.iter().copied())
+                .collect::<BTreeSet<_>>();
             retired.extend(
                 stage
                     .removals
                     .iter()
-                    .filter(|key| !stage.additions.contains_key(key))
-                    .copied(),
+                    .copied()
+                    .chain(self.sampling_support.iter().copied())
+                    .filter(|key| !retained.contains(key)),
             );
             self.committed = prospective;
+            self.sampling_support = stage.sampling_support;
             committed += 1;
             self.counters.replacements_committed =
                 self.counters.replacements_committed.saturating_add(1);
@@ -324,7 +376,7 @@ impl TerrainRefinementFrontier {
                 break;
             }
         }
-        Ok((retired, committed))
+        Ok((retired.into_iter().collect(), committed))
     }
 }
 
@@ -367,8 +419,20 @@ impl TerrainIncrementalResidencySession {
         self.frontier.committed_demands()
     }
 
+    pub fn sampling_support_pages(&self) -> impl ExactSizeIterator<Item = PageKey> + '_ {
+        self.frontier.sampling_support_pages()
+    }
+
+    pub fn protected_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
+        self.frontier.protected_pages()
+    }
+
     pub fn staged_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
         self.frontier.staged_pages()
+    }
+
+    pub fn staged_surface_pages(&self) -> impl Iterator<Item = PageKey> + '_ {
+        self.frontier.staged_surface_pages()
     }
 
     pub fn is_converged(&self) -> bool {
@@ -403,18 +467,35 @@ impl TerrainIncrementalResidencySession {
         self.frontier.prepare_stage()?;
         let resident = runtime.resident_page_generations(self.planet_id())?;
         let published = publisher.published_resident_pages(self.planet_id(), &resident);
-        let staged = self.frontier.staged.as_ref();
+        let staged_work = self
+            .frontier
+            .staged
+            .as_ref()
+            .into_iter()
+            .flat_map(|stage| {
+                stage
+                    .additions
+                    .iter()
+                    .map(|(key, class)| (*key, *class))
+                    .chain(
+                        stage
+                            .sampling_support
+                            .iter()
+                            .map(|key| (*key, TerrainRequestClass::Visible)),
+                    )
+            })
+            .collect::<Vec<_>>();
         let mut requests = Vec::new();
         let mut bounded_work = 0;
-        for (key, request_class) in staged.into_iter().flat_map(|stage| stage.additions.iter()) {
-            if published.contains(key) {
+        for (key, request_class) in staged_work {
+            if published.contains(&key) {
                 continue;
             }
             if bounded_work == self.frontier.config.max_requests_per_reconcile {
                 break;
             }
-            if let Some(generation) = resident.get(key) {
-                publisher.ensure_resident_upload(self.planet_id(), *key, *generation)?;
+            if let Some(generation) = resident.get(&key) {
+                publisher.ensure_resident_upload(self.planet_id(), key, *generation)?;
                 bounded_work += 1;
                 continue;
             }
@@ -424,7 +505,7 @@ impl TerrainIncrementalResidencySession {
                 | TerrainRequestClass::Collision
                 | TerrainRequestClass::EditResponse => self.frontier.config.visible_deadline_ticks,
             };
-            requests.push((*key, *request_class, tick.saturating_add(deadline)));
+            requests.push((key, request_class, tick.saturating_add(deadline)));
             bounded_work += 1;
         }
         let (outcomes, request_error) = runtime.request_pages_bounded(self.planet_id(), &requests);
@@ -470,11 +551,17 @@ impl TerrainIncrementalResidencySession {
             .pages_evicted
             .saturating_add(report.evicted as u64);
         report.committed_pages = self.frontier.committed.len();
+        report.committed_sampling_pages = self.frontier.sampling_support.len();
         report.staged_pages = self
             .frontier
             .staged
             .as_ref()
             .map_or(0, |stage| stage.additions.len());
+        report.staged_sampling_pages = self
+            .frontier
+            .staged
+            .as_ref()
+            .map_or(0, |stage| stage.sampling_support.len());
         report.converged = self.frontier.is_converged();
         Ok(report)
     }
@@ -492,6 +579,7 @@ fn choose_replacement(
             return Ok(Some(StagedReplacement {
                 additions: BTreeMap::from([(*key, *request_class)]),
                 removals: BTreeSet::from([*key]),
+                sampling_support: BTreeSet::new(),
             }));
         }
     }
@@ -517,6 +605,7 @@ fn choose_replacement(
         let stage = StagedReplacement {
             additions: BTreeMap::from([(parent, target_class)]),
             removals,
+            sampling_support: BTreeSet::new(),
         };
         if replacement_is_safe(committed, &stage) {
             return Ok(Some(stage));
@@ -571,6 +660,7 @@ fn choose_replacement(
         let stage = StagedReplacement {
             additions,
             removals: BTreeSet::from([parent]),
+            sampling_support: BTreeSet::new(),
         };
         if replacement_is_safe(committed, &stage) {
             return Ok(Some(stage));
@@ -723,6 +813,19 @@ fn replacement_is_safe(
     prospective.extend(stage.additions.iter().map(|(key, class)| (*key, *class)));
     validate_non_overlapping(prospective.keys().copied()).is_ok()
         && is_face_balanced(prospective.keys().copied())
+}
+
+fn sampling_support_after(
+    committed: &BTreeMap<PageKey, TerrainRequestClass>,
+    stage: &StagedReplacement,
+) -> Result<BTreeSet<PageKey>, TerrainSurfaceSamplingError> {
+    let mut prospective = committed.clone();
+    for key in &stage.removals {
+        prospective.remove(key);
+    }
+    prospective.extend(stage.additions.iter().map(|(key, class)| (*key, *class)));
+    let masks = transition_masks(prospective.keys().copied());
+    terrain_frontier_sampling_support(prospective.into_keys(), &masks)
 }
 
 pub(crate) fn is_ancestor(ancestor: PageKey, descendant: PageKey) -> bool {
@@ -891,6 +994,8 @@ pub enum TerrainRefinementError {
     EmptyTarget,
     #[error("no target terrain frontier has been submitted")]
     MissingTarget,
+    #[error(transparent)]
+    Sampling(#[from] TerrainSurfaceSamplingError),
     #[error("the target terrain frontier is not 2:1 face balanced")]
     UnbalancedTarget,
     #[error("invalid target terrain frontier: {0}")]
@@ -960,11 +1065,11 @@ mod tests {
             frontier.prepare_stage().unwrap();
             resident.extend(frontier.staged_pages());
             let (retired, committed) = frontier.commit_ready_stages(resident).unwrap();
-            assert_eq!(committed, 1);
+            assert!((1..=frontier.config().max_commits_per_reconcile).contains(&committed));
             for key in retired {
                 resident.remove(&key);
             }
-            commits += 1;
+            commits += committed;
             let pages = frontier.committed_pages().collect::<BTreeSet<_>>();
             validate_non_overlapping(pages.iter().copied()).unwrap();
             assert!(is_face_balanced(pages.iter().copied()));
@@ -990,9 +1095,13 @@ mod tests {
         .unwrap();
         frontier.set_target(&target).unwrap();
         frontier.prepare_stage().unwrap();
-        assert_eq!(frontier.staged_pages().collect::<Vec<_>>(), vec![parent]);
+        assert_eq!(
+            frontier.staged_surface_pages().collect::<Vec<_>>(),
+            vec![parent]
+        );
+        assert_eq!(frontier.staged_sampling_support_pages().count(), 26);
 
-        let resident = BTreeSet::from([parent]);
+        let resident = frontier.staged_pages().collect();
         let (retired, committed) = frontier.commit_ready_stages(&resident).unwrap();
         assert!(retired.is_empty());
         assert_eq!(committed, 1);
@@ -1015,20 +1124,20 @@ mod tests {
         .unwrap();
         frontier.set_target(&target).unwrap();
         frontier.prepare_stage().unwrap();
-        frontier
-            .commit_ready_stages(&BTreeSet::from([parent]))
-            .unwrap();
+        let initial = frontier.staged_pages().collect();
+        frontier.commit_ready_stages(&initial).unwrap();
         frontier.prepare_stage().unwrap();
 
-        let partial = children[..7].iter().copied().collect::<BTreeSet<_>>();
+        let mut partial = frontier.staged_pages().collect::<BTreeSet<_>>();
+        partial.remove(&children[7]);
         let (retired, committed) = frontier.commit_ready_stages(&partial).unwrap();
         assert!(retired.is_empty());
         assert_eq!(committed, 0);
         assert_eq!(frontier.committed_pages().collect::<Vec<_>>(), vec![parent]);
 
-        let ready = children.iter().copied().collect::<BTreeSet<_>>();
+        let ready = frontier.staged_pages().collect::<BTreeSet<_>>();
         let (retired, committed) = frontier.commit_ready_stages(&ready).unwrap();
-        assert_eq!(retired, vec![parent]);
+        assert!(retired.contains(&parent));
         assert_eq!(committed, 1);
         assert_eq!(
             frontier.committed_pages().collect::<BTreeSet<_>>(),
@@ -1053,9 +1162,8 @@ mod tests {
         .unwrap();
         frontier.set_target(&fine).unwrap();
         frontier.prepare_stage().unwrap();
-        frontier
-            .commit_ready_stages(&children.iter().copied().collect())
-            .unwrap();
+        let fine_ready = frontier.staged_pages().collect();
+        frontier.commit_ready_stages(&fine_ready).unwrap();
         assert!(frontier.is_converged());
 
         frontier.set_target(&coarse).unwrap();
@@ -1065,13 +1173,10 @@ mod tests {
         assert_eq!(committed, 0);
         assert_eq!(frontier.committed_pages().count(), 8);
 
-        let (retired, committed) = frontier
-            .commit_ready_stages(&BTreeSet::from([parent]))
-            .unwrap();
-        assert_eq!(
-            retired.into_iter().collect::<BTreeSet<_>>(),
-            children.into_iter().collect()
-        );
+        let coarse_ready = frontier.staged_pages().collect();
+        let (retired, committed) = frontier.commit_ready_stages(&coarse_ready).unwrap();
+        let retired = retired.into_iter().collect::<BTreeSet<_>>();
+        assert!(children.into_iter().all(|child| retired.contains(&child)));
         assert_eq!(committed, 1);
         assert_eq!(frontier.committed_pages().collect::<Vec<_>>(), vec![parent]);
         assert!(frontier.is_converged());
@@ -1113,14 +1218,12 @@ mod tests {
             TerrainRefinementFrontier::new(planet(), TerrainRefinementConfig::default()).unwrap();
         frontier.set_target(&visible).unwrap();
         frontier.prepare_stage().unwrap();
-        frontier
-            .commit_ready_stages(&BTreeSet::from([key]))
-            .unwrap();
+        let ready = frontier.staged_pages().collect();
+        frontier.commit_ready_stages(&ready).unwrap();
 
         frontier.set_target(&prefetch).unwrap();
-        let (retired, committed) = frontier
-            .commit_ready_stages(&BTreeSet::from([key]))
-            .unwrap();
+        let resident = frontier.protected_pages().collect();
+        let (retired, committed) = frontier.commit_ready_stages(&resident).unwrap();
         assert!(retired.is_empty());
         assert_eq!(committed, 1);
         assert_eq!(
@@ -1174,24 +1277,22 @@ mod tests {
         .unwrap();
         frontier.set_target(&first).unwrap();
         frontier.prepare_stage().unwrap();
-        frontier
-            .commit_ready_stages(&BTreeSet::from([parent]))
-            .unwrap();
+        let parent_ready = frontier.staged_pages().collect();
+        frontier.commit_ready_stages(&parent_ready).unwrap();
         frontier.prepare_stage().unwrap();
         assert_eq!(
-            frontier.staged_pages().collect::<BTreeSet<_>>(),
+            frontier.staged_surface_pages().collect::<BTreeSet<_>>(),
             children.iter().copied().collect()
         );
 
         assert!(frontier.set_target(&next).unwrap().is_empty());
         assert_eq!(frontier.counters().stages_cancelled, 0);
         assert_eq!(
-            frontier.staged_pages().collect::<BTreeSet<_>>(),
+            frontier.staged_surface_pages().collect::<BTreeSet<_>>(),
             children.iter().copied().collect()
         );
-        let (_, committed) = frontier
-            .commit_ready_stages(&children.iter().copied().collect())
-            .unwrap();
+        let ready = frontier.staged_pages().collect();
+        let (_, committed) = frontier.commit_ready_stages(&ready).unwrap();
         assert_eq!(committed, 1);
         assert_eq!(
             frontier.committed_pages().collect::<BTreeSet<_>>(),
@@ -1257,7 +1358,7 @@ mod tests {
             planet(),
             TerrainRefinementConfig {
                 max_active_pages: 256,
-                max_transition_pages: 264,
+                max_transition_pages: 2_048,
                 initial_coarse_pages: 8,
                 max_commits_per_reconcile: 1,
                 ..TerrainRefinementConfig::default()
@@ -1266,6 +1367,7 @@ mod tests {
         .unwrap();
         let mut resident = BTreeSet::new();
         converge_frontier(&mut frontier, &target, &mut resident);
+        assert!(frontier.counters().transition_page_high_water <= 2_048);
         assert_eq!(
             frontier.committed_pages().collect::<BTreeSet<_>>(),
             target
@@ -1319,7 +1421,7 @@ mod tests {
             planet(),
             TerrainRefinementConfig {
                 max_active_pages: 64,
-                max_transition_pages: 72,
+                max_transition_pages: 1_024,
                 initial_coarse_pages: 8,
                 max_commits_per_reconcile: 1,
                 ..TerrainRefinementConfig::default()
@@ -1329,6 +1431,7 @@ mod tests {
         let mut resident = BTreeSet::new();
         converge_frontier(&mut frontier, &ground, &mut resident);
         converge_frontier(&mut frontier, &orbit, &mut resident);
+        assert!(frontier.counters().transition_page_high_water <= 1_024);
         assert_eq!(
             frontier.committed_pages().collect::<BTreeSet<_>>(),
             orbit
@@ -1337,5 +1440,72 @@ mod tests {
                 .map(|demand| demand.page_key())
                 .collect()
         );
+    }
+
+    #[test]
+    fn earth_scale_live_frontier_fits_the_bounded_sampling_residency() {
+        let radius_cells = 63_710_000_u64;
+        let definition = PlanetDefinition {
+            planet_id: planet(),
+            center_cell: [0; 3],
+            radius_cells,
+            material: 1,
+            root_lod: 22,
+            max_resident_pages: 2_048,
+        };
+        let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
+            max_pages: 96,
+            ..TerrainStreamingConfig::default()
+        })
+        .unwrap();
+        let camera_cell = i64::try_from(radius_cells).unwrap() + 10;
+        let make_view = |camera_cell, forward| {
+            PlanetView::new(
+                PlanetPosition::from_lod0_cell(camera_cell),
+                forward,
+                [0.0, 1.0, 0.0],
+                60_f64.to_radians(),
+                [1920, 1080],
+                0.1,
+                100_000_000.0,
+                [0.0; 3],
+            )
+            .unwrap()
+        };
+        let ground = planner
+            .plan_fixed_sphere(
+                &definition,
+                make_view([camera_cell, 0, 0], [-1.0, 0.0, 0.0]),
+            )
+            .unwrap();
+        let orbit = planner
+            .plan_fixed_sphere(
+                &definition,
+                make_view([camera_cell + 40_000_000, 0, 0], [-1.0, 0.0, 0.0]),
+            )
+            .unwrap();
+        let antipode = planner
+            .plan_fixed_sphere(
+                &definition,
+                make_view([-camera_cell, 0, 0], [1.0, 0.0, 0.0]),
+            )
+            .unwrap();
+        let mut frontier = TerrainRefinementFrontier::new(
+            planet(),
+            TerrainRefinementConfig {
+                max_active_pages: 96,
+                max_transition_pages: 2_048,
+                initial_coarse_pages: 32,
+                max_commits_per_reconcile: 8,
+                ..TerrainRefinementConfig::default()
+            },
+        )
+        .unwrap();
+        let mut resident = BTreeSet::new();
+        converge_frontier(&mut frontier, &ground, &mut resident);
+        converge_frontier(&mut frontier, &orbit, &mut resident);
+        converge_frontier(&mut frontier, &antipode, &mut resident);
+        assert!(frontier.counters().transition_page_high_water > 512);
+        assert!(frontier.counters().transition_page_high_water <= 2_048);
     }
 }

--- a/crates/subsystems/pulsar_terrain/src/refinement.rs
+++ b/crates/subsystems/pulsar_terrain/src/refinement.rs
@@ -1328,6 +1328,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 8.0,
             target_projected_error_px: 2.0,
+            finest_surface_lod: 0,
             prediction_seconds: 0.0,
             max_pages: 256,
             max_traversal_nodes: 4_096,
@@ -1391,6 +1392,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 8.0,
             target_projected_error_px: 2.0,
+            finest_surface_lod: 0,
             prediction_seconds: 0.0,
             max_pages: 64,
             max_traversal_nodes: 4_096,

--- a/crates/subsystems/pulsar_terrain/src/render.rs
+++ b/crates/subsystems/pulsar_terrain/src/render.rs
@@ -878,7 +878,7 @@ mod tests {
         }
     }
 
-    fn start() -> TerrainSubsystem {
+    fn start_with_resident_pages(max_resident_pages: usize) -> TerrainSubsystem {
         let mut subsystem = TerrainSubsystem::new(TerrainRuntimeConfig {
             worker_count: 4,
             max_planets: 2,
@@ -887,13 +887,17 @@ mod tests {
             critical_request_reserve: 4,
             completion_capacity: 64,
             event_capacity: 128,
-            max_resident_pages: 64,
-            max_resident_dense_bytes: 64 * DENSE_PAGE_BYTES,
+            max_resident_pages,
+            max_resident_dense_bytes: max_resident_pages * DENSE_PAGE_BYTES,
             max_completions_per_frame: 64,
         })
         .unwrap();
         subsystem.init(&SubsystemContext::new()).unwrap();
         subsystem
+    }
+
+    fn start() -> TerrainSubsystem {
+        start_with_resident_pages(64)
     }
 
     fn wait_for_page_events(
@@ -983,9 +987,10 @@ mod tests {
 
     #[test]
     fn incremental_handoff_keeps_the_coarse_page_visible_until_children_commit() {
-        let mut subsystem = start();
+        let mut subsystem = start_with_resident_pages(128);
         let runtime = subsystem.runtime_handle();
-        let planet = definition(9);
+        let mut planet = definition(9);
+        planet.max_resident_pages = 128;
         runtime.upsert_planet(planet.clone()).unwrap();
         let parent = PageKey::new(2, [0, 0, 0]);
         let base = parent.page_xyz.map(|coordinate| coordinate * 2);
@@ -1023,9 +1028,9 @@ mod tests {
             planet.planet_id,
             TerrainRefinementConfig {
                 max_active_pages: 8,
-                max_transition_pages: 9,
+                max_transition_pages: 128,
                 initial_coarse_pages: 1,
-                max_requests_per_reconcile: 1,
+                max_requests_per_reconcile: 16,
                 max_commits_per_reconcile: 1,
                 ..TerrainRefinementConfig::default()
             },
@@ -1035,7 +1040,7 @@ mod tests {
             max_events_per_delta: 16,
             max_commands_per_delta: 16,
             max_upload_bytes_per_delta: 16 * DENSE_PAGE_BYTES,
-            max_tracked_pages: 16,
+            max_tracked_pages: 128,
             max_visible_pages: 8,
         })
         .unwrap();
@@ -1099,7 +1104,7 @@ mod tests {
                 assert_eq!(visible_keys, committed);
                 if committed == BTreeSet::from([parent]) {
                     saw_parent = true;
-                    saw_parent_while_children_staged |= session.staged_pages().count() == 8;
+                    saw_parent_while_children_staged |= session.staged_surface_pages().count() == 8;
                 }
             }
             if session.is_converged() {

--- a/crates/subsystems/pulsar_terrain/src/sampling.rs
+++ b/crates/subsystems/pulsar_terrain/src/sampling.rs
@@ -1,0 +1,246 @@
+//! Canonical page dependencies required to extract one smooth terrain surface.
+//!
+//! Pulsar owns these pages because they are ordinary canonical samples. Helio
+//! may cache them for GPU extraction, but it must never synthesize a separate
+//! halo or transition slab that canonical edits and persistence cannot see.
+
+use crate::{PageKey, TerrainTransitionFace, PAGE_EDGE_CELLS, TERRAIN_TRANSITION_FACE_MASK};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+const TRANSITION_FACE_SAMPLE_EDGE: i64 = PAGE_EDGE_CELLS * 2 + 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+pub enum TerrainSurfaceSamplingError {
+    #[error("terrain surface transition mask {0:#010b} contains unsupported face bits")]
+    TransitionMask(u8),
+    #[error("LOD0 has no finer neighbor and cannot own a transition surface")]
+    FinestLodTransition,
+    #[error("terrain surface sampling dependency address overflows")]
+    CoordinateOverflow,
+}
+
+/// Return the exact canonical page identities needed by the regular 34^3
+/// extraction halo and every enabled fine-side 67x67x3 transition slab.
+pub fn terrain_surface_required_pages(
+    page: PageKey,
+    transition_mask: u8,
+) -> Result<BTreeSet<PageKey>, TerrainSurfaceSamplingError> {
+    if transition_mask & !TERRAIN_TRANSITION_FACE_MASK != 0 {
+        return Err(TerrainSurfaceSamplingError::TransitionMask(transition_mask));
+    }
+    if page.lod == 0 && transition_mask != 0 {
+        return Err(TerrainSurfaceSamplingError::FinestLodTransition);
+    }
+
+    let mut pages = BTreeSet::new();
+    let page_min = page
+        .lod0_cell_min()
+        .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?;
+    let coarse_scale = 1_i64
+        .checked_shl(u32::from(page.lod))
+        .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?;
+    let page_span = PAGE_EDGE_CELLS
+        .checked_mul(coarse_scale)
+        .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?;
+    let regular_min = checked_axis_offset(page_min, [-coarse_scale; 3])?;
+    let regular_max = checked_axis_offset(page_min, [page_span; 3])?;
+    insert_page_box(page.lod, regular_min, regular_max, &mut pages)?;
+
+    if transition_mask == 0 {
+        return Ok(pages);
+    }
+
+    let fine_lod = page.lod - 1;
+    let fine_scale = coarse_scale / 2;
+    for face in TerrainTransitionFace::ALL {
+        if transition_mask & face.bit() == 0 {
+            continue;
+        }
+        let basis = transition_face_integer_basis(face);
+        let mut minimum = [i64::MAX; 3];
+        let mut maximum = [i64::MIN; 3];
+        for u in [-1_i64, TRANSITION_FACE_SAMPLE_EDGE] {
+            for v in [-1_i64, TRANSITION_FACE_SAMPLE_EDGE] {
+                for outward in [-1_i64, 1] {
+                    let mut position = page_min;
+                    for axis in 0..3 {
+                        let origin_offset = i64::from(basis.origin[axis])
+                            .checked_mul(page_span)
+                            .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?;
+                        let u_offset = i64::from(basis.u_axis[axis])
+                            .checked_mul(u)
+                            .and_then(|value| value.checked_mul(fine_scale))
+                            .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?;
+                        let v_offset = i64::from(basis.v_axis[axis])
+                            .checked_mul(v)
+                            .and_then(|value| value.checked_mul(fine_scale))
+                            .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?;
+                        let outward_offset = i64::from(basis.outward[axis])
+                            .checked_mul(outward)
+                            .and_then(|value| value.checked_mul(fine_scale))
+                            .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?;
+                        position[axis] = position[axis]
+                            .checked_add(origin_offset)
+                            .and_then(|value| value.checked_add(u_offset))
+                            .and_then(|value| value.checked_add(v_offset))
+                            .and_then(|value| value.checked_add(outward_offset))
+                            .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?;
+                        minimum[axis] = minimum[axis].min(position[axis]);
+                        maximum[axis] = maximum[axis].max(position[axis]);
+                    }
+                }
+            }
+        }
+        insert_page_box(fine_lod, minimum, maximum, &mut pages)?;
+    }
+    Ok(pages)
+}
+
+/// Union the extraction dependencies for a complete non-overlapping surface
+/// frontier. Surface-owning pages are removed from the result so callers can
+/// track sampling-only residency independently.
+pub(crate) fn terrain_frontier_sampling_support(
+    pages: impl IntoIterator<Item = PageKey>,
+    transition_masks: &std::collections::BTreeMap<PageKey, u8>,
+) -> Result<BTreeSet<PageKey>, TerrainSurfaceSamplingError> {
+    let surfaces = pages.into_iter().collect::<BTreeSet<_>>();
+    let mut support = BTreeSet::new();
+    for page in &surfaces {
+        support.extend(terrain_surface_required_pages(
+            *page,
+            transition_masks.get(page).copied().unwrap_or(0),
+        )?);
+    }
+    support.retain(|page| !surfaces.contains(page));
+    Ok(support)
+}
+
+fn checked_axis_offset(
+    position: [i64; 3],
+    offset: [i64; 3],
+) -> Result<[i64; 3], TerrainSurfaceSamplingError> {
+    Ok([
+        position[0]
+            .checked_add(offset[0])
+            .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?,
+        position[1]
+            .checked_add(offset[1])
+            .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?,
+        position[2]
+            .checked_add(offset[2])
+            .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?,
+    ])
+}
+
+fn insert_page_box(
+    lod: u8,
+    minimum: [i64; 3],
+    maximum: [i64; 3],
+    output: &mut BTreeSet<PageKey>,
+) -> Result<(), TerrainSurfaceSamplingError> {
+    let minimum_page = PageKey::address_lod0_cell(lod, minimum)
+        .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?
+        .0
+        .page_xyz;
+    let maximum_page = PageKey::address_lod0_cell(lod, maximum)
+        .ok_or(TerrainSurfaceSamplingError::CoordinateOverflow)?
+        .0
+        .page_xyz;
+    for z in minimum_page[2]..=maximum_page[2] {
+        for y in minimum_page[1]..=maximum_page[1] {
+            for x in minimum_page[0]..=maximum_page[0] {
+                output.insert(PageKey::new(lod, [x, y, z]));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct IntegerFaceBasis {
+    origin: [i8; 3],
+    u_axis: [i8; 3],
+    v_axis: [i8; 3],
+    outward: [i8; 3],
+}
+
+const fn transition_face_integer_basis(face: TerrainTransitionFace) -> IntegerFaceBasis {
+    match face {
+        TerrainTransitionFace::NegativeX => IntegerFaceBasis {
+            origin: [0, 0, 1],
+            u_axis: [0, 1, 0],
+            v_axis: [0, 0, -1],
+            outward: [-1, 0, 0],
+        },
+        TerrainTransitionFace::PositiveX => IntegerFaceBasis {
+            origin: [1, 0, 0],
+            u_axis: [0, 1, 0],
+            v_axis: [0, 0, 1],
+            outward: [1, 0, 0],
+        },
+        TerrainTransitionFace::NegativeY => IntegerFaceBasis {
+            origin: [1, 0, 0],
+            u_axis: [0, 0, 1],
+            v_axis: [-1, 0, 0],
+            outward: [0, -1, 0],
+        },
+        TerrainTransitionFace::PositiveY => IntegerFaceBasis {
+            origin: [0, 1, 0],
+            u_axis: [0, 0, 1],
+            v_axis: [1, 0, 0],
+            outward: [0, 1, 0],
+        },
+        TerrainTransitionFace::NegativeZ => IntegerFaceBasis {
+            origin: [0, 1, 0],
+            u_axis: [1, 0, 0],
+            v_axis: [0, -1, 0],
+            outward: [0, 0, -1],
+        },
+        TerrainTransitionFace::PositiveZ => IntegerFaceBasis {
+            origin: [0, 0, 1],
+            u_axis: [1, 0, 0],
+            v_axis: [0, 1, 0],
+            outward: [0, 0, 1],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regular_halo_is_exact_and_signed_boundary_safe() {
+        let page = PageKey::new(3, [-3, 4, -5]);
+        let required = terrain_surface_required_pages(page, 0).unwrap();
+        assert_eq!(required.len(), 27);
+        assert!(required.contains(&PageKey::new(3, [-4, 3, -6])));
+        assert!(required.contains(&page));
+        assert!(required.contains(&PageKey::new(3, [-2, 5, -4])));
+    }
+
+    #[test]
+    fn transition_support_includes_fine_pages_and_rejects_invalid_requests() {
+        let page = PageKey::new(2, [-1, 0, 1]);
+        let required = terrain_surface_required_pages(
+            page,
+            TerrainTransitionFace::PositiveX.bit() | TerrainTransitionFace::NegativeZ.bit(),
+        )
+        .unwrap();
+        assert!(required.iter().any(|key| key.lod == 1));
+        assert!(required.iter().any(|key| key.lod == 2));
+        assert!(matches!(
+            terrain_surface_required_pages(PageKey::new(0, [0; 3]), 1),
+            Err(TerrainSurfaceSamplingError::FinestLodTransition)
+        ));
+        assert!(matches!(
+            terrain_surface_required_pages(page, 0b1000_0000),
+            Err(TerrainSurfaceSamplingError::TransitionMask(0b1000_0000))
+        ));
+        assert!(matches!(
+            terrain_surface_required_pages(PageKey::new(62, [i64::MAX, 0, 0]), 0),
+            Err(TerrainSurfaceSamplingError::CoordinateOverflow)
+        ));
+    }
+}

--- a/crates/subsystems/pulsar_terrain/src/streaming.rs
+++ b/crates/subsystems/pulsar_terrain/src/streaming.rs
@@ -150,6 +150,10 @@ impl PlanetView {
 pub struct TerrainStreamingConfig {
     pub interaction_radius_m: f64,
     pub target_projected_error_px: f64,
+    /// Finest LOD the smooth extracted surface may request. LOD0 remains the
+    /// canonical storage/edit quantum; selecting a coarser floor avoids
+    /// treating that quantum as the smooth renderer's required sample size.
+    pub finest_surface_lod: u8,
     pub prediction_seconds: f64,
     pub max_pages: usize,
     pub max_traversal_nodes: usize,
@@ -160,6 +164,7 @@ impl Default for TerrainStreamingConfig {
         Self {
             interaction_radius_m: 64.0,
             target_projected_error_px: 2.0,
+            finest_surface_lod: 0,
             prediction_seconds: 0.75,
             max_pages: 2_048,
             max_traversal_nodes: 262_144,
@@ -177,6 +182,11 @@ impl TerrainStreamingConfig {
         if !self.target_projected_error_px.is_finite() || self.target_projected_error_px <= 0.0 {
             return Err(TerrainStreamingError::InvalidConfig(
                 "projected error target must be finite and positive",
+            ));
+        }
+        if self.finest_surface_lod > 62 {
+            return Err(TerrainStreamingError::InvalidConfig(
+                "finest surface LOD must be at most 62",
             ));
         }
         if !self.prediction_seconds.is_finite() || self.prediction_seconds < 0.0 {
@@ -805,6 +815,7 @@ struct ViewGeometry {
     motion_m: [f64; 3],
     interaction_radius_m: f64,
     target_projected_error_px: f64,
+    finest_surface_lod: u8,
     focal_length_px: f64,
 }
 
@@ -845,6 +856,7 @@ impl ViewGeometry {
             motion_m,
             interaction_radius_m: config.interaction_radius_m,
             target_projected_error_px: config.target_projected_error_px,
+            finest_surface_lod: config.finest_surface_lod,
             focal_length_px,
         })
     }
@@ -884,7 +896,7 @@ impl ViewGeometry {
             request_class,
             projected_error_px,
             distance_m,
-            should_refine: key.lod > 0
+            should_refine: key.lod > self.finest_surface_lod
                 && (current_relevant || predictive_relevant)
                 && (interaction_forced || projected_error_px > self.target_projected_error_px),
             interaction_forced,
@@ -1287,6 +1299,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 8.0,
             target_projected_error_px: 2.0,
+            finest_surface_lod: 0,
             prediction_seconds: 0.5,
             max_pages: 4_096,
             max_traversal_nodes: 65_536,
@@ -1305,6 +1318,33 @@ mod tests {
             .demands()
             .iter()
             .any(|demand| demand.page_key().lod == 0));
+    }
+
+    #[test]
+    fn smooth_surface_floor_does_not_force_the_canonical_ten_centimeter_grid() {
+        let definition = definition(1_000, 6, 4_096);
+        let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
+            interaction_radius_m: 8.0,
+            target_projected_error_px: 0.25,
+            finest_surface_lod: 3,
+            prediction_seconds: 0.5,
+            max_pages: 4_096,
+            max_traversal_nodes: 65_536,
+        })
+        .unwrap();
+        let plan = planner
+            .plan_fixed_sphere(&definition, view([1_000, 0, 0], [-1.0, 0.0, 0.0], [0.0; 3]))
+            .unwrap();
+
+        assert!(plan.is_face_balanced());
+        assert!(plan
+            .demands()
+            .iter()
+            .all(|demand| demand.page_key().lod >= 3));
+        assert!(plan
+            .demands()
+            .iter()
+            .any(|demand| demand.page_key().lod == 3));
     }
 
     #[test]
@@ -1337,6 +1377,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 8.0,
             target_projected_error_px: 2.0,
+            finest_surface_lod: 0,
             prediction_seconds: 0.5,
             max_pages: 4_096,
             max_traversal_nodes: 65_536,
@@ -1436,6 +1477,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 64.0,
             target_projected_error_px: 2.0,
+            finest_surface_lod: 0,
             prediction_seconds: 1.0,
             max_pages: 2_048,
             max_traversal_nodes: 131_072,
@@ -1511,6 +1553,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 64.0,
             target_projected_error_px: 2.0,
+            finest_surface_lod: 0,
             prediction_seconds: 1.0,
             max_pages: 2_048,
             max_traversal_nodes: 131_072,
@@ -1543,6 +1586,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 64.0,
             target_projected_error_px: 0.25,
+            finest_surface_lod: 0,
             prediction_seconds: 0.0,
             max_pages: 32,
             max_traversal_nodes: 4_096,
@@ -1563,6 +1607,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 8.0,
             target_projected_error_px: 4.0,
+            finest_surface_lod: 0,
             prediction_seconds: 1.0,
             max_pages: 4_096,
             max_traversal_nodes: 65_536,
@@ -1584,6 +1629,7 @@ mod tests {
         let planner = TerrainStreamingPlanner::new(TerrainStreamingConfig {
             interaction_radius_m: 64.0,
             target_projected_error_px: 0.25,
+            finest_surface_lod: 0,
             prediction_seconds: 0.0,
             max_pages: 4_096,
             max_traversal_nodes: 8,

--- a/crates/subsystems/pulsar_terrain/src/types.rs
+++ b/crates/subsystems/pulsar_terrain/src/types.rs
@@ -3,6 +3,9 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 pub type MaterialId = u8;
+/// Canonical address/edit quantum. This does not require the smooth extracted
+/// surface to render at 10 cm; smooth fidelity is selected independently by
+/// projected error and `TerrainStreamingConfig::finest_surface_lod`.
 pub const LOD0_CELL_SIZE_METERS: f64 = 0.1;
 pub const PAGE_EDGE_CELLS: i64 = 32;
 pub const MILLIMETER_INTERACTION_RADIUS_METERS: f64 = 8_192.0;
@@ -51,7 +54,7 @@ pub enum PlanetIdParseError {
     Hex { offset: usize },
 }
 
-/// Authoritative planet-space position at 10 cm LOD0 resolution.
+/// Authoritative planet-space position using a 10 cm canonical address quantum.
 ///
 /// `lod0_cell` is the persistent integer address. `subcell_m` is private and
 /// normalized to `[0, 0.1)` meters on every axis, including negative world


### PR DESCRIPTION
## What changed

- Route planet frame updates, page uploads, evictions, and visible-set publication through Helio's graph-owned PlanetaryVoxelRenderPass.
- Preserve bounded upload and eviction chunking and generation-exact render feedback.
- Pin every Helio workspace dependency to the paired transactional surface-publication revision from Far-Beyond-Pulsar/Helio#230.
- Reserve bounded surface capacity for the active multi-planet aggregate plus one planet's candidate frontier, so refinement never requires dropping the active surface.
- Keep GPU cache recreation and canonical page ownership unchanged.

## Root cause

The adapter previously bypassed render-pass surface publication. After that path was repaired, the live surface budget still covered only active pages and could not hold an active frontier beside its replacement. The renderer therefore needed a bounded active-plus-candidate contract for atomic LOD handoff.

## Boundaries

This does not add a fallback mesh, duplicate terrain cache, legacy planet path, or SceneDB integration. Pulsar remains the canonical terrain owner and Helio remains a bounded disposable renderer cache.

Closes #577. Tracks #502 and Far-Beyond-Pulsar/Helio#229.

## Validation

- cargo test -p pulsar_rendering --lib: 28 passed
- cargo metadata --locked --no-deps --format-version 1
- rustfmt check on the touched planet runtime file
- git diff --check
- Live visual validation remains before promotion
