### PR TITLE
Pin published SceneDB through Helio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.19.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "helio-asset-compat"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4619,7 +4619,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "helio",
  "helio-core",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "helio-foliage-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4691,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4702,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4736,7 +4736,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-dof"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-flare"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4769,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-foliage-place"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4795,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-forward-lit"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4819,7 +4819,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio",
@@ -4832,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4844,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -4856,7 +4856,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4867,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4900,7 +4900,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planetary-voxel"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4926,7 +4926,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4938,7 +4938,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-portal-instances"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4952,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4963,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4974,7 +4974,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -4997,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5019,7 +5019,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5031,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5042,7 +5042,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5053,7 +5053,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5064,7 +5064,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio",
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-tsr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5089,7 +5089,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5112,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5126,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -5137,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "helio-planet-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.19",
@@ -5146,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "helio-portal-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5155,7 +5155,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -5164,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "helio-xr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "ash",
  "glam 0.33.2",
@@ -6158,7 +6158,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=59b3b284#59b3b284e581e0d8ed49df2a1c88ad488f309530"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=081b818d222193bc50e366ba5c59687be5db0138#081b818d222193bc50e366ba5c59687be5db0138"
 dependencies = [
  "bytemuck",
  "glam 0.33.2",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=42dde7d#42dde7df974cca58edb37965a1400836d03e9a95"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=411ecd7707140765d99ba576e423d799e6869bbf#411ecd7707140765d99ba576e423d799e6869bbf"
 dependencies = [
  "ahash 0.8.12",
  "profiling 0.1.0",
@@ -9178,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb_derive"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=42dde7d#42dde7df974cca58edb37965a1400836d03e9a95"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=411ecd7707140765d99ba576e423d799e6869bbf#411ecd7707140765d99ba576e423d799e6869bbf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ window_manager                     = { path = "crates/core/window_manager" }
 pulsar_game                        = { path = "crates/core/pulsar_game" }
 pulsar_core                        = { path = "crates/core/pulsar_core" }
 pulsar_pie_abi                     = { path = "crates/core/pulsar_pie_abi" }
-pulsar_scenedb                     = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "42dde7d", features = ["gpu"] }
+pulsar_scenedb                     = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "411ecd7707140765d99ba576e423d799e6869bbf", features = ["gpu"] }
 # Rev history (2026-08-15, Pulsar-Native#561 Phase D):
 # 43921b0 (this workspace's long-standing pin) -> 697967b (caught up ~114
 # commits: SceneDb/the GPU-mirror module) -> 4895d04 (merged origin/
@@ -195,17 +195,17 @@ plugin_editor_api     = { path = "crates/core/plugin_editor_api"}
 plugin_manager        = { path = "crates/core/plugin_manager" }
 
 # ---------- Helio Renderer (external git dep) ----------
-helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "59b3b284" }
-helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "59b3b284" }
-helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "59b3b284" }
-helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "59b3b284" }
-helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "59b3b284" }
+helio                      = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "081b818d222193bc50e366ba5c59687be5db0138" }
+helio-asset-compat         = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "081b818d222193bc50e366ba5c59687be5db0138" }
+helio-default-graphs       = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "081b818d222193bc50e366ba5c59687be5db0138" }
+helio-planet-voxel-core    = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "081b818d222193bc50e366ba5c59687be5db0138" }
+helio-pass-planetary-voxel = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "081b818d222193bc50e366ba5c59687be5db0138" }
 # `helio`'s own crate root doesn't re-export ReflectionCaptureShape/Mobility
 # (or other libhelio-only types Phase D's new components need) -- rather
 # than editing the Helio submodule itself (already in a dirty, unrelated
 # state locally; a cross-repo change for a one-line re-export isn't worth
 # the coordination), depend on libhelio directly at the same pinned rev.
-libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "59b3b284" }
+libhelio                   = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "081b818d222193bc50e366ba5c59687be5db0138" }
 glam                  = { version = "0.33", features = ["bytemuck"] }
 
 # ---------- Third-party (vendored) ----------


### PR DESCRIPTION
## Summary

- replaces Pulsar's unpublished SceneDB revision with the current published revision
- moves every Helio git dependency and the Helio gitlink to the matching manifest-only Helio hotfix
- refreshes only dependency source identities in `Cargo.lock`
- changes no engine source code

## Why both pins move

Pulsar directly requested the unavailable SceneDB revision, but its previous Helio revision also requested it transitively. Updating only the root dependency leaves Cargo resolving the unavailable commit. This PR aligns both package identities on revisions that exist remotely.

## Merge order

1. Far-Beyond-Pulsar/Helio#233
2. this PR
3. rebase the active 3D SDF planet integration onto the resulting `main`

## Validation

- `cargo check -p pulsar_terrain --all-targets` (passed)
- `cargo check -p engine_backend --features render` (passed)
- invalid revision `42dde7d` is absent from the workspace
- `git diff --check` (passed)

Closes #580.